### PR TITLE
Exclude zero transmissibility NNCs from ECL flux graph

### DIFF
--- a/examples/computeToFandTracers.cpp
+++ b/examples/computeToFandTracers.cpp
@@ -80,8 +80,7 @@ namespace {
     }
 
     Opm::FlowDiagnostics::ConnectionValues
-    extractFluxField(const Opm::ECLGraph& G,
-                     const int step)
+    extractFluxField(const Opm::ECLGraph& G, const int step)
     {
         using ConnVals = Opm::FlowDiagnostics::ConnectionValues;
 
@@ -89,14 +88,15 @@ namespace {
         using NPhas = ConnVals::NumPhases;
 
         const auto nconn = NConn{G.numConnections()};
-        const auto nphas = NPhas{2};
+        const auto nphas = NPhas{3};
 
         auto flux = ConnVals(nconn, nphas);
 
         auto phas = ConnVals::PhaseID{0};
 
         for (const auto& p : { Opm::BlackoilPhases::Aqua   ,
-                               Opm::BlackoilPhases::Liquid  })
+                               Opm::BlackoilPhases::Liquid ,
+                               Opm::BlackoilPhases::Vapour })
         {
             const auto pflux = G.flux(p, step);
 

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1379,7 +1379,8 @@ NNC::add(const std::vector<ECL::CartesianGridData>& grid,
          const ecl_nnc_type&                        nnc)
 {
     if (! this->isViable(grid, nnc)) {
-        // At least one endpoint unviable.  Don't record connection.
+        // Zero transmissibility or at least one endpoint unviable.  Don't
+        // record connection.
         return;
     }
 
@@ -1492,7 +1493,8 @@ Opm::ECLGraph::Impl::NNC::
 isViable(const std::vector<ECL::CartesianGridData>& grids,
          const ecl_nnc_type&                        nnc) const
 {
-    return this->isViable(grids, nnc.grid_nr1, nnc.global_index1)
+    return (nnc.trans > 0.0)    // Omit zero-trans NNCs
+        && this->isViable(grids, nnc.grid_nr1, nnc.global_index1)
         && this->isViable(grids, nnc.grid_nr2, nnc.global_index2);
 }
 

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -466,7 +466,7 @@ ECL::getGrid(const ecl_grid_type* G, const int gridID)
 {
     assert ((gridID >= 0) && "Grid ID must be non-negative");
 
-    if (gridID == 0) {
+    if (gridID == ECL_GRID_MAINGRID_LGR_NR) {
         return G;
     }
 
@@ -1462,7 +1462,7 @@ classifyConnection(const int grid1, const int grid2) const
         return Category::Normal;
     }
 
-    if (grid1 == 0) {           // Main grid
+    if (grid1 == ECL_GRID_MAINGRID_LGR_NR) { // Main grid
         return Category::GlobalToLocal;
     }
 


### PR DESCRIPTION
This change-set fixes an omission in the original implementation of the NNC support for LGRs.  We must not include zero transmissibility NNCs in the neighbourship relations.

With this we produce the same flux graph as MRST on the NORNE_ATW2013 result set.