### PR TITLE
ECLGraph: Protect against missing NNC fluxes

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1582,8 +1582,8 @@ Opm::ECLGraph::Impl::neighbours() const
 {
     auto N = std::vector<int>{};
 
-    N.reserve(2 * (this->numConnections() +
-                   this->nnc_.numConnections()));
+    // this->numConnections() includes NNCs.
+    N.reserve(2 * this->numConnections());
 
     {
         auto off = this->activeOffset_.begin();
@@ -1636,8 +1636,8 @@ flux(const BlackoilPhases::PhaseIndex phase,
 
     auto v = std::vector<double>{};
 
-    const auto totconn =
-        this->numConnections() + this->nnc_.numConnections();
+    // Recall: this->numConnections() includes NNCs.
+    const auto totconn = this->numConnections();
 
     v.reserve(totconn);
 


### PR DESCRIPTION
This commit installs a guard in the handling of fluxes from non-Cartesian connections (i.e., categories of NNC keywords).  In particular we do not append NNC values to the global flux vector unless all entries in the NNC vector have actually been extracted from the relevant result set.

This fixes a problem in [`computeToFandTraces`](https://github.com/OPM/opm-flowdiagnostics-applications/commit/82eb3cfc431d86a8b2f2b61171fdf505ea69557d#diff-4ca8b47d6574a22e6a45b57ea41bba00L100) when asking for gas fluxes in an oil/water system.

Pointy hat: Bard.Skaflestad@sintef.no