### PR TITLE
ECLGraph: Add support for Local Grid Refinement (LGR)

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1754,6 +1754,13 @@ Opm::ECLGraph::load(const Path& grid, const Path& init)
     return { std::move(pImpl) };
 }
 
+int
+Opm::ECLGraph::activeCell(const std::array<int,3>& ijk,
+                          const int                gridID) const
+{
+    return this->pImpl_->activeCell(gridID, ijk);
+}
+
 void
 Opm::ECLGraph::assignFluxDataSource(const Path& src)
 {

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -52,19 +52,6 @@ namespace {
         using GridPtr = ::ERT::ert_unique_ptr<ecl_grid_type, ecl_grid_free>;
         using FilePtr = ::ERT::ert_unique_ptr<ecl_file_type, ecl_file_close>;
 
-        /// Retrieve global pore-volume vector from INIT source.
-        ///
-        /// Specialised tool needed to determine the active cells.
-        ///
-        /// \param[in] G ERT Grid representation.
-        ///
-        /// \param[in] init ERT representation of INIT source.
-        ///
-        /// \return Vector of pore-volumes for all global cells of \p G.
-        std::vector<double>
-        getPVolVector(const ecl_grid_type* G,
-                      const ecl_file_type* init);
-
         /// Internalise on-disk representation of ECLIPSE grid.
         ///
         /// \param[in] grid Name or prefix of on-disk representation of
@@ -82,271 +69,427 @@ namespace {
         /// \return Internalised ERT file contents.
         FilePtr loadFile(const boost::filesystem::path& file);
 
-        /// Extract non-neighbouring connections from ECLIPSE model
+        /// Retrieve total number of grids managed by model's main grid.
+        ///
+        /// \param[in] G Main grid obtained from loadCase().
+        ///
+        /// \return Total number of grids in \p G.  Equal to 1 + total
+        /// number of LGRs in model.
+        int numGrids(const ecl_grid_type* G);
+
+        /// Access individual grid by numeric index.
+        ///
+        /// \param[in] G Main grid obtained from loadCase().
+        ///
+        /// \param[in] gridID Numeric index of requested grid.  Zero for the
+        ///    main grid (i.e., \p G itself) or positive for one of the
+        ///    LGRs.  Must be strictly less than \code numGrids(G) \endcode.
+        ///
+        /// \return Pointer to ECL grid corresponding to numeric ID.
+        const ecl_grid_type*
+        getGrid(const ecl_grid_type* G, const int gridID);
+
+        /// Extract Cartesian dimensions of an ECL grid.
+        ///
+        /// \param[in] G ERT grid instance corresponding to the model's main
+        ///    grid or one of its LGRs.  Typically obtained from function
+        ///    getGrid().
+        ///
+        /// \return Cartesian dimensions of \p G.  Corresponds to number of
+        ///    cells in each cardinal direction in 3D depositional space.
+        std::array<std::size_t,3>
+        cartesianDimensions(const ecl_grid_type* G);
+
+        /// Retrieve global pore-volume vector from INIT source.
+        ///
+        /// Specialised tool needed to determine the active cells.
         ///
         /// \param[in] G ERT Grid representation.
         ///
         /// \param[in] init ERT representation of INIT source.
         ///
+        /// \return Vector of pore-volumes for all global cells of \p G.
+        std::vector<double>
+        getPVolVector(const ecl_grid_type* G,
+                      const ecl_file_type* init,
+                      const int            grid_ID = 0);
+
+        /// Extract non-neighbouring connections from ECLIPSE model
+        ///
+        /// \param[in] G ERT Grid representation corresponding to model's
+        ///    main grid obtained directly from loadCase().
+        ///
+        /// \param[in] init ERT representation of INIT source.
+        ///
         /// \return Model's non-neighbouring connections, including those
-        ///         between main and local grids.
+        ///    between main and local grids.
         std::vector<ecl_nnc_type>
         loadNNC(const ecl_grid_type* G,
                 const ecl_file_type* init);
 
-        /// Facility for mapping a result set vector defined either on all
-        /// global cells or on the explicitly active cells (ACTNUM != 0) to
-        /// the global cells.
-        class ScatterMap
+        class CartesianGridData
         {
         public:
-            /// Constructor
+            /// Constructor.
             ///
-            /// \param[in] G ERT Grid representation.
+            /// \param[in] G ERT grid structure corresponding either to the
+            ///    model's main grid or, if applicable, one of its LGRs.
             ///
-            /// \param[in] pvol Vector of pore-volumes on all global cells
-            ///                 of \p G.  Typically obtained through
-            ///                 function getPVolVector().
-            ScatterMap(const ecl_grid_type*       G,
-                       const std::vector<double>& pvol);
+            /// \param[in] init Internalised ERT representation of result
+            ///    set's INIT file.
+            ///
+            /// \param[in] gridID Numeric identifier of this grid.  Zero for
+            ///    main grid, positive for LGRs.
+            CartesianGridData(const ecl_grid_type* G,
+                              const ecl_file_type* init,
+                              const int            gridID);
 
-            /// Retrive global cell indices of all active cells.
-            std::vector<std::size_t> activeGlobalCells() const;
+            /// Retrieve number of active cells in graph.
+            std::size_t numCells() const;
 
-            /// Map input vector to all global cells.
+            /// Retrive number of connections in graph.
+            std::size_t numConnections() const;
+
+            /// Retrive neighbourship relations between active cells.
             ///
-            /// \param[in] x Input vector, defined on the explicitly active
-            ///              cells, all global cells or some other subset
-            ///              (e.g., all non-neighbouring connections).
+            /// The \c i-th connection is between active cells \code
+            /// neighbours()[2*i + 0] \endcode and \code neighbours()[2*i + 1]
+            /// \endcode.
+            const std::vector<int>& neighbours() const;
+
+            /// Retrive static pore-volume values on active cells only.
             ///
-            /// \return Input vector mapped to global cells or unchanged if
-            /// input is defined on some other subset.
-            template <typename T>
-            std::vector<T>
-            scatterToGlobal(const std::vector<T>& x) const;
+            /// Corresponds to the \c PORV vector in the INIT file, possibly
+            /// restricted to those active cells for which the pore-volume is
+            /// strictly positive.
+            const std::vector<double>& activePoreVolume() const;
+
+            /// Retrieve ID of active cell from global ID.
+            int activeCell(const std::size_t globalCell) const;
+
+            /// Retrieve ID of active cell from (I,J,K) index tuple.
+            int activeCell(const int i, const int j, const int k) const;
+
+            /// Predicate for whether or not a particular active cell is
+            /// further subdivided by an LGR.
+            ///
+            /// \param[in] cellID Index of particular active cell in this
+            ///     grid.
+            ///
+            /// \return Whether or not cell identified by grid-local active
+            ///     index \p cellID is further subdivided by an LGR.
+            bool isSubdivided(const int cellID) const;
+
+            /// Retrieve values of result set vector for all global cells in
+            /// grid.
+            ///
+            /// Mostly for implementing connectionData().
+            ///
+            /// \param[in] src ECLIPSE result set.
+            ///
+            /// \param[in] vector Name of result set vector.
+            ///
+            /// \return Numerical values of result set vector, relative to
+            /// global cell numbering of this grid.
+            std::vector<double>
+            cellData(const ecl_file_type* src,
+                     const std::string&   vector) const;
+
+            /// Retrieve values of result set vector for all Cartesian
+            /// connections in grid.
+            ///
+            /// \param[in] src ECLIPSE result set.
+            ///
+            /// \param[in] vector Name prefix of result set vector (e.g.,
+            ///     "FLROIL" for oil flux (flow-rate of oil)).
+            ///
+            /// \return Numerical values of result set vector attributed to
+            ///     all of the grid's Cartesian connections.
+            std::vector<double>
+            connectionData(const ecl_file_type* src,
+                           const std::string&   vector) const;
 
         private:
-            /// Explicit mapping between ACTNUM!=0 cells and global cells.
-            struct ID {
-                std::size_t act;
-                std::size_t glob;
+            /// Facility for deriving Cartesian neighbourship in a grid
+            /// (main or LGR) and for mapping result set vectors to grid's
+            /// canonical (global) cells.
+            class CartesianCells
+            {
+            public:
+                /// Canonical directions of Cartesian neighbours.
+                enum class Direction { I, J, K };
+
+                /// Constructor
+                ///
+                /// \param[in] G ERT Grid representation.
+                ///
+                /// \param[in] pvol Vector of pore-volumes on all global
+                ///                 cells of \p G.  Typically obtained
+                ///                 through function getPVolVector().
+                CartesianCells(const ecl_grid_type*       G,
+                               const std::vector<double>& pvol);
+
+                /// Retrive global cell indices of all active cells in grid.
+                std::vector<std::size_t> activeGlobal() const;
+
+                const std::vector<double>& activePoreVolume() const;
+
+                /// Map input vector to all global cells.
+                ///
+                /// \param[in] x Input vector, defined on the explicitly
+                ///              active cells, all global cells or some
+                ///              other subset (e.g., all non-neighbouring
+                ///              connections).
+                ///
+                /// \return Input vector mapped to global cells or unchanged
+                /// if input is defined on some other subset.
+                template <typename T>
+                std::vector<T>
+                scatterToGlobal(const std::vector<T>& x) const;
+
+                /// Retrieve total number of cells in grid, including
+                /// inactive ones.
+                ///
+                /// Needed to allocate result vectors on global cells.
+                std::size_t numGlobalCells() const;
+
+                /// Retrieve active cell ID of particular global cell.
+                ///
+                /// \param[in] globalCell Index of particular global cell.
+                ///
+                /// \return Active cell ID of \p globalCell.  Returns
+                /// negative one (\code -1 \endcode) if \code globalCell >=
+                /// numGlobalCells \endcode or if the global cell is
+                /// inactive.
+                int getActiveCell(const std::size_t globalCell) const;
+
+                /// Retrieve global cell ID of from (I,J,K) index tuple.
+                std::size_t
+                getGlobalCell(const int i, const int j, const int k) const;
+
+                /// Retrieve active cell ID of particular global cell's
+                /// neighbour in given Cartesian direction.
+                ///
+                /// \param[in] globalCell Index of particular global cell.
+                ///
+                /// \param[in] d Cartesian direction in which to look for a
+                /// neighbouring cell.
+                ///
+                /// \return Active cell ID of \p globalCell's neighbour in
+                /// direction \d.  Returns negative one (\code -1 \endcode)
+                /// if \code globalCell >= numGlobalCells \endcode or if the
+                /// global cell is inactive, or if there is no neighbour in
+                /// direction \p d (e.g., if purported neighbour would be
+                /// outside model).
+                int getNeighbour(const std::size_t globalCell,
+                                 const Direction   d) const;
+
+                /// Predicate for whether or not a particular active cell is
+                /// further subdivided by an LGR.
+                bool isSubdivided(const int cellID) const;
+
+            private:
+                struct ResultSetMapping {
+                    /// Explicit mapping between ACTNUM!=0 cells and global
+                    /// cells.
+                    struct ID {
+                        std::size_t act;
+                        std::size_t glob;
+                    };
+
+                    /// Number of explicitly active cells (SUM(ACTNUM != 0)).
+                    std::size_t num_active;
+
+                    /// Active subset of global cells.
+                    std::vector<ID> subset;
+                };
+
+                using IndexTuple = std::array<std::size_t,3>;
+
+                /// Size of grid's bounding box (i.e., the number of cells
+                /// in each cardinal direction in 3D depositional space).
+                const IndexTuple cartesianSize_;
+
+                /// Map cell-based data vectors to grid's global cells.
+                ResultSetMapping rsMap_;
+
+                /// Static pore-volumes of all active cells.
+                std::vector<double> activePVol_;
+
+                /// Active index of model's global cells.
+                std::vector<int> active_ID_;
+
+                /// Whether or not a particular active cell is subdivided.
+                std::vector<bool> is_divided_;
+
+                /// Identify those grid cells that are further subdivided by
+                /// an LGR.
+                ///
+                /// Writes to \c is_divided_.
+                ///
+                /// \param
+                void identifySubdividedCells(const ecl_grid_type* G);
+
+                /// Compute linear index of global cell from explicit
+                /// (I,J,K) tuple.
+                ///
+                /// \param[in] ijk Explicit (I,J,K) tuple of global cell.
+                ///
+                /// \return Linear index (natural ordering) of global cell
+                /// (I,J,K).
+                std::size_t globIdx(const IndexTuple& ijk) const;
+
+                /// Decompose global (linear) cell index into its (I,J,K)
+                /// index tuple.
+                ///
+                /// \param[in] globalCell Index of particular global cell.
+                ///    Must be in the range \code [0 .. numGlobalCells())
+                ///    \endcode.
+                ///
+                /// \return Index triplet of \p globalCell's location within
+                /// model.
+                IndexTuple ind2sub(const std::size_t globalCell) const;
             };
 
-            /// Number of explicitly active cells (SUM(ACTNUM != 0)).
-            std::size_t nact_;
+            /// Collection of global (cell) IDs.
+            using GlobalIDColl = std::vector<std::size_t>;
 
-            /// Number of global cells.
-            std::size_t nglob_;
+            /// Collection of (global) cell IDs corresponding to the flow
+            /// source of each connection.
+            using OutCell =
+                std::map<CartesianCells::Direction, GlobalIDColl>;
 
-            /// Active subset of global cells.
-            std::vector<ID> subset_;
-        };
+            /// Collection of direction strings to simplify vector name
+            /// derivation (replaces chains of if-else)
+            using DirectionSuffix =
+                std::map<CartesianCells::Direction, std::string>;
 
-        /// Facility for cached querying of ECLIPSE result set.
-        class GlobalCellData
-        {
-        public:
-            /// Constructor
-            ///
-            /// \param[in] G ERT Grid representation.
-            ///
-            /// \param[in] pvol Vector of pore-volumes on all global cells
-            ///                 of \p G.  Typically obtained through
-            ///                 function getPVolVector().
-            GlobalCellData(const ecl_grid_type*       grid,
-                           const std::vector<double>& pvol);
-
-            /// Assign result set backing object.
-            ///
-            /// \param[in] src Name of result set (restart) file, possibly
-            /// unified.
-            void assignDataSource(const boost::filesystem::path& src);
-
-            /// Assign result set backing object.
-            ///
-            /// Specialised convenience interface.
-            ///
-            /// \param[in] src Internalised result set.  Typically
-            /// corresponds to the INIT object.
-            void assignDataSource(FilePtr src);
-
-            using DataVector = std::vector<double>;
-
-            /// Retrive ERT representation of current result set.
-            ///
-            /// Convenience method that typically accesses the result set
-            /// that was assigned through assignDataSource() with a \c
-            /// FilePtr argument.
-            const ecl_file_type* getDataSource() const;
-
-            /// Retrive global cell indices of all active cells.
-            std::vector<std::size_t> activeGlobalCells() const;
-
-            /// Predicate for whether or not a particular vector exists in
-            /// the current result set.
-            bool haveVector(const std::string& vector) const;
-
-            /// Retrieve particular vector from current result set.
-            ///
-            /// \param[in] vector Name of result vector.  Clients should
-            ///                   ensure existence of data through
-            ///                   haveVector() before calling getVector().
-            ///
-            /// \param[in] occurrence Selected temporal vector.  Essentially
-            ///                       the report step number.
-            ///
-            /// \return Result vector corresponding to named quantity at
-            /// given time.
-            const DataVector&
-            getVector(const std::string& vector,
-                      const int          occurrence = 0);
-
-        private:
-            using DataHandle     = std::unique_ptr<DataVector>;
-            using TemporalData   = std::map<int, DataHandle>;
-            using DataCollection = std::map<std::string, TemporalData>;
+            /// Numeric identity of this grid.  Zero for main grid, greater
+            /// than zero for LGRs.
+            const int gridID_;
 
             /// Map results from active to global cells.
-            ScatterMap map_;
+            CartesianCells cells_;
 
-            /// Current result set.
-            ECL::FilePtr src_;
+            /// Known directional suffixes.
+            DirectionSuffix suffix_;
 
-            /// Result vector cache.
-            DataCollection coll_;
+            /// Flattened neighbourship relation (array of size \code
+            /// 2*numConnections() \endcode).
+            std::vector<int> neigh_;
 
-            /// Load a result vector from backing store.
+            /// Source cells for each Cartesian connection.
+            OutCell outCell_;
+
+            /// Predicate for whether or not a particular result vector is
+            /// defined on the grid's cells.
             ///
-            /// \param[in] vector Name of result vector.  Clients should
-            ///                   ensure existence of data through
-            ///                   haveVector() before calling getVector().
+            /// \param[in] src Result set.
             ///
-            /// \param[in] occurrence Selected temporal vector.  Essentially
-            ///                       the report step number.
+            /// \param[in] vector Name of result vector.
             ///
-            /// \return Raw result vector as represented in the backing
-            /// store.  Must be mapped to global cells prior to access.
-            DataVector
-            load(const std::string& vector,
-                 const int          occurrence);
+            /// \return Whether or not \p vector is defined on model's
+            /// cells and part of the result set \p src.
+            bool haveCellData(const ecl_file_type* src,
+                              const std::string&   vector) const;
+
+            /// Predicate for whether or not a particular result vector is
+            /// defined on the grid's Cartesian connections.
+            ///
+            /// \param[in] src Result set.
+            ///
+            /// \param[in] vector Prefix of result vector name.
+            ///
+            /// \return Whether or not all vectors formed by \p vector plus
+            /// known directional suffixes are defined on model's cells and
+            /// part of the result set \p src.
+            bool haveConnData(const ecl_file_type* src,
+                              const std::string&   vector) const;
+
+            /// Append directional cell data to global collection of
+            /// connection data identified by vector name prefix.
+            ///
+            /// \param[in] src Result set.
+            ///
+            /// \param[in] d Cartesian direction.
+            ///
+            /// \param[in] vector Prefix of result vector name.
+            ///
+            /// \param[in,out] x Global collection of connection data.  On
+            /// input, collection of values corresponding to any previous
+            /// directions (preserved), and on output additionally contains
+            /// the data corresponding to the Cartesian direction \p d.
+            void connectionData(const ecl_file_type*            src,
+                                const CartesianCells::Direction d,
+                                const std::string&              vector,
+                                std::vector<double>&            x) const;
+
+            /// Form complete name of directional result set vector from
+            /// prefix and identified direction.
+            ///
+            /// \param[in] vector Prefix of result vector name.
+            ///
+            /// \param[in] d Cartesian direction.
+            ///
+            /// \return \code vector + suffix_[d] \endcode.
+            std::string
+            vectorName(const std::string&              vector,
+                       const CartesianCells::Direction d) const;
+
+            /// Derive neighbourship relations on active cells in particular
+            /// Cartesian directions.
+            ///
+            /// Writes to \c neigh_ and \c outCell_.
+            ///
+            /// \param[in] gcells Collection of global (relative to \c
+            ///    gridID_) cells that should be considered active (strictly
+            ///    positive pore-volume and not deactivated through
+            ///    ACTNUM=0).
+            ///
+            /// \param[in] init Internalised
+            void deriveNeighbours(const std::vector<std::size_t>& gcells,
+                                  const ecl_file_type*            init,
+                                  const CartesianCells::Direction d);
         };
     } // namespace ECL
-
-    /// Derive neighbourship relations between active cells from Cartesian
-    /// relations.
-    class CellCollection
-    {
-    public:
-        /// Canonical directions of Cartesian neighbours.
-        enum class Direction { I, J, K };
-
-        /// Constructor.
-        ///
-        /// \param[in] G ERT Grid representation.
-        ///
-        /// \param[in] active_glob_cells Global indices of model's active
-        ///       cells (\code ACTNUM != 0 && pore_volume > 0 \endcode).
-        CellCollection(const ecl_grid_type*       G,
-                       std::vector<std::size_t>&& active_glob_cells);
-
-        /// Retrieve global indices of model's active cells.
-        ///
-        /// Convenience method that returns the second constructor argument.
-        const std::vector<std::size_t>& activeGlobalCells() const;
-
-        /// Retrieve total number of cells in model, including inactive ones.
-        ///
-        /// Needed to allocate result vectors on global cells.
-        std::size_t numGlobalCells() const;
-
-        /// Retrieve active cell ID of particular global cell.
-        ///
-        /// \param[in] globalCell Index of particular global cell.
-        ///
-        /// \return Active cell ID of \p globalCell.  Returns negative one
-        /// (\code -1 \endcode) if \code globalCell >= numGlobalCells
-        /// \endcode or if the global cell is inactive.
-        int activeCell(const std::size_t globalCell) const;
-
-        /// Retrieve active cell ID of particular global cell's neighbour in
-        /// given Cartesian direction.
-        ///
-        /// \param[in] globalCell Index of particular global cell.
-        ///
-        /// \param[in] d Cartesian direction in which to look for a
-        /// neighbouring cell.
-        ///
-        /// \return Active cell ID of \p globalCell's neighbour in direction
-        /// \d.  Returns negative one (\code -1 \endcode) if \code
-        /// globalCell >= numGlobalCells \endcode or if the global cell is
-        /// inactive, or if there is no neighbour in direction \p d (e.g.,
-        /// if purported neighbour would be outside model).
-        int cartesianNeighbour(const std::size_t globalCell,
-                               const Direction   d) const;
-
-    private:
-        using IJKTuple = std::array<std::size_t,3>;
-
-        /// Number of global cells in X (I) direction.
-        std::size_t nx_;
-
-        /// Number of global cells in Y (J) direction.
-        std::size_t ny_;
-
-        /// Number of global cells in Z (K) direction.
-        std::size_t nz_;
-
-        /// Global indices of model's active cells.
-        std::vector<std::size_t> glob_cell_;
-
-        /// Active cell ID of model's global cells.  Negative one (\code -1
-        /// \endcode) if inactive.
-        std::vector<int> active_id_;
-
-        /// Retrieve number of active cells.  Equivalent to \code
-        /// glob_cell_.size() \endcode, but with a named expression.
-        std::size_t numActive() const;
-
-        /// Compute linear index of global cell from explicit (I,J,K) tuple.
-        ///
-        /// \param[in] ijk Explicit (I,J,K) tuple of global cell.
-        ///
-        /// \return Linear index (natural ordering) of global cell (I,J,K).
-        std::size_t globIdx(const IJKTuple& ijk) const;
-
-        /// Decompose global (linear) cell index into its (I,J,K) index
-        /// tuple.
-        ///
-        /// \param[in] globalCell Index of particular global cell.  Must be
-        ///    in the range \code [0 .. numGlobalCells()) \endcode.
-        ///
-        /// \return Index triplet of \p globalCell's location within model.
-        IJKTuple ind2sub(const std::size_t globalCell) const;
-    };
 } // Anonymous namespace
 
 // ======================================================================
 
+int ECL::numGrids(const ecl_grid_type* G)
+{
+    return 1 + ecl_grid_get_num_lgr(G); // Main + #LGRs.
+}
+
+const ecl_grid_type*
+ECL::getGrid(const ecl_grid_type* G, const int gridID)
+{
+    assert ((gridID >= 0) && "Grid ID must be non-negative");
+
+    if (gridID == 0) {
+        return G;
+    }
+
+    return ecl_grid_iget_lgr(G, gridID - 1);
+}
+
 std::vector<double>
 ECL::getPVolVector(const ecl_grid_type* G,
-                   const ecl_file_type* init)
+                   const ecl_file_type* init,
+                   const int            gridID)
 {
     auto make_szt = [](const int i)
     {
         return static_cast<std::vector<double>::size_type>(i);
     };
 
-    const auto nx = make_szt(ecl_grid_get_nx(G));
-    const auto ny = make_szt(ecl_grid_get_ny(G));
-    const auto nz = make_szt(ecl_grid_get_nz(G));
-
-    const auto nglob = nx * ny * nz;
+    const auto nglob = make_szt(ecl_grid_get_global_size(G));
 
     auto pvol = std::vector<double>(nglob, 1.0);
 
     if (ecl_file_has_kw(init, "PORV")) {
         auto porv =
-            ecl_file_iget_named_kw(init, "PORV", 0);
+            ecl_file_iget_named_kw(init, "PORV", gridID);
 
         assert ((make_szt(ecl_kw_get_size(porv)) == nglob)
                 && "Pore-volume must be provided for all global cells");
@@ -398,6 +541,19 @@ ECL::loadFile(const boost::filesystem::path& file)
     return F;
 }
 
+std::array<std::size_t,3>
+ECL::cartesianDimensions(const ecl_grid_type* G)
+{
+    auto make_szt = [](const int i)
+    {
+        return static_cast<std::size_t>(i);
+    };
+
+    return { { make_szt(ecl_grid_get_nx(G)) ,
+               make_szt(ecl_grid_get_ny(G)) ,
+               make_szt(ecl_grid_get_nz(G)) } };
+}
+
 std::vector<ecl_nnc_type>
 ECL::loadNNC(const ecl_grid_type* G,
              const ecl_file_type* init)
@@ -417,214 +573,151 @@ ECL::loadNNC(const ecl_grid_type* G,
         ecl_nnc_export(G, init, nncData.data());
     }
 
-    std::sort(nncData.begin(), nncData.end(),
-              [](const ecl_nnc_type& nd1, const ecl_nnc_type& nd2) {
-                  return nd1.input_index < nd2.input_index;
-              });
-
     return nncData;
 }
 
 // ======================================================================
 
-ECL::ScatterMap::ScatterMap(const ecl_grid_type*       G,
-                            const std::vector<double>& pvol)
+ECL::CartesianGridData::
+CartesianCells::CartesianCells(const ecl_grid_type*       G,
+                               const std::vector<double>& pvol)
+    : cartesianSize_(::ECL::cartesianDimensions(G))
 {
+    if (pvol.size() != static_cast<decltype(pvol.size())>
+        (this->cartesianSize_[0] *
+         this->cartesianSize_[1] *
+         this->cartesianSize_[2]))
+    {
+        throw std::invalid_argument("Grid must have PORV for all cells");
+    }
+
     auto make_szt = [](const int i)
     {
         return static_cast<std::size_t>(i);
     };
 
-    this->nact_ = make_szt(ecl_grid_get_nactive(G));
+    using ID = ResultSetMapping::ID;
 
+    this->rsMap_.num_active = make_szt(ecl_grid_get_nactive(G));
+
+    this->rsMap_.subset.clear();
+    this->rsMap_.subset.reserve(this->rsMap_.num_active);
+
+    for (decltype(ecl_grid_get_nactive(G))
+             act = 0, nact = ecl_grid_get_nactive(G);
+         act < nact; ++act)
     {
-        const auto nx = make_szt(ecl_grid_get_nx(G));
-        const auto ny = make_szt(ecl_grid_get_ny(G));
-        const auto nz = make_szt(ecl_grid_get_nz(G));
+        const auto glob =
+            make_szt(ecl_grid_get_global_index1A(G, act));
 
-        this->nglob_ = nx * ny * nz;
-    }
-
-    subset_.clear();
-    subset_.reserve(this->nact_);
-
-    if (pvol.empty()) {
-        for (decltype(ecl_grid_get_nactive(G))
-                 act = 0, nact = ecl_grid_get_nactive(G);
-             act < nact; ++act)
-        {
-            const auto glob =
-                make_szt(ecl_grid_get_global_index1A(G, act));
-
-            this->subset_.push_back(ID{ make_szt(act), glob });
+        if (pvol[glob] > 0.0) {
+            this->rsMap_.subset.push_back(ID{ make_szt(act), glob });
         }
     }
-    else {
-        for (decltype(ecl_grid_get_nactive(G))
-                 act = 0, nact = ecl_grid_get_nactive(G);
-             act < nact; ++act)
-        {
-            const auto glob =
-                make_szt(ecl_grid_get_global_index1A(G, act));
 
-            if (pvol[glob] > 0.0) {
-                this->subset_.push_back(ID{ make_szt(act), glob });
-            }
+    {
+        std::vector<int>(pvol.size(), -1).swap(this->active_ID_);
+
+        this->activePVol_.clear();
+        this->activePVol_.reserve(this->rsMap_.subset.size());
+
+        this->is_divided_.clear();
+        this->is_divided_.reserve(this->rsMap_.subset.size());
+
+        auto active = 0;
+
+        for (const auto& cell : this->rsMap_.subset) {
+            this->active_ID_[cell.glob] = active++;
+            this->activePVol_.push_back(pvol[cell.glob]);
+
+            const auto ert_active = static_cast<int>(cell.act);
+            const auto is_divided =
+                nullptr != ecl_grid_get_cell_lgr1A(G, ert_active);
+
+            this->is_divided_.push_back(is_divided);
         }
     }
 }
 
 std::vector<std::size_t>
-ECL::ScatterMap::activeGlobalCells() const
+ECL::CartesianGridData::CartesianCells::activeGlobal() const
 {
     auto active = std::vector<std::size_t>{};
-    active.reserve(this->subset_.size());
+    active.reserve(this->rsMap_.subset.size());
 
-    for (const auto& id : this->subset_) {
+    for (const auto& id : this->rsMap_.subset) {
         active.push_back(id.glob);
     }
 
     return active;
 }
 
+const std::vector<double>&
+ECL::CartesianGridData::CartesianCells::activePoreVolume() const
+{
+    return this->activePVol_;
+}
+
 template <typename T>
 std::vector<T>
-ECL::ScatterMap::scatterToGlobal(const std::vector<T>& x) const
+ECL::CartesianGridData::
+CartesianCells::scatterToGlobal(const std::vector<T>& x) const
 {
-    // Assume that input vector 'x' is either defined on explicit
-    // notion of active cells (ACTNUM != 0) or on all global cells or
-    // some other contiguous index set (e.g., the NNCs).
+    // Assume that input vector 'x' is either defined on explicit notion of
+    // active cells (ACTNUM != 0) or on all global cells or some other
+    // contiguous index set (e.g., the NNCs).
 
-    if (x.size() != static_cast<decltype(x.size())>(this->nact_)) {
-        // Input not defined on explictly active cells.  Let caller
-        // deal with it.  This typically corresponds to the set of
-        // global cells or the list of NNCs.
+    const auto num_explicit_active =
+        static_cast<decltype(x.size())>(this->rsMap_.num_active);
+
+    if (x.size() != num_explicit_active) {
+        // Input not defined on explictly active cells.  Let caller deal
+        // with it.  This typically corresponds to the set of global cells
+        // or the list of NNCs.
         return x;
     }
 
-    auto y = std::vector<T>(this->nglob_);
+    auto y = std::vector<T>(this->numGlobalCells());
 
-    for (const auto& i : this->subset_) {
+    for (const auto& i : this->rsMap_.subset) {
         y[i.glob] = x[i.act];
     }
 
     return y;
 }
 
-// ======================================================================
-
-ECL::GlobalCellData::GlobalCellData(const ecl_grid_type*       grid,
-                                    const std::vector<double>& pvol)
-    : map_(grid, pvol)
-{
-}
-
-void
-ECL::GlobalCellData::assignDataSource(const boost::filesystem::path& src)
-{
-    this->src_ = ECL::loadFile(src);
-}
-
-void
-ECL::GlobalCellData::assignDataSource(ECL::FilePtr src)
-{
-    this->src_ = std::move(src);
-}
-
-const ecl_file_type*
-ECL::GlobalCellData::getDataSource() const
-{
-    return this->src_.get();
-}
-
-std::vector<std::size_t>
-ECL::GlobalCellData::activeGlobalCells() const
-{
-    return this->map_.activeGlobalCells();
-}
-
-bool
-ECL::GlobalCellData::haveVector(const std::string& vector) const
-{
-    return ecl_file_has_kw(this->src_.get(), vector.c_str());
-}
-
-const ECL::GlobalCellData::DataVector&
-ECL::GlobalCellData::getVector(const std::string& vector,
-                               const int          occurrence)
-{
-    auto& p = this->coll_[vector][occurrence];
-
-    if (! p) {
-        auto x = this->map_.scatterToGlobal(load(vector, occurrence));
-
-        p = DataHandle{ new DataVector{ std::move(x) } };
-    }
-
-    return *p;
-}
-
-ECL::GlobalCellData::DataVector
-ECL::GlobalCellData::load(const std::string& vector,
-                          const int          occurrence)
-{
-    auto x = ecl_file_iget_named_kw(this->src_.get(),
-                                    vector.c_str(),
-                                    occurrence);
-
-    auto y = DataVector(ecl_kw_get_size(x));
-
-    ecl_kw_get_data_as_double(x, y.data());
-
-    return y;
-}
-
-// ======================================================================
-
-CellCollection::CellCollection(const ecl_grid_type*       G,
-                               std::vector<std::size_t>&& active_glob_cells)
-    : nx_       (static_cast<std::size_t>(ecl_grid_get_nx(G)))
-    , ny_       (static_cast<std::size_t>(ecl_grid_get_ny(G)))
-    , nz_       (static_cast<std::size_t>(ecl_grid_get_nz(G)))
-    , glob_cell_(std::move(active_glob_cells))
-    , active_id_(nx_ * ny_ * nz_, -1)
-{
-    auto act = 0;
-
-    for (const auto& id : glob_cell_) {
-        this->active_id_[static_cast<std::size_t>(id)] = act++;
-    }
-}
-
-const std::vector<std::size_t>&
-CellCollection::activeGlobalCells() const
-{
-    return this->glob_cell_;
-}
-
 std::size_t
-CellCollection::numActive() const
+ECL::CartesianGridData::CartesianCells::numGlobalCells() const
 {
-    return this->glob_cell_.size();
-}
-
-std::size_t
-CellCollection::numGlobalCells() const
-{
-    return this->active_id_.size();
+    return this->active_ID_.size();
 }
 
 int
-CellCollection::activeCell(const std::size_t globalCell) const
+ECL::CartesianGridData::
+CartesianCells::getActiveCell(const std::size_t globalCell) const
 {
     if (globalCell >= numGlobalCells()) { return -1; }
 
-    return this->active_id_[globalCell];
+    return this->active_ID_[globalCell];
+}
+
+std::size_t
+ECL::CartesianGridData::
+CartesianCells::getGlobalCell(const int i, const int j, const int k) const
+{
+    const auto ijk = IndexTuple {
+        static_cast<std::size_t>(i),
+        static_cast<std::size_t>(j),
+        static_cast<std::size_t>(k),
+    };
+
+    return this->globIdx(ijk);
 }
 
 int
-CellCollection::cartesianNeighbour(const std::size_t globalCell,
-                                   const Direction   d) const
+ECL::CartesianGridData::
+CartesianCells::getNeighbour(const std::size_t globalCell,
+                             const Direction   d) const
 {
     if (globalCell >= numGlobalCells()) { return -1; }
 
@@ -641,34 +734,281 @@ CellCollection::cartesianNeighbour(const std::size_t globalCell,
 
     if (globNeigh >= numGlobalCells()) { return -1; }
 
-    return this->active_id_[globNeigh];
+    return this->active_ID_[globNeigh];
+}
+
+bool
+ECL::CartesianGridData::CartesianCells::isSubdivided(const int cellID) const
+{
+    const auto ix =
+        static_cast<decltype(this->is_divided_.size())>(cellID);
+
+    assert ((cellID >= 0) && (ix < this->is_divided_.size()));
+
+    return this->is_divided_[ix];
 }
 
 std::size_t
-CellCollection::globIdx(const IJKTuple& ijk) const
+ECL::CartesianGridData::
+CartesianCells::globIdx(const IndexTuple& ijk) const
 {
-    if (ijk[0] >= this->nx_) { return -1; }
-    if (ijk[1] >= this->ny_) { return -1; }
-    if (ijk[2] >= this->nz_) { return -1; }
+    const auto& dim = this->cartesianSize_;
 
-    return ijk[0] + nx_*(ijk[1] + ny_*ijk[2]);
+    for (auto d = 0*dim.size(), nd = dim.size(); d < nd; ++d) {
+        if (ijk[d] >= dim[d]) { return -1; }
+    }
+
+    return ijk[0] + dim[0]*(ijk[1] + dim[1]*ijk[2]);
 }
 
-CellCollection::IJKTuple
-CellCollection::ind2sub(const std::size_t globalCell) const
+ECL::CartesianGridData::CartesianCells::IndexTuple
+ECL::CartesianGridData::
+CartesianCells::ind2sub(const std::size_t globalCell) const
 {
     assert (globalCell < numGlobalCells());
 
-    auto ijk = IJKTuple{};
+    auto ijk = IndexTuple{};
     auto g   = globalCell;
 
-    ijk[0] = g % this->nx_;  g /= this->nx_;
-    ijk[1] = g % this->ny_;
-    ijk[2] = g / this->ny_;  assert (ijk[2] < this->nz_);
+    const auto& dim = this->cartesianSize_;
+
+    ijk[0] = g % dim[0];  g /= dim[0];
+    ijk[1] = g % dim[1];
+    ijk[2] = g / dim[1];  assert (ijk[2] < dim[2]);
 
     assert (globIdx(ijk) == globalCell);
 
     return ijk;
+}
+
+// ======================================================================
+
+ECL::CartesianGridData::CartesianGridData(const ecl_grid_type* G,
+                                          const ecl_file_type* init,
+                                          const int            gridID)
+    : gridID_(gridID)
+    , cells_ (G, ::ECL::getPVolVector(G, init, gridID_))
+{
+    {
+        using VT = DirectionSuffix::value_type;
+
+        suffix_.insert(VT(CartesianCells::Direction::I, "I+"));
+        suffix_.insert(VT(CartesianCells::Direction::J, "J+"));
+        suffix_.insert(VT(CartesianCells::Direction::K, "K+"));
+    }
+
+    const auto gcells = this->cells_.activeGlobal();
+
+    // Too large, but this is a quick estimate.
+    this->neigh_.reserve(3 * (2 * this->numCells()));
+
+    for (const auto d : { CartesianCells::Direction::I ,
+                          CartesianCells::Direction::J ,
+                          CartesianCells::Direction::K })
+    {
+        this->deriveNeighbours(gcells, init, d);
+    }
+}
+
+std::size_t
+ECL::CartesianGridData::numCells() const
+{
+    return this->activePoreVolume().size();
+}
+
+std::size_t
+ECL::CartesianGridData::numConnections() const
+{
+    return this->neigh_.size() / 2;
+}
+
+const std::vector<int>&
+ECL::CartesianGridData::neighbours() const
+{
+    return this->neigh_;
+}
+
+const std::vector<double>&
+ECL::CartesianGridData::activePoreVolume() const
+{
+    return this->cells_.activePoreVolume();
+}
+
+int
+ECL::CartesianGridData::activeCell(const std::size_t globalCell) const
+{
+    return this->cells_.getActiveCell(globalCell);
+}
+
+int
+ECL::CartesianGridData::activeCell(const int i,
+                                   const int j,
+                                   const int k) const
+{
+    return this->activeCell(this->cells_.getGlobalCell(i, j, k));
+}
+
+bool
+ECL::CartesianGridData::isSubdivided(const int cellID) const
+{
+    return this->cells_.isSubdivided(cellID);
+}
+
+std::vector<double>
+ECL::CartesianGridData::cellData(const ecl_file_type* src,
+                                 const std::string&   vector) const
+{
+    if (! this->haveCellData(src, vector)) {
+        return {};
+    }
+
+    const auto v =
+        ecl_file_iget_named_kw(src, vector.c_str(), this->gridID_);
+
+    auto x = std::vector<double>(ecl_kw_get_size(v));
+
+    ecl_kw_get_data_as_double(v, x.data());
+
+    return this->cells_.scatterToGlobal(x);
+}
+
+bool
+ECL::CartesianGridData::haveCellData(const ecl_file_type* src,
+                                     const std::string&   vector) const
+{
+    // Recall: get_num_named_kw() is block aware (uses src->active_map).
+
+    return ecl_file_get_num_named_kw(src, vector.c_str()) > this->gridID_;
+}
+
+bool
+ECL::CartesianGridData::haveConnData(const ecl_file_type* src,
+                                     const std::string&   vector) const
+{
+    auto have_data = true;
+
+    for (const auto& d : { CartesianCells::Direction::I ,
+                           CartesianCells::Direction::J ,
+                           CartesianCells::Direction::K })
+    {
+        const auto vname = this->vectorName(vector, d);
+        have_data = this->haveCellData(src, vname);
+
+        if (! have_data) { break; }
+    }
+
+    return have_data;
+}
+
+std::vector<double>
+ECL::CartesianGridData::connectionData(const ecl_file_type* src,
+                                       const std::string&   vector) const
+{
+    if (! this->haveConnData(src, vector)) {
+        return {};
+    }
+
+    auto x = std::vector<double>{};  x.reserve(this->numConnections());
+
+    for (const auto& d : { CartesianCells::Direction::I ,
+                           CartesianCells::Direction::J ,
+                           CartesianCells::Direction::K })
+    {
+        this->connectionData(src, d, vector, x);
+    }
+
+    return x;
+}
+
+void
+ECL::CartesianGridData::
+connectionData(const ecl_file_type*            src,
+               const CartesianCells::Direction d,
+               const std::string&              vector,
+               std::vector<double>&            x) const
+{
+    const auto v = this->cellData(src, this->vectorName(vector, d));
+
+    const auto& cells = this->outCell_.find(d);
+
+    assert ((cells != this->outCell_.end()) &&
+            "Direction must be I, J, or K");
+
+    for (const auto& cell : cells->second) {
+        x.push_back(v[cell]);
+    }
+}
+
+std::string
+ECL::CartesianGridData::
+vectorName(const std::string&              vector,
+           const CartesianCells::Direction d) const
+{
+    const auto i = this->suffix_.find(d);
+
+    assert ((i != this->suffix_.end()) &&
+            "Direction must be I, J, or K");
+
+    return vector + i->second;
+}
+
+void
+ECL::CartesianGridData::
+deriveNeighbours(const std::vector<std::size_t>& gcells,
+                 const ecl_file_type*            init,
+                 const CartesianCells::Direction d)
+{
+    auto tran = std::string{"TRAN"};
+
+    switch (d) {
+    case CartesianCells::Direction::I:
+        tran += 'X';
+        break;
+
+    case CartesianCells::Direction::J:
+        tran += 'Y';
+        break;
+
+    case CartesianCells::Direction::K:
+        tran += 'Z';
+        break;
+
+    default:
+        throw std::invalid_argument("Input direction must be (I,J,K)");
+    }
+
+    const auto& T = this->haveCellData(init, tran)
+        ? this->cellData(init, tran)
+        : std::vector<double>(this->cells_.numGlobalCells(), 1.0);
+
+    auto& ocell = this->outCell_[d];
+    ocell.reserve(gcells.size());
+
+    for (const auto& globID : gcells) {
+        const auto c1 = this->cells_.getActiveCell(globID);
+
+        assert ((c1 >= 0) && "Internal error in active cell derivation");
+
+        if (this->cells_.isSubdivided(c1)) {
+            // Don't form connections to subdivided cells.  We care only
+            // about the final refinement level (i.e., the most nested LGR
+            // object) and the connections are handled by the NNC code.
+            continue;
+        }
+
+        if (T[globID] > 0.0) {
+            const auto other = this->cells_.getNeighbour(globID, d);
+
+            if ((other >= 0) && ! this->cells_.isSubdivided(other)) {
+                assert (c1 != other);
+
+                this->neigh_.push_back(c1);
+                this->neigh_.push_back(other);
+
+                ocell.push_back(globID);
+            }
+        }
+    }
 }
 
 // =====================================================================
@@ -698,6 +1038,22 @@ public:
     ///                which next set of phase fluxes should be retrieved.
     void assignDataSource(const Path& src);
 
+    /// Retrieve active cell ID from (I,J,K) tuple in particular grid.
+    ///
+    /// \param[in] gridID Identity of specific grid to which to relate the
+    ///     (I,J,K) tuple.  Zero for main grid and positive indices for any
+    ///     LGRs.  The (I,J,K) indices must be within the ranges implied by
+    ///     the specific grid.
+    ///
+    /// \param[in] ijk Cartesian index tuple of particular cell.
+    ///
+    /// \return Active ID (relative to linear, global numbering) of cell \p
+    ///     ijk from specified grid.  Negative one (-1) if (I,J,K) outside
+    ///     valid range or if the specific cell identified by \p ijk and \p
+    ///     gridID is not actually active.
+    int activeCell(const int                gridID,
+                   const std::array<int,3>& ijk) const;
+
     /// Retrieve number of active cells in graph.
     std::size_t numCells() const;
 
@@ -709,14 +1065,14 @@ public:
     /// The \c i-th connection is between active cells \code
     /// neighbours()[2*i + 0] \endcode and \code neighbours()[2*i + 1]
     /// \endcode.
-    const std::vector<int>& neighbours() const;
+    std::vector<int> neighbours() const;
 
     /// Retrive static pore-volume values on active cells only.
     ///
     /// Corresponds to the \c PORV vector in the INIT file, possibly
     /// restricted to those active cells for which the pore-volume is
     /// strictly positive.
-    const std::vector<double>& activePoreVolume() const;
+    std::vector<double> activePoreVolume() const;
 
     /// Retrive phase flux on all connections defined by \code neighbours()
     /// \endcode.
@@ -726,8 +1082,7 @@ public:
     ///
     /// \param[in] phase Canonical phase for which to retrive flux.
     ///
-    /// \param[in] occurrence Selected temporal vector.  Essentially the
-    ///                       report step number.
+    /// \param[in] rptstep Selected temporal vector.  Report-step ID.
     ///
     /// \return Flux values corresponding to selected phase and report step.
     /// Empty if unavailable in the result set (e.g., by querying the gas
@@ -736,52 +1091,204 @@ public:
     /// all).
     std::vector<double>
     flux(const BlackoilPhases::PhaseIndex phase,
-         const int                        occurrence);
+         const int                        rptstep) const;
 
 private:
-    /// Collection of global (cell) IDs.
-    using GlobalIDColl = std::vector<std::size_t>;
+    /// Collection of non-Cartesian neighbourship relations attributed to a
+    /// particular ECL keyword set (i.e., one of NNC{1,2}, NNC{G,L}, NNCLL).
+    class NonNeighKeywordIndexSet
+    {
+    public:
+        /// Establish mapping between particular non-Cartesian neighbourship
+        /// relation and particular entry within a grid's keyword data.
+        struct Map {
+            /// Non-Cartesian neighbourship relation.
+            std::size_t neighIdx;
 
-    /// Local convenience alias.
-    using Direction = CellCollection::Direction;
+            /// Index into grid's keyword data.
+            std::size_t kwIdx;
+        };
 
-    /// Collection of (global) cell IDs corresponding to the flow source of
-    /// each connection.
-    using OutCell = std::map<Direction, GlobalIDColl>;
+        using MapCollection = std::vector<Map>;
 
-    /// Handle to ECL result set.
-    using CDataPtr = std::unique_ptr<ECL::GlobalCellData>;
+        /// Record a mapping in a particular grid.
+        ///
+        /// \param[in] grid Particular model grid for which to record a
+        ///     mapping.
+        ///
+        /// \param[in] entry Individual index map.
+        void add(const int grid, Map&& entry);
 
-    /// Flattened neighbourship relation (array of size \code
-    /// 2*numConnections() \endcode).
-    std::vector<int> neigh_;
+        /// Retrieve collection of index maps for particular grid.
+        ///
+        /// \param[in] grid Specific model grid ID.  Must be non-negative
+        ///    and strictly less than the total number of grids in the
+        ///    model.
+        ///
+        /// \return Collection of index maps attributable to \p grid.  Empty
+        ///    if no such collection exists.
+        const MapCollection& getGridCollection(const int grid) const;
 
-    /// Static pore-volumes of all active cells.
-    std::vector<double> activePVol_;
+    private:
+        using KWEntries = std::map<int, MapCollection>;
 
-    /// Source cells for each Cartesian connection.
-    OutCell outCell_;
+        /// Collection of all index maps attributable to all grids for this
+        /// set of ECL keywords.
+        KWEntries subset_;
 
-    /// Subset of non-neighbouring connections that affect active cells in
-    /// main grid.
-    GlobalIDColl nncID_;
+        /// Return value for the case of no existing collection.
+        MapCollection empty_;
+    };
 
-    /// Hook into ECL result set.  Pointer because we need deferred
-    /// initialisation.
-    CDataPtr data_;
+    /// Collection of all non-Cartesian neighbourship relations classified
+    /// according to connection type.
+    class NNC
+    {
+    public:
+        /// Classification of non-Cartesian neighbourship relations.
+        enum class Category {
+            /// Traditional non-neighbouring connections entirely internal
+            /// to a grid.  Typically due to faults or fully unstructured
+            /// grid descriptions.  Keywords NNC{1,2}, TRANNNC, and FLR*N+.
+            /// Positive from NNC1 to NNC2.
+            Normal,
 
-    /// Derive connections in particular Cartesian direction on all active
-    /// cells.
-    ///
-    /// Writes to \c neigh_ and \c outCell_.  Will possibly change the \code
-    /// *data_ \endcode object.
-    ///
-    /// \param[in] d Cartesian direction in which to look for neighbouring
-    ///              cells.
-    ///
-    /// \param[in] coll Backing data for neighbourship extraction.
-    void deriveNeighbours(const CellCollection::Direction d,
-                          const CellCollection&           coll);
+            /// Connections between main grid and LGRs.  Keywords NNCG,
+            /// NNCL, TRANGL, and FLR*L+.  Positive from NNCG to NNCL.
+            GlobalToLocal,
+
+            /// Connections between LGRs.  Either due to two LGRs being
+            /// neighbouring entities in physical space or one LGR being
+            /// nested within another.  Keywords NNA{1,2}, TRANLL, and
+            /// FLR*A+.  Positive from NNA1 to NNA2.
+            Amalgamated,
+        };
+
+        /// Map a collection of non-Cartesian neighbourship relations to a
+        /// specific flux vector identifier.
+        struct FluxRelation {
+            /// Flux vector identifier.  Should be one of "N+" for Normal
+            /// connections, "L+" for GlobalToLocal connections, and "A+"
+            /// for Amalgamated connections.
+            std::string fluxID;
+
+            /// Collection of non-Cartesian neighbourship relations.
+            NonNeighKeywordIndexSet indexSet;
+        };
+
+        /// Constructor.
+        NNC();
+
+        /// Potentially record a new non-Cartesian connection.
+        ///
+        /// Will classify the connection according to the grids involved and
+        /// actually record the connection if both cells are active and
+        /// neither are subdivided.
+        ///
+        /// \param[in] grids Collection of all active grids in model.
+        ///
+        /// \param[in] offset Start index into global linear number for all
+        ///    active grids.
+        ///
+        /// \param[in] nnc Non-neighbouring connection from result set.
+        void add(const std::vector<ECL::CartesianGridData>& grids,
+                 const std::vector<std::size_t>&            offset,
+                 const ecl_nnc_type&                        nnc);
+
+        std::vector<Category> allCategories() const;
+
+        /// Retrieve total number of active non-neighbouring connections.
+        std::size_t numConnections() const;
+
+        /// Access all active non-neighbouring connections.
+        const std::vector<int>& getNeighbours() const;
+
+        /// Retrieve all non-neighbouring connections of a particular
+        /// category (i.e., pertaining to a particular set of keywords).
+        ///
+        /// \param[in] type Category of non-neighbouring connections.
+        ///
+        /// \return All non-neighbouring connections of category \p type.
+        const FluxRelation& getRelations(const Category& type) const;
+
+    private:
+        using KeywordIndexMap = std::map<Category, FluxRelation>;
+
+        /// Active non-Cartesian (non-neighbouring) connections.  Cell IDs
+        /// in linear numbering of all model's active cells.
+        std::vector<int> neigh_;
+
+        /// Collection of
+        KeywordIndexMap keywords_;
+
+        /// Factory for FluxRelations.
+        ///
+        /// Simplifies implementation of ctor.
+        ///
+        /// \param[in] cat Class
+        FluxRelation makeRelation(const Category cat) const;
+
+        /// Identify connection category from connection's grids.
+        ///
+        ///   - Normal connection if both grid IDs equal
+        ///   - GlobalToLocal if one grid is the main model grid and the
+        ///     other is an LGR.
+        ///   - Amalgamated if both grids are LGRs.
+        ///
+        /// \param[in] grid1 Numeric identity of connection's first grid.
+        ///     Zero if main grid, positive if LGR.
+        ///
+        /// \param[in] grid2 Numeric identity of connection's second grid.
+        ///     Zero if main grid, positive if LGR.
+        ///
+        /// \return Category of connection between \p grid1 and \p grid2.
+        Category classifyConnection(const int grid1, const int grid2) const;
+
+        /// Check if cell is viable connection endpoint in grid.
+        ///
+        /// A cell is a viable connection endpoint if it is active within a
+        /// particular grid and not further subdivided by an LGR.
+        ///
+        /// \param[in] grids Collection of all active grids in model.
+        ///
+        /// \param[in] gridID Numeric identity of connection grid.
+        ///     Zero if main grid, positive if LGR.
+        ///
+        /// \param[in] cellID Global ID (relative to \p grid) of candidate
+        ///     connection endpoint.
+        ///
+        /// \return Whether or not \p cellID is a viable connection endpoint
+        ///     within \p gridID.
+        bool isViable(const std::vector<ECL::CartesianGridData>& grids,
+                      const int         gridID,
+                      const std::size_t cellID) const;
+
+        /// Check if connection is viable
+        ///
+        /// A candidate non-Cartesian connection is viable if both of its
+        /// endpoints satisfy the viability criterion.
+        ///
+        /// \param[in] nnc Candidate non-Cartesian connection.
+        ///
+        /// \return Whether or not both candidate endpoints satisfy the
+        /// viability criterion.
+        bool isViable(const std::vector<ECL::CartesianGridData>& grids,
+                      const ecl_nnc_type& nnc) const;
+    };
+
+    /// Collection of model's non-neighbouring connections--be they within a
+    /// grid or between grids.
+    NNC nnc_;
+
+    /// Collection of model's grids (main + LGRs).
+    std::vector<ECL::CartesianGridData> grid_;
+
+    /// Map each grid's active cellIDs to global numbering (in the index
+    /// range \code [0 .. numCells()) \endcode).
+    std::vector<std::size_t> activeOffset_;
+
+    /// Current result set.
+    ECL::FilePtr src_;
 
     /// Extract explicit non-neighbouring connections from ECL output.
     ///
@@ -792,18 +1299,8 @@ private:
     /// \param[in] init ERT representation of INIT source.
     ///
     /// \param[in] coll Backing data for neighbourship extraction.
-    void nnc(const ecl_grid_type*  G,
-             const ecl_file_type*  init,
-             const CellCollection& coll);
-
-    /// Predicate that establishes availability of a particular phase flux
-    /// in the current result set.
-    ///
-    /// \param[in] phase Canonical phase for which to check availability.
-    ///
-    /// \return Whether or not the current result set (\code *data_
-    /// \endcode) contains phase flux data for the input phase.
-    bool fluxAvailable(const BlackoilPhases::PhaseIndex phase) const;
+    void defineNNCs(const ecl_grid_type* G,
+                    const ecl_file_type* init);
 
     /// Compute ECL vector basename for particular phase flux.
     ///
@@ -815,116 +1312,314 @@ private:
     std::string
     flowVector(const BlackoilPhases::PhaseIndex phase) const;
 
-    /// Extract phase flux values for all Cartesian connections in a
-    /// particular direction.
+    /// Extract flux values corresponding to particular result set vector
+    /// for all identified non-neighbouring connections.
     ///
-    /// Potentially modifies \code *data_ \endcode.
+    /// \param[in] vector Result set vector prefix.  Typically computed by
+    ///    method flowVector().
     ///
-    /// \param[in] d Cartesian direction for which to extract phase flux
-    ///              values.
-    ///
-    /// \param[in] vector Basename for ECL vector corresponding to
-    ///              particular phase flux.  Intentially taken as mutable
-    ///              copy which is modified in function body.
-    ///
-    /// \param[in] occurrence Selected temporal vector.  Essentially the
-    ///              report step number.
-    ///
-    /// \param[in,out] flux Phase flux values.  Values corresponding to
-    /// direction \c d are appended to the \p flux vector.
-    void phaseFluxCartesian(const CellCollection::Direction d,
-                            std::string                     vector,
-                            const int                       occurrence,
-                            std::vector<double>&            flux);
-
-    /// Extract phase flux values for all non-neighbouring connections
-    /// between active cells in main grid.
-    ///
-    /// Potentially modifies \code *data_ \endcode.
-    ///
-    /// \param[in] vector Basename for ECL vector corresponding to
-    ///              particular phase flux.  Intentially taken as mutable
-    ///              copy (modified in function body).
-    ///
-    /// \param[in] occurrence Selected temporal vector.  Essentially the
-    ///              report step number.
-    ///
-    /// \param[in,out] flux Phase flux values.  Values corresponding to
-    /// direction \c d are appended to the \p flux vector.
-    void phaseFluxNNC(const std::string&   vector,
-                      const int            occurrence,
-                      std::vector<double>& flux);
+    /// \param[in,out] flux Numerical values of result set vector.  On
+    ///    input, contains all values corresponding to all fully Cartesian
+    ///    connections across all active grids.  On output additionally
+    ///    contains those values that correspond to the non-neighbouring
+    ///    connections (appended onto \p flux).
+    void fluxNNC(const std::string&   vector,
+                 std::vector<double>& flux) const;
 };
+
+// ======================================================================
+
+void
+Opm::ECLGraph::Impl::NonNeighKeywordIndexSet::
+add(const int grid, Map&& entry)
+{
+    this->subset_[grid].push_back(std::move(entry));
+}
+
+const
+Opm::ECLGraph::Impl::NonNeighKeywordIndexSet::MapCollection&
+Opm::ECLGraph::Impl::NonNeighKeywordIndexSet::
+getGridCollection(const int grid) const
+{
+    auto coll = this->subset_.find(grid);
+
+    if (coll == this->subset_.end()) {
+        // No NNCs of this category for this grid.  Return empty.
+        return this->empty_;
+    }
+
+    return coll->second;
+}
+
+// ======================================================================
+
+Opm::ECLGraph::Impl::NNC::NNC()
+{
+    using VT = KeywordIndexMap::value_type;
+
+    for (const auto& cat : this->allCategories()) {
+        this->keywords_.insert(VT(cat, this->makeRelation(cat)));
+    }
+}
+
+std::vector<Opm::ECLGraph::Impl::NNC::Category>
+Opm::ECLGraph::Impl::NNC::allCategories() const
+{
+    return { Category::Normal        ,
+             Category::GlobalToLocal ,
+             Category::Amalgamated   };
+}
+
+void
+Opm::ECLGraph::Impl::
+NNC::add(const std::vector<ECL::CartesianGridData>& grid,
+         const std::vector<std::size_t>&            offset,
+         const ecl_nnc_type&                        nnc)
+{
+    if (! this->isViable(grid, nnc)) {
+        // At least one endpoint unviable.  Don't record connection.
+        return;
+    }
+
+    const auto neighIdx = this->numConnections();
+
+    {
+        const auto c = grid[nnc.grid_nr1].activeCell(nnc.global_index1);
+        const auto o = static_cast<int>(offset[nnc.grid_nr1]);
+
+        this->neigh_.push_back(o + c);
+    }
+
+    {
+        const auto c = grid[nnc.grid_nr2].activeCell(nnc.global_index2);
+        const auto o = static_cast<int>(offset[nnc.grid_nr2]);
+
+        this->neigh_.push_back(o + c);
+    }
+
+    const auto cat = this->classifyConnection(nnc.grid_nr1, nnc.grid_nr2);
+
+    auto entry = NonNeighKeywordIndexSet::Map {
+        neighIdx,
+        static_cast<std::size_t>(nnc.input_index)
+    };
+
+    this->keywords_[cat].indexSet.add(nnc.grid_nr2, std::move(entry));
+}
+
+std::size_t
+Opm::ECLGraph::Impl::NNC::numConnections() const
+{
+    assert (this->neigh_.size() % 2 == 0);
+
+    return this->neigh_.size() / 2;
+}
+
+const std::vector<int>&
+Opm::ECLGraph::Impl::NNC::getNeighbours() const
+{
+    return this->neigh_;
+}
+
+const Opm::ECLGraph::Impl::NNC::FluxRelation&
+Opm::ECLGraph::Impl::NNC::getRelations(const Category& cat) const
+{
+    auto r = this->keywords_.find(cat);
+
+    assert ((r != this->keywords_.end()) &&
+            "Input category must be Normal, "
+            "GlobalToLocal or Amalgamated");
+
+    return r->second;
+}
+
+Opm::ECLGraph::Impl::NNC::FluxRelation
+Opm::ECLGraph::Impl::NNC::makeRelation(const Category cat) const
+{
+    switch (cat) {
+    case Category::Normal:
+        return { "N+", {} };
+
+    case Category::GlobalToLocal:
+        return { "L+", {} };
+
+    case Category::Amalgamated:
+        return { "A+", {} };
+    }
+
+    throw std::invalid_argument("Category must be Normal, "
+                                "GlobalToLocal, or Amalgamated");
+}
+
+Opm::ECLGraph::Impl::NNC::Category
+Opm::ECLGraph::Impl::NNC::
+classifyConnection(const int grid1, const int grid2) const
+{
+    if (grid1 == grid2) {
+        return Category::Normal;
+    }
+
+    if (grid1 == 0) {           // Main grid
+        return Category::GlobalToLocal;
+    }
+
+    return Category::Amalgamated;
+}
+
+bool
+Opm::ECLGraph::Impl::NNC::
+isViable(const std::vector<ECL::CartesianGridData>& grids,
+         const int                                  gridID,
+         const std::size_t                          cellID) const
+{
+    using GridIndex = decltype(grids.size());
+    const auto gIdx = static_cast<GridIndex>(gridID);
+
+    if (gIdx >= grids.size()) {
+        return false;
+    }
+
+    const auto& G     = grids[gIdx];
+    const auto  acell = G.activeCell(cellID);
+
+    return (acell >= 0) && (! G.isSubdivided(acell));
+}
+
+bool
+Opm::ECLGraph::Impl::NNC::
+isViable(const std::vector<ECL::CartesianGridData>& grids,
+         const ecl_nnc_type&                        nnc) const
+{
+    return this->isViable(grids, nnc.grid_nr1, nnc.global_index1)
+        && this->isViable(grids, nnc.grid_nr2, nnc.global_index2);
+}
+
+// ======================================================================
 
 Opm::ECLGraph::Impl::Impl(const Path& grid, const Path& init)
 {
     const auto G = ECL::loadCase(grid);
     auto       I = ECL::loadFile(init);
 
-    const auto pvol = ECL::getPVolVector(G.get(), I.get());
+    const auto numGrids = ECL::numGrids(G.get());
 
-    this->data_.reset(new ECL::GlobalCellData(G.get(), pvol));
-    this->data_->assignDataSource(std::move(I));
+    this->grid_.reserve(numGrids);
+    this->activeOffset_.reserve(numGrids + 1);
+    this->activeOffset_.push_back(0);
 
-    const auto coll =
-        CellCollection{ G.get(), this->data_->activeGlobalCells() };
-
-    this->activePVol_.reserve(coll.activeGlobalCells().size());
-    for (const auto& globCell : coll.activeGlobalCells()) {
-        this->activePVol_.push_back(pvol[globCell]);
-    }
-
-    // Too large, but this is a quick estimate.
-    this->neigh_.reserve(3 * (2 * this->numCells()));
-
-    for (const auto d : { CellCollection::Direction::I ,
-                          CellCollection::Direction::J ,
-                          CellCollection::Direction::K })
+    for (auto gridID = 0*numGrids; gridID < numGrids; ++gridID)
     {
-        this->deriveNeighbours(d, coll);
+        this->grid_.emplace_back(ECL::getGrid(G.get(), gridID),
+                                 I.get(), gridID);
+
+        this->activeOffset_.push_back(this->activeOffset_.back() +
+                                      this->grid_.back().numCells());
     }
 
-    this->nnc(G.get(), this->data_->getDataSource(), coll);
+    this->defineNNCs(G.get(), I.get());
 }
 
 void
 Opm::ECLGraph::Impl::assignDataSource(const Path& src)
 {
-    this->data_->assignDataSource(src);
+    this->src_ = ECL::loadFile(src);
+}
+
+int
+Opm::ECLGraph::Impl::
+activeCell(const int                gridID,
+           const std::array<int,3>& ijk) const
+{
+    const auto gIdx =
+        static_cast<decltype(this->grid_.size())>(gridID);
+
+    if (gIdx >= this->grid_.size()) {
+        return -1;
+    }
+
+    const auto& grid = this->grid_[gIdx];
+
+    const auto active = grid.activeCell(ijk[0], ijk[1], ijk[2]);
+
+    if ((active < 0) || grid.isSubdivided(active)) {
+        return -1;
+    }
+
+    const auto off = static_cast<int>(this->activeOffset_[gIdx]);
+
+    return off + active;
 }
 
 std::size_t
 Opm::ECLGraph::Impl::numCells() const
 {
-    return this->activePVol_.size();
+    return this->activeOffset_.back();
 }
 
 std::size_t
 Opm::ECLGraph::Impl::numConnections() const
 {
-    assert (this->neighbours().size() % 2 == 0);
+    auto nconn = std::size_t{0};
 
-    return this->neighbours().size() / 2;
+    for (const auto& G : this->grid_) {
+        nconn += G.numConnections();
+    }
+
+    return nconn + this->nnc_.numConnections();
 }
 
-const std::vector<int>&
+std::vector<int>
 Opm::ECLGraph::Impl::neighbours() const
 {
-    return this->neigh_;
+    auto N = std::vector<int>{};
+
+    N.reserve(2 * (this->numConnections() +
+                   this->nnc_.numConnections()));
+
+    {
+        auto off = this->activeOffset_.begin();
+
+        for (const auto& G : this->grid_) {
+            const auto add = static_cast<int>(*off);
+
+            for (const auto& cell : G.neighbours()) {
+                N.push_back(cell + add);
+            }
+
+            ++off;
+        }
+    }
+
+    {
+        const auto& nnc = this->nnc_.getNeighbours();
+
+        N.insert(N.end(), nnc.begin(), nnc.end());
+    }
+
+    return N;
 }
 
-const std::vector<double>&
+std::vector<double>
 Opm::ECLGraph::Impl::activePoreVolume() const
 {
-    return this->activePVol_;
+    auto pvol = std::vector<double>{};
+    pvol.reserve(this->numCells());
+
+    for (const auto& G : this->grid_) {
+        const auto& pv = G.activePoreVolume();
+
+        pvol.insert(pvol.end(), pv.begin(), pv.end());
+    }
+
+    return pvol;
 }
 
 std::vector<double>
 Opm::ECLGraph::Impl::
 flux(const BlackoilPhases::PhaseIndex phase,
-     const int                        occurrence)
+     const int                        rptstep) const
 {
-    if (! this->fluxAvailable(phase)) {
+    if (! ecl_file_has_report_step(this->src_.get(), rptstep)) {
         return {};
     }
 
@@ -932,124 +1627,74 @@ flux(const BlackoilPhases::PhaseIndex phase,
 
     auto v = std::vector<double>{};
 
-    for (const auto d : { CellCollection::Direction::I ,
-                          CellCollection::Direction::J ,
-                          CellCollection::Direction::K })
-    {
-        this->phaseFluxCartesian(d, vector, occurrence, v);
+    v.reserve(this->numConnections());
+
+    ecl_file_select_rstblock_report_step(this->src_.get(), rptstep);
+
+    for (const auto& G : this->grid_) {
+        const auto& q = G.connectionData(this->src_.get(), vector);
+
+        v.insert(v.end(), q.begin(), q.end());
     }
 
-    if (! this->nncID_.empty()) {
-        this->phaseFluxNNC(vector, occurrence, v);
-    }
+    this->fluxNNC(vector, v);
 
     return v;
 }
 
 void
-Opm::ECLGraph::Impl::
-deriveNeighbours(const CellCollection::Direction d,
-                 const CellCollection&           coll)
+Opm::ECLGraph::Impl::defineNNCs(const ecl_grid_type* G,
+                                const ecl_file_type* init)
 {
-    auto tran = std::string{"TRAN"};
-
-    switch (d) {
-    case CellCollection::Direction::I:
-        tran += 'X';
-        break;
-
-    case CellCollection::Direction::J:
-        tran += 'Y';
-        break;
-
-    case CellCollection::Direction::K:
-        tran += 'Z';
-        break;
-
-    default:
-        throw std::invalid_argument("Input direction must be (I,J,K)");
-    }
-
-    const auto& T = this->data_->haveVector(tran)
-        ? this->data_->getVector(tran)
-        : std::vector<double>(coll.numGlobalCells(), 1.0);
-
-    auto& ocell = this->outCell_[d];
-    ocell.reserve(this->data_->activeGlobalCells().size());
-
-    for (const auto& globID : coll.activeGlobalCells()) {
-        if (T[globID] > 0.0) {
-            const auto other = coll.cartesianNeighbour(globID, d);
-
-            if (other >= 0) {
-                const auto c1 = coll.activeCell(globID);
-
-                assert (c1 != other);
-
-                this->neigh_.push_back(c1);
-                this->neigh_.push_back(other);
-
-                ocell.push_back(globID);
-            }
-        }
+    for (const auto& nnc : ECL::loadNNC(G, init)) {
+        this->nnc_.add(this->grid_, this->activeOffset_, nnc);
     }
 }
 
 void
-Opm::ECLGraph::Impl::nnc(const ecl_grid_type*  G,
-                                  const ecl_file_type*  init,
-                                  const CellCollection& coll)
+Opm::ECLGraph::Impl::fluxNNC(const std::string&   vector,
+                             std::vector<double>& flux) const
 {
-    const auto nncData = ECL::loadNNC(G, init);
-    const auto numNNC  = nncData.size();
+    auto v = std::vector<double>(this->nnc_.numConnections(), 0.0);
 
-    this->neigh_.reserve(this->neigh_.size() + (2 * numNNC));
+    for (const auto& cat : this->nnc_.allCategories()) {
+        const auto& rel    = this->nnc_.getRelations(cat);
+        const auto  fluxID = vector + rel.fluxID;
 
-    this->nncID_.clear();
-    this->nncID_.reserve(numNNC);
+        auto gridID = 0;
+        for (const auto& G : this->grid_) {
+            const auto& iset = rel.indexSet.getGridCollection(gridID);
 
-    auto nncID = static_cast<std::size_t>(0);
+            // Must increment grid ID irrespective of early break of
+            // iteration.
+            gridID += 1;
 
-    for (const auto& conn : nncData) {
-        // Omit LGR.
-        if ((conn.grid_nr1 == 0) && (conn.grid_nr2 == 0) &&
-            (conn.trans > 0.0))
-        {
-            const auto c1 = coll.activeCell(conn.global_index1);
-            const auto c2 = coll.activeCell(conn.global_index2);
+            if (iset.empty()) {
+                // No NNCs for this category in this grid.  Skip.
+                continue;
+            }
 
-            if ((c1 >= 0) && (c2 >= 0)) {
-                assert (c1 != c2);
+            // Note: Method name is confusing, but does actually do what we
+            // want here.
+            const auto q = G.cellData(this->src_.get(), fluxID);
 
-                this->neigh_.push_back(c1);
-                this->neigh_.push_back(c2);
+            if (q.empty()) {
+                // No flux data for this category in this grid.  Skip.
+                continue;
+            }
 
-                this->nncID_.push_back(nncID);
+            // Data fully available for (category,gridID).  Assign
+            // approriate subset of NNC flux vector.
+            for (const auto& ix : iset) {
+                assert (ix.neighIdx < v.size());
+                assert (ix.kwIdx    < q.size());
+
+                v[ix.neighIdx] = q[ix.kwIdx];
             }
         }
-
-        nncID += 1;
-    }
-}
-
-bool
-Opm::ECLGraph::Impl::
-fluxAvailable(const BlackoilPhases::PhaseIndex phase) const
-{
-    const auto vector = this->flowVector(phase);
-
-    auto haveVector = true;
-
-    for (const auto* flowdir : { "I+", "J+", "K+" }) {
-        haveVector = haveVector &&
-            this->data_->haveVector(vector + flowdir);
     }
 
-    if (haveVector && ! this->nncID_.empty()) {
-        haveVector = this->data_->haveVector(vector + "N+");
-    }
-
-    return haveVector;
+    flux.insert(flux.end(), v.begin(), v.end());
 }
 
 std::string
@@ -1076,54 +1721,6 @@ flowVector(const BlackoilPhases::PhaseIndex phase) const
         os << "Invalid phase index '" << phase << '\'';
 
         throw std::invalid_argument(os.str());
-    }
-}
-
-void
-Opm::ECLGraph::Impl::
-phaseFluxCartesian(const CellCollection::Direction d,
-                   std::string                     vector,
-                   const int                       occurrence,
-                   std::vector<double>&            flux)
-{
-    switch (d) {
-    case CellCollection::Direction::I:
-        vector += 'I';
-        break;
-
-    case CellCollection::Direction::J:
-        vector += 'J';
-        break;
-
-    case CellCollection::Direction::K:
-        vector += 'K';
-        break;
-    }
-
-    vector += '+';
-
-    const auto& v = this->data_->getVector(vector, occurrence);
-
-    flux.reserve(flux.size() + this->outCell_[d].size());
-
-    for (const auto& globCell : this->outCell_[d]) {
-        flux.push_back(v[globCell]);
-    }
-}
-
-void
-Opm::ECLGraph::Impl::
-phaseFluxNNC(const std::string&   vector,
-             const int            occurrence,
-             std::vector<double>& flux)
-{
-    const auto& v =
-        this->data_->getVector(vector + "N+", occurrence);
-
-    flux.reserve(flux.size() + this->nncID_.size());
-
-    for (const auto& nnc : this->nncID_) {
-        flux.push_back(v[nnc]);
     }
 }
 
@@ -1175,14 +1772,12 @@ Opm::ECLGraph::numConnections() const
     return this->pImpl_->numConnections();
 }
 
-const std::vector<int>&
-Opm::ECLGraph::neighbours() const
+std::vector<int> Opm::ECLGraph::neighbours() const
 {
     return this->pImpl_->neighbours();
 }
 
-const std::vector<double>&
-Opm::ECLGraph::poreVolume() const
+std::vector<double> Opm::ECLGraph::poreVolume() const
 {
     return this->pImpl_->activePoreVolume();
 }
@@ -1190,7 +1785,7 @@ Opm::ECLGraph::poreVolume() const
 std::vector<double>
 Opm::ECLGraph::
 flux(const BlackoilPhases::PhaseIndex phase,
-     const int                        occurrence)
+     const int                        rptstep) const
 {
-    return this->pImpl_->flux(phase, occurrence);
+    return this->pImpl_->flux(phase, rptstep);
 }

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1077,9 +1077,6 @@ public:
     /// Retrive phase flux on all connections defined by \code neighbours()
     /// \endcode.
     ///
-    /// Non-"const" because this potentially loads new data from the backing
-    /// store into internal cache data structures.
-    ///
     /// \param[in] phase Canonical phase for which to retrive flux.
     ///
     /// \param[in] rptstep Selected temporal vector.  Report-step ID.

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -23,6 +23,7 @@
 
 #include <opm/core/props/BlackoilPhases.hpp>
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <vector>
@@ -95,6 +96,22 @@ namespace Opm {
         /// \param[in] src Name of ECL restart file, possibly unified, from
         ///                which next set of phase fluxes should be retrieved.
         void assignFluxDataSource(const Path& src);
+
+        /// Retrieve active cell ID from (I,J,K) tuple in particular grid.
+        ///
+        /// \param[in] ijk Cartesian index tuple of particular cell.
+        ///
+        /// \param[in] gridID Identity of specific grid to which to relate
+        ///     the (I,J,K) tuple.  Use zero (default) for main grid and
+        ///     positive indices for any LGRs.  The (I,J,K) indices must be
+        ///     within the ranges implied by the specific grid.
+        ///
+        /// \return Active ID (relative to linear, global numbering) of cell
+        ///     (I,J,K) from specified grid.  Negative one (-1) if (I,J,K)
+        ///     outside valid range or if the specific cell identified by \p
+        ///     ijk and \p gridID is not actually active.
+        int activeCell(const std::array<int,3>& ijk,
+                       const int                gridID = 0) const;
 
         /// Retrieve number of active cells in graph.
         std::size_t numCells() const;

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -107,25 +107,21 @@ namespace Opm {
         /// The \c i-th connection is between active cells \code
         /// neighbours()[2*i + 0] \endcode and \code neighbours()[2*i + 1]
         /// \endcode.
-        const std::vector<int>& neighbours() const;
+        std::vector<int> neighbours() const;
 
         /// Retrive static pore-volume values on active cells only.
         ///
         /// Corresponds to the \c PORV vector in the INIT file, possibly
         /// restricted to those active cells for which the pore-volume is
         /// strictly positive.
-        const std::vector<double>& poreVolume() const;
+        std::vector<double> poreVolume() const;
 
         /// Retrive phase flux on all connections defined by \code
         /// neighbours() \endcode.
         ///
-        /// Non-"const" because this potentially loads new data from the
-        /// backing store into internal cache data structures.
-        ///
         /// \param[in] phase Canonical phase for which to retrive flux.
         ///
-        /// \param[in] occurrence Selected temporal vector.  Essentially the
-        ///                       report step number.
+        /// \param[in] rptstep Selected temporal vector.  Report-step ID.
         ///
         /// \return Flux values corresponding to selected phase and report
         /// step.  Empty if unavailable in the result set (e.g., by querying
@@ -134,7 +130,7 @@ namespace Opm {
         /// values are output at all).
         std::vector<double>
         flux(const BlackoilPhases::PhaseIndex phase,
-             const int                        occurrence = 0);
+             const int                        rptstep = 0) const;
 
     private:
         /// Implementation class.


### PR DESCRIPTION
This change-set extends the initial implementation of the derivation of an unstructured graph from an ECLIPSE result set to account for the possibility of there being local grid refinement.  This means that the implementation class (`ECLGraph::Impl`) now manages a collection of underlying Cartesian grid structures, of which grid ID zero is the main (host) grid and any LGRs have positive grid IDs.

In some extra detail, we merge the existing classes

  * `ECL::ScatterMap`
  * `ECL::GlobalCellData`
  * `ECL::CellCollection`

into a single new class, `CartesianGridData`, that supports generation of Cartesian connections and extraction of data values on those connections (e.g., phase flow rates) on one ERT grid--irrespective
of the nature of that grid (main grid or LGR).  The `ECLGraph::Impl` class gains a vector of such `CartesianGridData` instances--one for each active grid in the model.  We furthermore defer managing the non-neighbouring connections to an internal class `Impl::NNC` that queries the Cartesian grids when deriving the neighbourship relations and extracting flux values.

We also expose a new method
```C++
int ECLGraph::activeCell(const std::array<int,3>& ijk, const int gridID = 0) const;
```
that translates an index (I,J,K) tuple, assumed to be relative to a particular grid (main grid by default), to the globally numbered linear index of an active cell.  If the tuple happens to go through an inactive cell, method `activeCell()` returns negative one.