### PR TITLE
Add Support for Running Solution Acceptance Tests

### DIFF
--- a/AcceptanceTests.cmake
+++ b/AcceptanceTests.cmake
@@ -1,0 +1,26 @@
+# Set absolute tolerance to be used for testing
+Set (abs_tol 5.0e-8)
+Set (rel_tol 1.0e-13)
+
+# Input:
+#   - casename: with or without extension
+#
+Macro (add_acceptance_test casename)
+
+  String (REGEX REPLACE "\\.[^.]*" "" basename "${casename}")
+
+  Add_Test (NAME    ToF_accept_${casename}_all_steps
+            COMMAND runAcceptanceTest
+            "case=${OPM_DATA_ROOT}/flow_diagnostic_test/eclipse-simulation/${basename}"
+            "ref-dir=${OPM_DATA_ROOT}/flow_diagnostic_test/fd-ref-data/${basename}"
+            "atol=${abs_tol}" "rtol=${rel_tol}")
+
+EndMacro (add_acceptance_test)
+
+If (NOT TARGET test-suite)
+  Add_Custom_Target (test-suite)
+EndIf ()
+
+# Acceptance tests
+
+Add_Acceptance_Test (SIMPLE_2PH_W_FAULT_LGR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ endif()
 macro (dir_hook)
 endmacro (dir_hook)
 
+# Look for the opm-data repository; if found the variable
+# HAVE_OPM_DATA will be set to true.
+include (Findopm-data)
+
 # list of prerequisites for this particular project; this is in a
 # separate file (in cmake/Modules sub-directory) because it is shared
 # with the find module
@@ -91,3 +95,7 @@ endmacro (install_hook)
 
 # all setup common to the OPM library modules is done here
 include (OpmLibMain)
+
+if (HAVE_OPM_DATA)
+  include (${CMAKE_CURRENT_SOURCE_DIR}/AcceptanceTests.cmake)
+endif()

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -33,6 +33,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
         examples/computeLocalSolutions.cpp
         examples/computeToFandTracers.cpp
         examples/computeTracers.cpp
+        tests/runAcceptanceTest.cpp
         )
 
 list (APPEND PUBLIC_HEADER_FILES

--- a/tests/runAcceptanceTest.cpp
+++ b/tests/runAcceptanceTest.cpp
@@ -1,0 +1,528 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <examples/exampleSetup.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <exception>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/regex.hpp>
+
+#include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_file_kw.h>
+#include <ert/ecl/ecl_file_view.h>
+#include <ert/ecl/ecl_kw.h>
+#include <ert/ecl/ecl_kw_magic.h>
+#include <ert/util/ert_unique_ptr.hpp>
+
+namespace StringUtils {
+    namespace {
+        std::string trim(const std::string& s)
+        {
+            const auto anchor_ws =
+                boost::regex(R"~~(^\s+([^\s]+)\s+$)~~");
+
+            auto m = boost::smatch{};
+
+            if (boost::regex_match(s, m, anchor_ws)) {
+                return m[1];
+            }
+
+            return s;
+        }
+
+        std::vector<std::string> split(const std::string& s)
+        {
+            if (s.empty()) {
+                // Single element vector whose only element is the empty
+                // string.
+                return { "" };
+            }
+
+            const auto sep = boost::regex(R"~~([\s,;.|]+)~~");
+
+            using TI = boost::sregex_token_iterator;
+
+            // vector<string>(begin, end)
+            //
+            // Range is every substring (i.e., token) in input string 's'
+            // that does NOT match 'sep'.
+            return{ TI(s.begin(), s.end(), sep, -1), TI{} };
+        }
+    } // namespace Anonymous
+
+    template <typename T>
+    struct StringTo;
+
+    template <>
+    struct StringTo<int>
+    {
+        static int value(const std::string& s);
+    };
+
+    template <>
+    struct StringTo<double>
+    {
+        static double value(const std::string& s);
+    };
+
+    template <>
+    struct StringTo<std::string>
+    {
+        static std::string value(const std::string& s);
+    };
+
+    int StringTo<int>::value(const std::string& s)
+    {
+        return std::stoi(s);
+    }
+
+    double StringTo<double>::value(const std::string& s)
+    {
+        return std::stod(s);
+    }
+
+    std::string StringTo<std::string>::value(const std::string& s)
+    {
+        return trim(s);
+    }
+
+    namespace VectorValue {
+        template <typename T>
+        std::vector<T> get(const std::string& s, std::true_type)
+        {
+            return split(s);
+        }
+
+        template <typename T>
+        std::vector<T> get(const std::string& s, std::false_type)
+        {
+            const auto tokens = split(s);
+
+            auto ret = std::vector<T>{};
+            ret.reserve(tokens.size());
+            for (const auto& token : tokens) {
+                ret.push_back(StringTo<T>::value(token));
+            }
+
+            return ret;
+        }
+
+        template <typename T>
+        std::vector<T> get(const std::string& s)
+        {
+            return get<T>(s, typename std::is_same<T, std::string>::type());
+        }
+    } // namespace VectorValue
+} // namespace StringUtils
+
+namespace {
+    struct PoreVolume
+    {
+        std::vector<double> data;
+    };
+
+    class VectorDifference
+    {
+    public:
+        using Vector    = std::vector<double>;
+        using size_type = Vector::size_type;
+
+        VectorDifference(const Vector& x, const Vector& y)
+            : x_(x), y_(y)
+        {
+            if (x_.size() != y_.size()) {
+                std::ostringstream os;
+
+                os << "Incompatible Array Sizes: Expected 2x"
+                   << x_.size() << ", but got ("
+                   << x_.size() << ", " << y_.size() << ')';
+
+                throw std::domain_error(os.str());
+            }
+        }
+
+        size_type size() const
+        {
+            return x_.size();
+        }
+
+        bool empty() const
+        {
+            return this->size() == 0;
+        }
+
+        double operator[](const size_type i) const
+        {
+            return x_[i] - y_[i];
+        }
+
+    private:
+        const Vector& x_;
+        const Vector& y_;
+    };
+
+    template <class Vector1, class Vector2>
+    class VectorRatio
+    {
+    public:
+        using size_type = typename std::decay<
+            decltype(std::declval<Vector1>()[0])
+        >::type;
+
+        VectorRatio(const Vector1& x, const Vector2& y)
+            : x_(x), y_(y)
+        {
+            if (x_.size() != y.size()) {
+                std::ostringstream os;
+
+                os << "Incompatible Array Sizes: Expected 2x"
+                   << x_.size() << ", but got ("
+                   << x_.size() << ", " << y_.size() << ')';
+
+                throw std::domain_error(os.str());
+            }
+        }
+
+        size_type size() const
+        {
+            return x_.size();
+        }
+
+        bool empty() const
+        {
+            return x_.empty();
+        }
+
+        double operator[](const size_type i) const
+        {
+            return x_[i] / y_[i];
+        }
+
+    private:
+        const Vector1& x_;
+        const Vector2& y_;
+    };
+
+    struct ErrorMeasurement
+    {
+        double volume;
+        double inf;
+    };
+
+    struct ErrorTolerance
+    {
+        double absolute;
+        double relative;
+    };
+
+    struct AggregateErrors
+    {
+        std::vector<ErrorMeasurement> absolute;
+        std::vector<ErrorMeasurement> relative;
+    };
+
+    struct ReferenceToF
+    {
+        std::vector<double> forward;
+        std::vector<double> reverse;
+    };
+
+    template <class FieldVariable>
+    double volumeMetric(const PoreVolume&    pv,
+                        const FieldVariable& x)
+    {
+        if (x.size() != pv.data.size()) {
+            std::ostringstream os;
+
+            os << "Incompatible Array Sizes: Expected 2x"
+               << pv.data.size() << ", but got ("
+               << pv.data.size() << ", " << x.size() << ')';
+
+            throw std::domain_error(os.str());
+        }
+
+        auto num = 0.0;
+        auto den = 0.0;
+
+        for (decltype(pv.data.size())
+                 i = 0, n = pv.data.size(); i < n; ++i)
+        {
+            num += std::abs(x[i]) * pv.data[i];
+            den +=                  pv.data[i];
+        }
+
+        return num / den;
+    }
+
+    template <class FieldVariable>
+    double pointMetric(const FieldVariable& x)
+    {
+        static_assert(std::is_same<typename std::decay<decltype(std::abs(x[0]))>::type, double>::value,
+                      "Field Variable Value Type Must be 'double'");
+
+        if (x.empty()) {
+            return 0;
+        }
+
+        auto max = 0*x[0] - 1;
+
+        for (decltype(x.size())
+                 i = 0, n = x.size(); i < n; ++i)
+        {
+            const auto t = std::abs(x[i]);
+
+            if (t > max) {
+                max = t;
+            }
+        }
+
+        return max;
+    }
+
+    std::vector<int>
+    availableReportSteps(const example::FilePaths& paths)
+    {
+        using FilePtr = ::ERT::
+            ert_unique_ptr<ecl_file_type, ecl_file_close>;
+
+        const auto rsspec_fn = example::
+            deriveFileName(paths.grid, { ".RSSPEC", ".FRSSPEC" });
+
+        // Read-only, keep open between requests
+        const auto open_flags = 0;
+
+        auto rsspec = FilePtr{
+            ecl_file_open(rsspec_fn.generic_string().c_str(), open_flags)
+        };
+
+        auto* globView = ecl_file_get_global_view(rsspec.get());
+
+        const auto* ITIME_kw = "ITIME";
+        const auto n = ecl_file_view_get_num_named_kw(globView, ITIME_kw);
+
+        auto steps = std::vector<int>(n);
+
+        for (auto i = 0*n; i < n; ++i) {
+            const auto* itime =
+                ecl_file_view_iget_named_kw(globView, ITIME_kw, i);
+
+            const auto* itime_data =
+                static_cast<const int*>(ecl_kw_iget_ptr(itime, 0));
+
+            steps[i] = itime_data[0];
+        }
+
+        return steps;
+    }
+
+    ErrorTolerance
+    testTolerances(const ::Opm::parameter::ParameterGroup& param)
+    {
+        const auto atol = param.getDefault("atol", 1.0e-8);
+        const auto rtol = param.getDefault("rtol", 5.0e-12);
+
+        return ErrorTolerance{ atol, rtol };
+    }
+
+    ReferenceToF
+    loadReference(const ::Opm::parameter::ParameterGroup& param,
+                  const int                               step)
+    {
+        namespace fs = boost::filesystem;
+
+        using VRef = std::reference_wrapper<std::vector<double>>;
+
+        auto fname = fs::path(param.get<std::string>("ref-dir"));
+        {
+            std::ostringstream os;
+
+            os << "tof-" << std::setw(2) << std::setfill('0')
+               << step << ".txt";
+
+            fname /= os.str();
+        }
+
+        fs::ifstream input(fname);
+
+        if (! input) {
+            std::ostringstream os;
+
+            os << "Unable to Open Reference Data File "
+               << fname.filename();
+
+            throw std::domain_error(os.str());
+        }
+
+        auto tof = ReferenceToF{};
+
+        auto ref = std::array<VRef,2>{{ std::ref(tof.forward) ,
+                                        std::ref(tof.reverse) }};
+
+        {
+            auto i = static_cast<decltype(ref[0].get().size())>(0);
+            auto t = 0.0;
+
+            while (input >> t) {
+                ref[i].get().push_back(t);
+
+                i = (i + 1) % 2;
+            }
+        }
+
+        if (tof.forward.size() != tof.reverse.size()) {
+            std::ostringstream os;
+
+            os << "Unable to Read Consistent ToF Reference Data From "
+               << fname.filename();
+
+            throw std::out_of_range(os.str());
+        }
+
+        return tof;
+    }
+
+    void computeErrors(const PoreVolume&                       pv,
+                       const std::vector<double>&              ref,
+                       const ::Opm::FlowDiagnostics::Solution& fd,
+                       AggregateErrors&                        E)
+    {
+        const auto tof  = fd.timeOfFlight();
+        const auto diff = VectorDifference(tof, ref); //  tof - ref
+
+        using Vector1  = std::decay<decltype(diff)>::type;
+        using Vector2  = std::decay<decltype(ref)>::type;
+        using Ratio    = VectorRatio<Vector1, Vector2>;
+
+        const auto rat = Ratio(diff, ref); // (tof - ref) / ref
+
+        auto abs = ErrorMeasurement{};
+        {
+            abs.volume = volumeMetric(pv, diff);
+            abs.inf    = pointMetric (    diff);
+        }
+
+        auto rel = ErrorMeasurement{};
+        {
+            rel.volume = volumeMetric(pv, rat);
+            rel.inf    = pointMetric (    rat);
+        }
+
+        E.absolute.push_back(std::move(abs));
+        E.relative.push_back(std::move(rel));
+    }
+
+    std::array<AggregateErrors, 2>
+    sampleDifferences(example::Setup&&        setup,
+                      const std::vector<int>& steps)
+    {
+        const auto start =
+            std::vector<Opm::FlowDiagnostics::CellSet>{};
+
+        const auto pv = PoreVolume{ setup.graph.poreVolume() };
+
+        auto E = std::array<AggregateErrors, 2>{};
+
+        for (const auto& step : steps) {
+            if (step == 0) {
+                // Ignore initial condition
+                continue;
+            }
+
+            if (! setup.selectReportStep(step)) {
+                continue;
+            }
+
+            const auto ref = loadReference(setup.param, step);
+
+            {
+                const auto fwd = setup.toolbox
+                    .computeInjectionDiagnostics(start);
+
+                computeErrors(pv, ref.forward, fwd.fd, E[0]);
+            }
+
+            {
+                const auto rev = setup.toolbox
+                    .computeProductionDiagnostics(start);
+
+                computeErrors(pv, ref.reverse, rev.fd, E[1]);
+            }
+        }
+
+        return E;
+    }
+
+    bool errorAcceptable(const std::vector<ErrorMeasurement>& E,
+                         const double                         tol)
+    {
+        return std::accumulate(std::begin(E), std::end(E), true,
+            [tol](const bool ok, const ErrorMeasurement& e)
+            {
+                // Fine if at least one of .volume or .inf <= tol.
+                return ok && ! ((e.volume > tol) && (e.inf > tol));
+            });
+    }
+
+    bool everythingFine(const AggregateErrors& E,
+                        const ErrorTolerance&  tol)
+    {
+        return errorAcceptable(E.absolute, tol.absolute)
+            && errorAcceptable(E.relative, tol.relative);
+    }
+} // namespace Anonymous
+
+int main(int argc, char* argv[])
+try {
+    auto setup = example::Setup(argc, argv);
+
+    const auto tol   = testTolerances(setup.param);
+    const auto steps = availableReportSteps(setup.file_paths);
+
+    const auto E  = sampleDifferences(std::move(setup), steps);
+    const auto ok =
+        everythingFine(E[0], tol) && everythingFine(E[1], tol);
+
+    std::cout << (ok ? "OK" : "FAIL") << '\n';
+
+    if (! ok) {
+        return EXIT_FAILURE;
+    }
+}
+catch (const std::exception& e) {
+    std::cerr << "Caught Exception: " << e.what() << '\n';
+
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
At present we only support the case of comparing both forward and reverse time-of-flight values (assuming reference solutions stored in [`opm-data/flow_diagnostic_test`](https://github.com/OPM/opm-data/tree/master/flow_diagnostic_test)) for all available report steps (except the initial condition for which all fluxes are zero).

Depends on OPM/opm-common#223 and OPM/opm-data#154.