### PR TITLE
Add Basic Unit Awareness Support

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -23,10 +23,12 @@
 list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLGraph.cpp
         opm/utility/ECLResultData.cpp
+        opm/utility/ECLUnitHandling.cpp
         opm/utility/ECLWellSolution.cpp
         )
 
 list (APPEND TEST_SOURCE_FILES
+        tests/test_eclunithandling.cpp
         )
 
 list (APPEND EXAMPLE_SOURCE_FILES
@@ -39,5 +41,6 @@ list (APPEND EXAMPLE_SOURCE_FILES
 list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLGraph.hpp
         opm/utility/ECLResultData.hpp
+        opm/utility/ECLUnitHandling.hpp
         opm/utility/ECLWellSolution.hpp
         )

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -1,0 +1,209 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <exception>
+#include <stdexcept>
+#include <string>
+
+#include <ert/ecl/ecl_util.h>
+
+namespace Opm { namespace ECLUnits {
+    namespace Impl {
+        ert_ecl_unit_enum getUnitConvention(const int usys);
+
+        template <ert_ecl_unit_enum convention>
+        class USys;
+
+        template <>
+        class USys<ECL_METRIC_UNITS> : public ::Opm::ECLUnits::UnitSystem
+        {
+        public:
+            virtual double pressure() const override
+            {
+                return Metric::Pressure;
+            }
+
+            virtual double reservoirRate() const override
+            {
+                return Metric::ReservoirVolume / Metric::Time;
+            }
+
+            virtual double reservoirVolume() const override
+            {
+                return Metric::ReservoirVolume;
+            }
+
+            virtual double time() const override
+            {
+                return Metric::Time;
+            }
+
+            virtual double transmissibility() const override
+            {
+                return Metric::Transmissibility;
+            }
+        };
+
+        template <>
+        class USys<ECL_FIELD_UNITS> : public ::Opm::ECLUnits::UnitSystem
+        {
+        public:
+            virtual double pressure() const override
+            {
+                return Field::Pressure;
+            }
+
+            virtual double reservoirRate() const override
+            {
+                return Field::ReservoirVolume / Field::Time;
+            }
+
+            virtual double reservoirVolume() const override
+            {
+                return Field::ReservoirVolume;
+            }
+
+            virtual double time() const override
+            {
+                return Field::Time;
+            }
+
+            virtual double transmissibility() const override
+            {
+                return Field::Transmissibility;
+            }
+        };
+
+        template <>
+        class USys<ECL_LAB_UNITS> : public ::Opm::ECLUnits::UnitSystem
+        {
+        public:
+            virtual double pressure() const override
+            {
+                return Lab::Pressure;
+            }
+
+            virtual double reservoirRate() const override
+            {
+                return Lab::ReservoirVolume / Lab::Time;
+            }
+
+            virtual double reservoirVolume() const override
+            {
+                return Lab::ReservoirVolume;
+            }
+
+            virtual double time() const override
+            {
+                return Lab::Time;
+            }
+
+            virtual double transmissibility() const override
+            {
+                return Lab::Transmissibility;
+            }
+        };
+
+        template <>
+        class USys<ECL_PVT_M_UNITS> : public ::Opm::ECLUnits::UnitSystem
+        {
+        public:
+            virtual double pressure() const override
+            {
+                return unit::atm;
+            }
+
+            virtual double reservoirRate() const override
+            {
+                using namespace prefix;
+                using namespace unit;
+
+                return cubic(meter) / day;
+            }
+
+            virtual double reservoirVolume() const override
+            {
+                using namespace prefix;
+                using namespace unit;
+
+                return cubic(meter);
+            }
+
+            virtual double time() const override
+            {
+                return unit::day;
+            }
+
+            virtual double transmissibility() const override
+            {
+                using namespace prefix;
+                using namespace unit;
+
+                return centi*Poise * cubic(meter) / (day * atm);
+            }
+        };
+    } // namespace Impl
+}} // namespace Opm::ECLUnits
+
+ert_ecl_unit_enum
+Opm::ECLUnits::Impl::getUnitConvention(const int usys)
+{
+    switch (usys) {
+    case 1: return ECL_METRIC_UNITS;
+    case 2: return ECL_FIELD_UNITS;
+    case 3: return ECL_LAB_UNITS;
+    case 4: return ECL_PVT_M_UNITS;
+    }
+
+    throw std::runtime_error("Unsupported Unit Convention: "
+                             + std::to_string(usys));
+}
+
+std::unique_ptr<const ::Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::createUnitSystem(const int usys)
+{
+    using UPtr =
+        std::unique_ptr<const ::Opm::ECLUnits::UnitSystem>;
+
+    switch (Impl::getUnitConvention(usys)) {
+    case ECL_METRIC_UNITS:
+        return UPtr{ new Impl::USys<ECL_METRIC_UNITS>{} };
+
+    case ECL_FIELD_UNITS:
+        return UPtr{ new Impl::USys<ECL_FIELD_UNITS>{} };
+
+    case ECL_LAB_UNITS:
+        return UPtr{ new Impl::USys<ECL_LAB_UNITS>{} };
+
+    case ECL_PVT_M_UNITS:
+        return UPtr{ new Impl::USys<ECL_PVT_M_UNITS>{} };
+    }
+
+    throw std::runtime_error("Unsupported Unit Convention: "
+                             + std::to_string(usys));
+}

--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -1,0 +1,45 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLUNITHANDLING_HEADER_INCLUDED
+#define OPM_ECLUNITHANDLING_HEADER_INCLUDED
+
+#include <memory>
+
+namespace Opm {
+
+    namespace ECLUnits {
+
+        struct UnitSystem
+        {
+            virtual double pressure()         const = 0;
+            virtual double reservoirRate()    const = 0;
+            virtual double reservoirVolume()  const = 0;
+            virtual double time()             const = 0;
+            virtual double transmissibility() const = 0;
+        };
+
+        std::unique_ptr<const UnitSystem>
+        createUnitSystem(const int usys);
+
+    } // namespace ECLUnits
+} // namespace Opm
+
+#endif // OPM_ECLUNITHANDLING_HEADER_INCLUDED

--- a/tests/test_eclunithandling.cpp
+++ b/tests/test_eclunithandling.cpp
@@ -1,0 +1,235 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ASSEMBLED_CONNECTIONS
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <exception>
+#include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE (Basic_Conversion)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    auto M = ::Opm::ECLUnits::createUnitSystem(1); // METRIC
+    auto F = ::Opm::ECLUnits::createUnitSystem(2); // FIELD
+    auto L = ::Opm::ECLUnits::createUnitSystem(3); // LAB
+    auto P = ::Opm::ECLUnits::createUnitSystem(4); // PVT-M
+
+    BOOST_CHECK_THROW(::Opm::ECLUnits::createUnitSystem( 5), std::runtime_error);
+    BOOST_CHECK_THROW(::Opm::ECLUnits::createUnitSystem(-1), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    auto M = ::Opm::ECLUnits::createUnitSystem(1);
+
+    // Pressure (bars)
+    {
+        const auto scale  = M->pressure();
+        const auto expect = 100.0e3;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume Rate (rm^3 / day)
+    {
+        const auto scale  = M->reservoirRate();
+        const auto expect = 1.157407407407407e-05;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume (rm^3)
+    {
+        const auto scale  = M->reservoirVolume();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Time (day)
+    {
+        const auto scale  = M->time();
+        const auto expect = 86.400e+03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Transmissibility ((cP * m^3) / (day * barsa))
+    {
+        const auto scale  = M->transmissibility();
+        const auto expect = 1.157407407407407e-13;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    auto F = ::Opm::ECLUnits::createUnitSystem(2);
+
+    // Pressure (psi)
+    {
+        const auto scale  = F->pressure();
+        const auto expect = 6.894757293168360e+03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume Rate (rb / day)
+    {
+        const auto scale  = F->reservoirRate();
+        const auto expect = 1.840130728333334e-06;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume (rb)
+    {
+        const auto scale  = F->reservoirVolume();
+        const auto expect = 1.589872949280001e-01;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Time (day)
+    {
+        const auto scale  = F->time();
+        const auto expect = 86.400e+03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Transmissibility ((cP * rb) / (day * psia))
+    {
+        const auto scale  = F->transmissibility();
+        const auto expect = 2.668883979653090e-13;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    auto L = ::Opm::ECLUnits::createUnitSystem(3);
+
+    // Pressure (atm)
+    {
+        const auto scale  = L->pressure();
+        const auto expect = 101.325e+03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume Rate (r(cm)^3 / h)
+    {
+        const auto scale  = L->reservoirRate();
+        const auto expect = 2.777777777777778e-10;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume (r(cm)^3)
+    {
+        const auto scale  = L->reservoirVolume();
+        const auto expect = 1.0e-06;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Time (hour)
+    {
+        const auto scale  = L->time();
+        const auto expect = 3600.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Transmissibility ((cP * (cm)^3) / (h * atm))
+    {
+        const auto scale  = L->transmissibility();
+        const auto expect = 2.741453518655592e-18;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    auto P = ::Opm::ECLUnits::createUnitSystem(4);
+
+    // Pressure (atm)
+    {
+        const auto scale  = P->pressure();
+        const auto expect = 101.325e+03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume Rate (rm^3 / day)
+    {
+        const auto scale  = P->reservoirRate();
+        const auto expect = 1.157407407407407e-05;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Reservoir Volume (rm^3)
+    {
+        const auto scale  = P->reservoirVolume();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Time (day)
+    {
+        const auto scale  = P->time();
+        const auto expect = 86.400e+03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Transmissibility ((cP * rm^3 / (day * atm))
+    {
+        const auto scale  = P->transmissibility();
+        const auto expect = 1.142272299439830e-13;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
Intended use case is
```C++
const auto ihead = src.keywordData<int>("INTEHEAD", gID);
auto       usys  = ECLUnits::
    createUnitSystem(ihead[INTEHEAD_UNIT_INDEX]);

const auto TScale = usys->transmissibility();

for (auto& Ti : trans) {
    Ti = unit::convert::from(Ti, TScale);
}
```

---

This is not yet complete, and is intended to initiate an interface discussion.  Please do not merge before the existing facilities (e.g., [`ECLGraph`](https://github.com/OPM/opm-flowdiagnostics-applications/blob/master/opm/utility/ECLGraph.hpp#L44)) have been made aware of unit handling conventions.