### PR TITLE
Ensure nncs are sorted in the same order as fluxes.

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -419,7 +419,7 @@ ECL::loadNNC(const ecl_grid_type* G,
 
     std::sort(nncData.begin(), nncData.end(),
               [](const ecl_nnc_type& nd1, const ecl_nnc_type& nd2) {
-                  return nd1.nnc_index < nd2.nnc_index;
+                  return nd1.input_index < nd2.input_index;
               });
 
     return nncData;

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -417,6 +417,11 @@ ECL::loadNNC(const ecl_grid_type* G,
         ecl_nnc_export(G, init, nncData.data());
     }
 
+    std::sort(nncData.begin(), nncData.end(),
+              [](const ecl_nnc_type& nd1, const ecl_nnc_type& nd2) {
+                  return nd1.nnc_index < nd2.nnc_index;
+              });
+
     return nncData;
 }
 


### PR DESCRIPTION
This probably needs to be revised to accord for LGRs, but since the class does not yet implement it in any case I think this should be merged.

Requires Ensembles/ert#1204.