### PR TITLE
Make ECLGraph Aware of Unit Conventions and Expose Transmissibility Fields

### DIFF
--- a/AcceptanceTests.cmake
+++ b/AcceptanceTests.cmake
@@ -7,7 +7,7 @@ Set (rel_tol 1.0e-13)
 #
 Macro (add_acceptance_test casename)
 
-  String (REGEX REPLACE "\\.[^.]*" "" basename "${casename}")
+  String (REGEX REPLACE "\\.[^.]*$" "" basename "${casename}")
 
   Add_Test (NAME    ToF_accept_${casename}_all_steps
             COMMAND runAcceptanceTest
@@ -17,6 +17,17 @@ Macro (add_acceptance_test casename)
 
 EndMacro (add_acceptance_test)
 
+Macro (add_trans_acceptance_test casename)
+
+  String (REGEX REPLACE "\\.[^.]*$" "" basename "${casename}")
+
+  Add_Test (NAME    Trans_accept_${casename}
+            COMMAND runTransTest
+            "case=${OPM_DATA_ROOT}/flow_diagnostic_test/eclipse-simulation/${basename}"
+            "ref-dir=${OPM_DATA_ROOT}/flow_diagnostic_test/fd-ref-data/${basename}"
+            "atol=${abs_tol}" "rtol=${rel_tol}")
+EndMacro (add_trans_acceptance_test)
+
 If (NOT TARGET test-suite)
   Add_Custom_Target (test-suite)
 EndIf ()
@@ -24,3 +35,4 @@ EndIf ()
 # Acceptance tests
 
 Add_Acceptance_Test (SIMPLE_2PH_W_FAULT_LGR)
+Add_Trans_Acceptance_Test (SIMPLE_2PH_W_FAULT_LGR)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -36,6 +36,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
         examples/computeToFandTracers.cpp
         examples/computeTracers.cpp
         tests/runAcceptanceTest.cpp
+        tests/runTransTest.cpp
         )
 
 list (APPEND PUBLIC_HEADER_FILES

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -138,26 +138,6 @@ namespace example {
         return inflow;
     }
 
-    namespace Hack {
-        inline Opm::FlowDiagnostics::ConnectionValues
-        convert_flux_to_SI(Opm::FlowDiagnostics::ConnectionValues&& fl)
-        {
-            using Co = Opm::FlowDiagnostics::ConnectionValues::ConnID;
-            using Ph = Opm::FlowDiagnostics::ConnectionValues::PhaseID;
-
-            const auto nconn = fl.numConnections();
-            const auto nphas = fl.numPhases();
-
-            for (auto phas = Ph{0}; phas.id < nphas; ++phas.id) {
-                for (auto conn = Co{0}; conn.id < nconn; ++conn.id) {
-                    fl(conn, phas) /= 86400;
-                }
-            }
-
-            return fl;
-        }
-    } // namespace Hack
-
 
 
 
@@ -251,7 +231,7 @@ namespace example {
             if (graph.selectReportStep(step)) {
                 auto wsol = Opm::ECLWellSolution{};
                 well_fluxes = wsol.solution(graph.rawResultData(), graph.numGrids());;
-                toolbox.assignConnectionFlux(Hack::convert_flux_to_SI(extractFluxField(graph)));
+                toolbox.assignConnectionFlux(extractFluxField(graph));
                 toolbox.assignInflowFlux(extractWellFlows(graph, well_fluxes));
                 return true;
             } else {

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -24,6 +24,9 @@
 
 #include <opm/utility/ECLGraph.hpp>
 #include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <algorithm>
 #include <array>
@@ -41,6 +44,7 @@
 #include <boost/filesystem.hpp>
 
 #include <ert/ecl/ecl_grid.h>
+#include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl/ecl_nnc_export.h>
 #include <ert/util/ert_unique_ptr.hpp>
 
@@ -93,6 +97,10 @@ namespace {
         std::array<std::size_t,3>
         cartesianDimensions(const ecl_grid_type* G);
 
+        auto getUnitSystem(const ::Opm::ECLResultData& rset,
+                           const int                   grid_ID)
+            -> decltype(::Opm::ECLUnits::createUnitSystem(0));
+
         /// Retrieve global pore-volume vector from INIT source.
         ///
         /// Specialised tool needed to determine the active cells.
@@ -101,7 +109,11 @@ namespace {
         ///
         /// \param[in] init ERT representation of INIT source.
         ///
-        /// \return Vector of pore-volumes for all global cells of \p G.
+        /// \param[in] grid_ID Numerical ID of grid.  Non-negative.  Zero
+        ///    for the main grid and positive in the case of an LGR.
+        ///
+        /// \return Vector of pore-volumes for all global cells of \p G in
+        ///    SI unit conventions (rm^3).
         std::vector<double>
         getPVolVector(const ecl_grid_type*        G,
                       const ::Opm::ECLResultData& init,
@@ -154,7 +166,7 @@ namespace {
             ///
             /// Corresponds to the \c PORV vector in the INIT file, possibly
             /// restricted to those active cells for which the pore-volume is
-            /// strictly positive.
+            /// strictly positive.  SI unit conventions (rm^3).
             const std::vector<double>& activePoreVolume() const;
 
             /// Retrieve ID of active cell from global ID.
@@ -200,7 +212,8 @@ namespace {
             ///     all of the grid's Cartesian connections.
             std::vector<double>
             connectionData(const ::Opm::ECLResultData& src,
-                           const std::string&          vector) const;
+                           const std::string&          vector,
+                           const double                unit) const;
 
         private:
             /// Facility for deriving Cartesian neighbourship in a grid
@@ -217,14 +230,18 @@ namespace {
                 /// \param[in] G ERT Grid representation.
                 ///
                 /// \param[in] pvol Vector of pore-volumes on all global
-                ///                 cells of \p G.  Typically obtained
-                ///                 through function getPVolVector().
+                ///    cells of \p G.  Typically obtained through function
+                ///    getPVolVector().  Numerical values assumed to be in
+                ///    SI units (rm^3).
                 CartesianCells(const ecl_grid_type*       G,
                                const std::vector<double>& pvol);
 
                 /// Retrive global cell indices of all active cells in grid.
                 std::vector<std::size_t> activeGlobal() const;
 
+                /// Retrieve pore-volume values for all active cells in grid.
+                ///
+                /// SI unit conventions (rm^3).
                 const std::vector<double>& activePoreVolume() const;
 
                 /// Map input vector to all global cells.
@@ -415,6 +432,7 @@ namespace {
             void connectionData(const ::Opm::ECLResultData&     src,
                                 const CartesianCells::Direction d,
                                 const std::string&              vector,
+                                const double                    unit,
                                 std::vector<double>&            x) const;
 
             /// Form complete name of directional result set vector from
@@ -487,6 +505,13 @@ ECL::getPVolVector(const ecl_grid_type*        G,
 
         assert ((pvol.size() == nglob) &&
                 "Pore-volume must be provided for all global cells");
+
+        const auto pvol_unit =
+            getUnitSystem(init, gridID)->reservoirVolume();
+
+        for (auto& pv : pvol) {
+            pv = ::Opm::unit::convert::from(pv, pvol_unit);
+        }
     }
 
     return pvol;
@@ -522,6 +547,18 @@ ECL::cartesianDimensions(const ecl_grid_type* G)
     return { { make_szt(ecl_grid_get_nx(G)) ,
                make_szt(ecl_grid_get_ny(G)) ,
                make_szt(ecl_grid_get_nz(G)) } };
+}
+
+auto ECL::getUnitSystem(const ::Opm::ECLResultData& rset,
+                        const int                   grid_ID)
+    -> decltype(::Opm::ECLUnits::createUnitSystem(0))
+{
+    assert (rset.haveKeywordData(INTEHEAD_KW, grid_ID)
+            && "Result Set Does Not Provide Grid Header");
+
+    const auto ih = rset.keywordData<int>(INTEHEAD_KW, grid_ID);
+
+    return ::Opm::ECLUnits::createUnitSystem(ih[INTEHEAD_UNIT_INDEX]);
 }
 
 std::vector<ecl_nnc_type>
@@ -871,7 +908,8 @@ haveConnData(const ::Opm::ECLResultData& src,
 std::vector<double>
 ECL::CartesianGridData::
 connectionData(const ::Opm::ECLResultData& src,
-               const std::string&          vector) const
+               const std::string&          vector,
+               const double                unit) const
 {
     if (! this->haveConnData(src, vector)) {
         return {};
@@ -883,7 +921,7 @@ connectionData(const ::Opm::ECLResultData& src,
                            CartesianCells::Direction::J ,
                            CartesianCells::Direction::K })
     {
-        this->connectionData(src, d, vector, x);
+        this->connectionData(src, d, this->vectorName(vector, d), unit, x);
     }
 
     return x;
@@ -894,10 +932,10 @@ ECL::CartesianGridData::
 connectionData(const ::Opm::ECLResultData&     src,
                const CartesianCells::Direction d,
                const std::string&              vector,
+               const double                    unit,
                std::vector<double>&            x) const
 {
-    const auto vname = this->vectorName(vector, d);
-    const auto v = this->cellData(src, vname);
+    const auto v = this->cellData(src, vector);
 
     const auto& cells = this->outCell_.find(d);
 
@@ -905,7 +943,7 @@ connectionData(const ::Opm::ECLResultData&     src,
             "Direction must be I, J, or K");
 
     for (const auto& cell : cells->second) {
-        x.push_back(v[cell]);
+        x.push_back(::Opm::unit::convert::from(v[cell], unit));
     }
 }
 
@@ -1049,9 +1087,24 @@ public:
     /// strictly positive.
     std::vector<double> activePoreVolume() const;
 
-    const ::Opm::ECLResultData& rawResultData() const;
 
+    /// Restrict dynamic result set data to single report step.
+    ///
+    /// This method must be called before calling either flux() or
+    /// rawResultData().
+    ///
+    /// \param[in] rptstep Selected temporal vector.  Report-step ID.
+    ///
+    /// \return Whether or not dynamic data for the requested report step
+    ///    exists in the underlying result set identified in method
+    ///    assignDataSource().
     bool selectReportStep(const int rptstep) const;
+
+    /// Access underlying result set.
+    ///
+    /// The result set dynamic data corresponds to the most recent call to
+    /// method selectReportStep().
+    const ::Opm::ECLResultData& rawResultData() const;
 
     /// Retrive phase flux on all connections defined by \code neighbours()
     /// \endcode.
@@ -1221,7 +1274,9 @@ private:
         ///
         /// Simplifies implementation of ctor.
         ///
-        /// \param[in] cat Class
+        /// \param[in] cat Requested category of flux relation.
+        ///
+        /// \return Flux relation of type \p cat.
         FluxRelation makeRelation(const Category cat) const;
 
         /// Identify connection category from connection's grids.
@@ -1312,15 +1367,29 @@ private:
     /// Extract flux values corresponding to particular result set vector
     /// for all identified non-neighbouring connections.
     ///
+    /// \tparam[in] GetFluxUnit Type of function object for computing the
+    ///    grid-dependent flux unit.
+    ///
     /// \param[in] vector Result set vector prefix.  Typically computed by
     ///    method flowVector().
+    ///
+    /// \param[in] fluxUnit Function object for computing grid-dependent
+    ///    flux units.  Must support the syntax
+    ///    \code
+    ///      unit = fluxUnit(gridID)
+    ///    \endcode
+    ///    with 'gridID' being a non-negative \c int that identifies a
+    ///    particular model grid (zero for the main grid and positive for
+    ///    LGRs) and 'unit' a positive floating-point value.
     ///
     /// \param[in,out] flux Numerical values of result set vector.  On
     ///    input, contains all values corresponding to all fully Cartesian
     ///    connections across all active grids.  On output additionally
     ///    contains those values that correspond to the non-neighbouring
     ///    connections (appended onto \p flux).
+    template <class GetFluxUnit>
     void fluxNNC(const std::string&   vector,
+                 GetFluxUnit&&        fluxUnit,
                  std::vector<double>& flux) const;
 };
 
@@ -1640,6 +1709,11 @@ std::vector<double>
 Opm::ECLGraph::Impl::
 flux(const PhaseIndex phase) const
 {
+    auto fluxUnit = [this](const int gridID)
+    {
+        return ::ECL::getUnitSystem(*this->src_, gridID)->reservoirRate();
+    };
+
     const auto vector = this->flowVector(phase);
 
     auto v = std::vector<double>{};
@@ -1649,8 +1723,10 @@ flux(const PhaseIndex phase) const
 
     v.reserve(totconn);
 
+    auto gridID = 0;
     for (const auto& G : this->grid_) {
-        const auto& q = G.connectionData(*this->src_, vector);
+        const auto& q =
+            G.connectionData(*this->src_, vector, fluxUnit(gridID++));
 
         if (q.empty()) {
             // Flux vector invalid unless all grids provide this result
@@ -1665,7 +1741,7 @@ flux(const PhaseIndex phase) const
         // Model includes non-neighbouring connections such as faults and/or
         // local grid refinement.  Extract pertinent flux values for these
         // connections.
-        this->fluxNNC(vector, v);
+        this->fluxNNC(vector, std::move(fluxUnit), v);
     }
 
     if (v.size() < totconn) {
@@ -1681,13 +1757,21 @@ void
 Opm::ECLGraph::Impl::defineNNCs(const ecl_grid_type*        G,
                                 const ::Opm::ECLResultData& init)
 {
+    // Assume all transmissibilites in the result set follow the same unit
+    // conventions.
+
+    const auto trans_unit =
+        ECL::getUnitSystem(init, 0)->transmissibility();
+
     for (const auto& nnc : ECL::loadNNC(G, init)) {
-        this->nnc_.add(this->grid_, this->activeOffset_, nnc);
+        this->nnc_.add(this->grid_, this->activeOffset_, trans_unit, nnc);
     }
 }
 
+template <class GetFluxUnit>
 void
 Opm::ECLGraph::Impl::fluxNNC(const std::string&   vector,
+                             GetFluxUnit&&        fluxUnit,
                              std::vector<double>& flux) const
 {
     auto v = std::vector<double>(this->nnc_.numConnections(), 0.0);
@@ -1719,13 +1803,17 @@ Opm::ECLGraph::Impl::fluxNNC(const std::string&   vector,
                 continue;
             }
 
+            // Note: Compensate for incrementing 'gridID' above.
+            const auto flux_unit = fluxUnit(gridID - 1);
+
             // Data fully available for (category,gridID).  Assign
             // approriate subset of NNC flux vector.
             for (const auto& ix : iset) {
                 assert (ix.neighIdx < v.size());
                 assert (ix.kwIdx    < q.size());
 
-                v[ix.neighIdx] = q[ix.kwIdx];
+                v[ix.neighIdx] =
+                    unit::convert::from(q[ix.kwIdx], flux_unit);
 
                 assigned[ix.neighIdx] = true;
             }

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -138,6 +138,15 @@ namespace Opm {
         /// strictly positive.  Numerical values in SI units (rm^3).
         std::vector<double> poreVolume() const;
 
+        /// Retrieve static (background) transmissibility values on all
+        /// connections defined by \code neighbours() \endcode.
+        ///
+        /// Specifically, \code transmissibility()[i] \endcode is the
+        /// transmissibility of the connection between cells \code
+        /// neighbours()[2*i + 0] \endcode and \code neighbours()[2*i + 1]
+        /// \endcode.
+        std::vector<double> transmissibility() const;
+
         /// Restrict dynamic result set data to single report step.
         ///
         /// This method must be called before calling either flux() or

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -135,7 +135,7 @@ namespace Opm {
         ///
         /// Corresponds to the \c PORV vector in the INIT file, possibly
         /// restricted to those active cells for which the pore-volume is
-        /// strictly positive.
+        /// strictly positive.  Numerical values in SI units (rm^3).
         std::vector<double> poreVolume() const;
 
         /// Restrict dynamic result set data to single report step.
@@ -167,7 +167,8 @@ namespace Opm {
         /// \return Flux values corresponding to selected phase.  Empty if
         ///    unavailable in the result set (e.g., when querying the gas
         ///    flux in an oil/water system or if no flux values at all were
-        ///    output to the restart file).
+        ///    output to the restart file).  Numerical values in SI units
+        ///    (rm^3/s).
         std::vector<double>
         flux(const PhaseIndex phase) const;
 

--- a/opm/utility/ECLWellSolution.cpp
+++ b/opm/utility/ECLWellSolution.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/utility/ECLWellSolution.hpp>
 #include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl_well/well_const.h>
@@ -108,15 +109,7 @@ namespace Opm
         // Reservoir rate units from code used in INTEHEAD.
         double resRateUnit(const int unit_code)
         {
-            using prefix::centi;
-            using namespace unit;
-
-            switch (unit_code) {
-            case INTEHEAD::Metric: return cubic(meter)/day;        // m^3/day
-            case INTEHEAD::Field:  return stb/day;                 // stb/day
-            case INTEHEAD::Lab:    return cubic(centi*meter)/hour; // (cm)^3/h
-            default: throw std::runtime_error("Unknown unit code from INTEHEAD: " + std::to_string(unit_code));
-            }
+            return ECLUnits::createUnitSystem(unit_code)->reservoirRate();
         }
 
 

--- a/tests/runTransTest.cpp
+++ b/tests/runTransTest.cpp
@@ -1,0 +1,229 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLGraph.hpp>
+
+#include <examples/exampleSetup.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <exception>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+namespace {
+    class VectorDifference
+    {
+    public:
+        using Vector    = std::vector<double>;
+        using size_type = Vector::size_type;
+
+        VectorDifference(const Vector& x, const Vector& y)
+            : x_(x), y_(y)
+        {
+            if (x_.size() != y_.size()) {
+                std::ostringstream os;
+
+                os << "Incompatible Array Sizes: Expected 2x"
+                   << x_.size() << ", but got ("
+                   << x_.size() << ", " << y_.size() << ')';
+
+                throw std::domain_error(os.str());
+            }
+        }
+
+        size_type size() const
+        {
+            return x_.size();
+        }
+
+        bool empty() const
+        {
+            return this->size() == 0;
+        }
+
+        double operator[](const size_type i) const
+        {
+            return x_[i] - y_[i];
+        }
+
+    private:
+        const Vector& x_;
+        const Vector& y_;
+    };
+
+    template <class Vector1, class Vector2>
+    class VectorRatio
+    {
+    public:
+        using size_type = typename std::decay<
+            decltype(std::declval<Vector1>()[0])
+        >::type;
+
+        VectorRatio(const Vector1& x, const Vector2& y)
+            : x_(x), y_(y)
+        {
+            if (x_.size() != y.size()) {
+                std::ostringstream os;
+
+                os << "Incompatible Array Sizes: Expected 2x"
+                   << x_.size() << ", but got ("
+                   << x_.size() << ", " << y_.size() << ')';
+
+                throw std::domain_error(os.str());
+            }
+        }
+
+        size_type size() const
+        {
+            return x_.size();
+        }
+
+        bool empty() const
+        {
+            return x_.empty();
+        }
+
+        double operator[](const size_type i) const
+        {
+            return x_[i] / y_[i];
+        }
+
+    private:
+        const Vector1& x_;
+        const Vector2& y_;
+    };
+
+    struct ErrorTolerance
+    {
+        double absolute;
+        double relative;
+    };
+
+    template <class FieldVariable>
+    double pointMetric(const FieldVariable& x)
+    {
+        static_assert(std::is_same<typename std::decay<decltype(std::abs(x[0]))>::type, double>::value,
+                      "Field Variable Value Type Must be 'double'");
+
+        if (x.empty()) {
+            return 0;
+        }
+
+        auto max = 0*x[0] - 1;
+
+        for (decltype(x.size())
+                 i = 0, n = x.size(); i < n; ++i)
+        {
+            const auto t = std::abs(x[i]);
+
+            if (t > max) {
+                max = t;
+            }
+        }
+
+        return max;
+    }
+
+    ErrorTolerance
+    testTolerances(const ::Opm::parameter::ParameterGroup& param)
+    {
+        const auto atol = param.getDefault("atol", 1.0e-8);
+        const auto rtol = param.getDefault("rtol", 5.0e-12);
+
+        return ErrorTolerance{ atol, rtol };
+    }
+
+    std::vector<double>
+    loadReference(const ::Opm::parameter::ParameterGroup& param)
+    {
+        namespace fs = boost::filesystem;
+
+        const auto fname =
+            fs::path(param.get<std::string>("ref-dir")) / "trans.txt";
+
+        fs::ifstream input(fname);
+
+        if (! input) {
+            std::ostringstream os;
+
+            os << "Unable to Open Reference Trans-Data File "
+               << fname.filename();
+
+            throw std::domain_error(os.str());
+        }
+
+        return {
+            std::istream_iterator<double>(input),
+            std::istream_iterator<double>()
+        };
+    }
+
+    bool transfieldAcceptable(const ::Opm::parameter::ParameterGroup& param,
+                              const std::vector<double>&              trans)
+    {
+        const auto Tref = loadReference(param);
+
+        if (Tref.size() != trans.size()) {
+            return false;
+        }
+
+        const auto diff = VectorDifference{ trans, Tref };
+
+        using Vector1 = std::decay<decltype(diff)>::type;
+        using Vector2 = std::decay<decltype(Tref)>::type;
+        using Ratio   = VectorRatio<Vector1, Vector2>;
+
+        const auto rat = Ratio(diff, Tref);
+        const auto tol = testTolerances(param);
+
+        return ! ((pointMetric(diff) > tol.absolute) ||
+                  (pointMetric(rat)  > tol.relative));
+    }
+} // namespace Anonymous
+
+int main(int argc, char* argv[])
+try {
+    const auto prm = example::initParam(argc, argv);
+    const auto pth = example::FilePaths(prm);
+    const auto G   = example::initGraph(pth);
+    const auto T   = G.transmissibility();
+    const auto ok  = transfieldAcceptable(prm, T);
+
+    std::cout << (ok ? "OK" : "FAIL") << '\n';
+
+    if (! ok) {
+        return EXIT_FAILURE;
+    }
+}
+catch (const std::exception& e) {
+    std::cerr << "Caught Exception: " << e.what() << '\n';
+
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
This change-set makes two changes to the handling of result sets.  In particular, we make the flux and pore-volume vectors in `ECLGraph` aware of the various unit handling conventions in an ECL result set and therefore return such data in strict SI conventions (rm^3 for the pore-volumes and rm^3/s for the reservoir fluxes).

Secondly, we also allow clients of the `ECLGraph` interface to access the underlying transmissibility field, linearised over all connections defined by `ECLGraph::neighbours()`.  This is in preparation of adding support for on-demand calculation of reservoir fluxes if such data is not stored in the result set.

Note: The new transmissibility regression test in commit 73ed423 depends on PR OPM/opm-data#160.