### PR TITLE
Use own enum instead of BlackoilPhases from opm-core.

### DIFF
--- a/examples/computeToFandTracers.cpp
+++ b/examples/computeToFandTracers.cpp
@@ -23,7 +23,6 @@
 #endif
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/props/BlackoilPhases.hpp>
 
 #include <opm/flowdiagnostics/ConnectivityGraph.hpp>
 #include <opm/flowdiagnostics/ConnectionValues.hpp>
@@ -94,9 +93,9 @@ namespace {
 
         auto phas = ConnVals::PhaseID{0};
 
-        for (const auto& p : { Opm::BlackoilPhases::Aqua   ,
-                               Opm::BlackoilPhases::Liquid ,
-                               Opm::BlackoilPhases::Vapour })
+        for (const auto& p : { Opm::ECLGraph::Aqua   ,
+                               Opm::ECLGraph::Liquid ,
+                               Opm::ECLGraph::Vapour })
         {
             const auto pflux = G.flux(p, step);
 

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1092,8 +1092,8 @@ public:
     /// reported due to report frequencies or no flux values are output at
     /// all).
     std::vector<double>
-    flux(const BlackoilPhases::PhaseIndex phase,
-         const int                        rptstep) const;
+    flux(const PhaseIndex phase,
+         const int        rptstep) const;
 
 private:
     /// Collection of non-Cartesian neighbourship relations attributed to a
@@ -1312,7 +1312,7 @@ private:
     /// \return Basename for ECl vector corresponding to particular phase
     /// flux.
     std::string
-    flowVector(const BlackoilPhases::PhaseIndex phase) const;
+    flowVector(const PhaseIndex phase) const;
 
     /// Extract flux values corresponding to particular result set vector
     /// for all identified non-neighbouring connections.
@@ -1627,8 +1627,8 @@ Opm::ECLGraph::Impl::activePoreVolume() const
 
 std::vector<double>
 Opm::ECLGraph::Impl::
-flux(const BlackoilPhases::PhaseIndex phase,
-     const int                        rptstep) const
+flux(const PhaseIndex phase,
+     const int        rptstep) const
 {
     if (! ecl_file_has_report_step(this->src_.get(), rptstep)) {
         return {};
@@ -1743,19 +1743,19 @@ Opm::ECLGraph::Impl::fluxNNC(const std::string&   vector,
 
 std::string
 Opm::ECLGraph::Impl::
-flowVector(const BlackoilPhases::PhaseIndex phase) const
+flowVector(const PhaseIndex phase) const
 {
     const auto vector = std::string("FLR"); // Flow-rate, reservoir
 
-    if (phase == BlackoilPhases::PhaseIndex::Aqua) {
+    if (phase == PhaseIndex::Aqua) {
         return vector + "WAT";
     }
 
-    if (phase == BlackoilPhases::PhaseIndex::Liquid) {
+    if (phase == PhaseIndex::Liquid) {
         return vector + "OIL";
     }
 
-    if (phase == BlackoilPhases::PhaseIndex::Vapour) {
+    if (phase == PhaseIndex::Vapour) {
         return vector + "GAS";
     }
 
@@ -1841,8 +1841,8 @@ std::vector<double> Opm::ECLGraph::poreVolume() const
 
 std::vector<double>
 Opm::ECLGraph::
-flux(const BlackoilPhases::PhaseIndex phase,
-     const int                        rptstep) const
+flux(const PhaseIndex phase,
+     const int        rptstep) const
 {
     return this->pImpl_->flux(phase, rptstep);
 }

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -21,8 +21,6 @@
 #ifndef OPM_ECLGRAPH_HEADER_INCLUDED
 #define OPM_ECLGRAPH_HEADER_INCLUDED
 
-#include <opm/core/props/BlackoilPhases.hpp>
-
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -138,6 +136,9 @@ namespace Opm {
         /// strictly positive.
         std::vector<double> poreVolume() const;
 
+        /// Enum for indicating requested phase from the flux() method.
+        enum PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
+
         /// Retrive phase flux on all connections defined by \code
         /// neighbours() \endcode.
         ///
@@ -151,8 +152,8 @@ namespace Opm {
         /// occurrence is not reported due to report frequencies or no flux
         /// values are output at all).
         std::vector<double>
-        flux(const BlackoilPhases::PhaseIndex phase,
-             const int                        rptstep = 0) const;
+        flux(const PhaseIndex phase,
+             const int        rptstep = 0) const;
 
     private:
         /// Implementation class.


### PR DESCRIPTION
This makes the ECLGraph class fully independent of any OPM modules.

Rather trivial change, self-merging.