### PR TITLE
[WIP] Add Skeleton Implementation of Linearised Cell Data Access

### DIFF
--- a/AcceptanceTests.cmake
+++ b/AcceptanceTests.cmake
@@ -28,6 +28,17 @@ Macro (add_trans_acceptance_test casename)
             "atol=${abs_tol}" "rtol=${rel_tol}")
 EndMacro (add_trans_acceptance_test)
 
+Macro (add_celldata_acceptance_test casename)
+
+  String (REGEX REPLACE "\\.[^.]*$" "" basename "${casename}")
+
+  Add_Test (NAME    CellData_accept_${casename}
+            COMMAND runLinearisedCellDataTest
+            "case=${OPM_DATA_ROOT}/flow_diagnostic_test/eclipse-simulation/${basename}"
+            "ref-dir=${OPM_DATA_ROOT}/flow_diagnostic_test/fd-ref-data/${basename}"
+            "atol=${abs_tol}" "rtol=${rel_tol}")
+EndMacro (add_celldata_acceptance_test)
+
 If (NOT TARGET test-suite)
   Add_Custom_Target (test-suite)
 EndIf ()
@@ -36,3 +47,4 @@ EndIf ()
 
 Add_Acceptance_Test (SIMPLE_2PH_W_FAULT_LGR)
 Add_Trans_Acceptance_Test (SIMPLE_2PH_W_FAULT_LGR)
+Add_CellData_Acceptance_Test (SIMPLE_2PH_W_FAULT_LGR)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -36,6 +36,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
         examples/computeToFandTracers.cpp
         examples/computeTracers.cpp
         tests/runAcceptanceTest.cpp
+        tests/runLinearisedCellDataTest.cpp
         tests/runTransTest.cpp
         )
 

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -217,6 +217,11 @@ namespace {
             cellData(const ::Opm::ECLResultData& src,
                      const std::string&          vector) const;
 
+            template <typename T>
+            std::vector<T>
+            activeCellData(const ::Opm::ECLResultData& src,
+                           const std::string&          vector) const;
+
             /// Retrieve values of result set vector for all Cartesian
             /// connections in grid.
             ///
@@ -273,6 +278,19 @@ namespace {
                 template <typename T>
                 std::vector<T>
                 scatterToGlobal(const std::vector<T>& x) const;
+
+                /// Map input vector to active grid cells.
+                ///
+                /// \param[in] x Input vector, defined on the explicitly
+                ///              active cells, all global cells or some
+                ///              other subset (e.g., all non-neighbouring
+                ///              connections).
+                ///
+                /// \return Input vector mapped to active cells or unchanged
+                /// if input is defined on some other subset.
+                template <typename T>
+                std::vector<T>
+                gatherToActive(const std::vector<T>& x) const;
 
                 /// Retrieve total number of cells in grid, including
                 /// inactive ones.
@@ -349,13 +367,8 @@ namespace {
                 /// Whether or not a particular active cell is subdivided.
                 std::vector<bool> is_divided_;
 
-                /// Identify those grid cells that are further subdivided by
-                /// an LGR.
-                ///
-                /// Writes to \c is_divided_.
-                ///
-                /// \param
-                void identifySubdividedCells(const ecl_grid_type* G);
+                /// Retrieve number of active cells in grid.
+                std::size_t numActiveCells() const;
 
                 /// Compute linear index of global cell from explicit
                 /// (I,J,K) tuple.
@@ -672,7 +685,7 @@ std::vector<std::size_t>
 ECL::CartesianGridData::CartesianCells::activeGlobal() const
 {
     auto active = std::vector<std::size_t>{};
-    active.reserve(this->rsMap_.subset.size());
+    active.reserve(this->numActiveCells());
 
     for (const auto& id : this->rsMap_.subset) {
         active.push_back(id.glob);
@@ -714,6 +727,48 @@ CartesianCells::scatterToGlobal(const std::vector<T>& x) const
 
     return y;
 }
+
+namespace { namespace ECL {
+    template <typename T>
+    std::vector<T>
+    CartesianGridData::CartesianCells::
+    gatherToActive(const std::vector<T>& x) const
+    {
+        const auto num_explicit_active =
+            static_cast<decltype(x.size())>(this->rsMap_.num_active);
+
+        if (x.size() == num_explicit_active) {
+            // Input defined on explictly active cells (ACTNUM != 0).
+            // Extract subset of these.
+
+            auto ax = std::vector<T>{};
+            ax.reserve(this->numActiveCells());
+
+            for (const auto& i : this->rsMap_.subset) {
+                ax.push_back(x[i.act]);
+            }
+
+            return ax;
+        }
+
+        if (x.size() == this->numGlobalCells()) {
+            // Input defined on all global cells.  Extract active subset.
+
+            auto ax = std::vector<T>{};
+            ax.reserve(this->numActiveCells());
+
+            for (const auto& i : this->rsMap_.subset) {
+                ax.push_back(x[i.glob]);
+            }
+
+            return ax;
+        }
+
+        // Input defined on neither explicitly active nor global cells.
+        // Possibly on all grid's NNCs.  Let caller deal with this.
+        return x;
+    }
+}} // namespace Anonymous::ECL
 
 std::size_t
 ECL::CartesianGridData::CartesianCells::numGlobalCells() const
@@ -777,6 +832,12 @@ ECL::CartesianGridData::CartesianCells::isSubdivided(const int cellID) const
     return this->is_divided_[ix];
 }
 
+std::size_t
+ECL::CartesianGridData::CartesianCells::numActiveCells() const
+{
+    return this->rsMap_.subset.size();
+}
+    
 std::size_t
 ECL::CartesianGridData::
 CartesianCells::globIdx(const IndexTuple& ijk) const
@@ -904,6 +965,22 @@ cellData(const ::Opm::ECLResultData& src,
 
     return this->cells_.scatterToGlobal(x);
 }
+
+namespace { namespace ECL {
+    template <typename T>
+    std::vector<T>
+    CartesianGridData::activeCellData(const ::Opm::ECLResultData& src,
+                                      const std::string&          vector) const
+    {
+        if (! this->haveCellData(src, vector)) {
+            return {};
+        }
+
+        auto x = src.keywordData<T>(vector, this->gridID_);
+
+        return this->cells_.gatherToActive(std::move(x));
+    }
+}} // namespace Anonymous::ECL
 
 bool
 ECL::CartesianGridData::
@@ -1166,6 +1243,14 @@ public:
     /// all).
     std::vector<double>
     flux(const PhaseIndex phase) const;
+
+    template <typename T>
+    std::vector<T>
+    rawLinearisedCellData(const std::string& vector) const;
+
+    std::vector<double>
+    linearisedCellData(const std::string& vector,
+                       UnitConvention     unit) const;
 
 private:
     /// Collection of non-Cartesian neighbourship relations attributed to a
@@ -1855,6 +1940,67 @@ flux(const PhaseIndex phase) const
     return v;
 }
 
+namespace Opm {
+
+    template <typename T>
+    std::vector<T>
+    ECLGraph::Impl::rawLinearisedCellData(const std::string& vector) const
+    {
+        auto x = std::vector<T>{};  x.reserve(this->numCells());
+
+        for (const auto& G : this->grid_) {
+            const auto xi = G.activeCellData<T>(*this->src_, vector);
+
+            x.insert(x.end(), std::begin(xi), std::end(xi));
+        }
+
+        if (x.size() != this->numCells()) {
+            return {};
+        }
+
+        return x;
+    }
+} // namespace Opm
+
+std::vector<double>
+Opm::ECLGraph::Impl::linearisedCellData(const std::string& vector,
+                                        UnitConvention     unit) const
+{
+    auto x = std::vector<double>{};  x.reserve(this->numCells());
+
+    auto gridID = 0;
+
+    for (const auto& G : this->grid_) {
+        const auto xi = G.activeCellData<double>(*this->src_, vector);
+
+        // Increment Grid ID irrespective of early return.
+        gridID += 1;
+
+        if (xi.empty()) { continue; }
+
+        // Note: Compensate for incrementing Grid ID above.
+        const auto usys =
+            ECL::getUnitSystem(*this->src_, gridID - 1);
+
+        // Note: 'usys' (generally, std::unique_ptr<>) does not support
+        // regular PMF syntax (i.e., operator->*()).
+        const auto vector_unit = ((*usys).*unit)();
+
+        std::transform(std::begin(xi), std::end(xi),
+                       std::back_inserter(x),
+            [vector_unit](const double value)
+            {
+                return ::Opm::unit::convert::from(value, vector_unit);
+            });
+    }
+
+    if (x.size() != this->numCells()) {
+        return {};
+    }
+
+    return x;
+}
+
 void
 Opm::ECLGraph::Impl::defineNNCs(const ecl_grid_type*        G,
                                 const ::Opm::ECLResultData& init)
@@ -2055,4 +2201,29 @@ Opm::ECLGraph::
 flux(const PhaseIndex phase) const
 {
     return this->pImpl_->flux(phase);
+}
+
+namespace Opm {
+
+    template <typename T>
+    std::vector<T>
+    ECLGraph::rawLinearisedCellData(const std::string& vector) const
+    {
+        return this->pImpl_->rawLinearisedCellData<T>(vector);
+    }
+
+    // Explicit instantiations for the element types we care about.
+    template std::vector<int>
+    ECLGraph::rawLinearisedCellData<int>(const std::string& vector) const;
+
+    template std::vector<double>
+    ECLGraph::rawLinearisedCellData<double>(const std::string& vector) const;
+
+} // namespace Opm
+
+std::vector<double>
+Opm::ECLGraph::linearisedCellData(const std::string& vector,
+                                  UnitConvention     unit) const
+{
+    return this->pImpl_->linearisedCellData(vector, unit);
 }

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -284,15 +284,26 @@ namespace {
                 std::vector<T>
                 scatterToGlobal(const std::vector<T>& x) const;
 
-                /// Map input vector to active grid cells.
+                /// Restrict input vector to active grid cells.
+                ///
+                /// Selects subsets corresponding to active cells (i.e.,
+                /// those cells for which \code pore_volume > 0 \endcode) if
+                /// input size is
+                ///
+                ///   - All global cells
+                ///   - Explicitly active cells (ACTNUM != 0)
+                ///
+                /// All other cases are returned unfiltered--i.e., as direct
+                /// copies of the input.
                 ///
                 /// \param[in] x Input vector, defined on the explicitly
                 ///              active cells, all global cells or some
                 ///              other subset (e.g., all non-neighbouring
                 ///              connections).
                 ///
-                /// \return Input vector mapped to active cells or unchanged
-                /// if input is defined on some other subset.
+                /// \return Input vector restricted to active cells if
+                ///    subset known.  Direct copy if \p x is defined on set
+                ///    other than explicitly active or all global cells.
                 template <typename T>
                 std::vector<T>
                 gatherToActive(const std::vector<T>& x) const;

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -194,7 +194,8 @@ namespace Opm {
         std::vector<T>
         rawLinearisedCellData(const std::string& vector) const;
 
-        /// Convenience type alias for \c UnitSystem PMFs.
+        /// Convenience type alias for \c UnitSystem PMFs (pointer to member
+        /// function).
         typedef double (ECLUnits::UnitSystem::*UnitConvention)() const;
 
         /// Retrieve floating-point result set vector from current view

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -22,6 +22,7 @@
 #define OPM_ECLGRAPH_HEADER_INCLUDED
 
 #include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
 
 #include <array>
 #include <cstddef>
@@ -180,6 +181,43 @@ namespace Opm {
         ///    (rm^3/s).
         std::vector<double>
         flux(const PhaseIndex phase) const;
+
+        /// Retrieve result set vector from current view (e.g., particular
+        /// report step) linearised on active cells.
+        ///
+        /// \tparam T Element type of result set vector.
+        ///
+        /// \param[in] vector Name of result set vector.
+        ///
+        /// \return Result set vector linearised on active cells.
+        template <typename T>
+        std::vector<T>
+        rawLinearisedCellData(const std::string& vector) const;
+
+        /// Convenience type alias for \c UnitSystem PMFs.
+        typedef double (ECLUnits::UnitSystem::*UnitConvention)() const;
+
+        /// Retrieve floating-point result set vector from current view
+        /// (e.g., particular report step) linearised on active cells and
+        /// converted to strict SI unit conventions.
+        ///
+        /// Typical call:
+        /// \code
+        ///  const auto press =
+        ///      lCD("PRESSURE", &ECLUnits::UnitSystem::pressure);
+        /// \endcode
+        ///
+        /// \param[in] vector Name of result set vector.
+        ///
+        /// \param[in] unit Call-back hook in \c UnitSystem implementation
+        ///    that enables converting the raw result data to strict SI unit
+        ///    conventions.  Hook is called for each grid in the result set.
+        ///
+        /// \return Result set vector linearised on active cells, converted
+        ///    to strict SI unit conventions.
+        std::vector<double>
+        linearisedCellData(const std::string& vector,
+                           UnitConvention     unit) const;
 
     private:
         /// Implementation class.

--- a/tests/runLinearisedCellDataTest.cpp
+++ b/tests/runLinearisedCellDataTest.cpp
@@ -1,0 +1,551 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <examples/exampleSetup.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <exception>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/regex.hpp>
+
+#include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_file_kw.h>
+#include <ert/ecl/ecl_file_view.h>
+#include <ert/ecl/ecl_kw.h>
+#include <ert/ecl/ecl_kw_magic.h>
+#include <ert/util/ert_unique_ptr.hpp>
+
+namespace StringUtils {
+    namespace {
+        std::string trim(const std::string& s)
+        {
+            const auto anchor_ws =
+                boost::regex(R"~~(^\s+([^\s]+)\s+$)~~");
+
+            auto m = boost::smatch{};
+
+            if (boost::regex_match(s, m, anchor_ws)) {
+                return m[1];
+            }
+
+            return s;
+        }
+
+        std::vector<std::string> split(const std::string& s)
+        {
+            if (s.empty()) {
+                // Single element vector whose only element is the empty
+                // string.
+                return { "" };
+            }
+
+            const auto sep = boost::regex(R"~~([\s,;.|]+)~~");
+
+            using TI = boost::sregex_token_iterator;
+
+            // vector<string>(begin, end)
+            //
+            // Range is every substring (i.e., token) in input string 's'
+            // that does NOT match 'sep'.
+            return{ TI(s.begin(), s.end(), sep, -1), TI{} };
+        }
+    } // namespace Anonymous
+
+    template <typename T>
+    struct StringTo;
+
+    template <>
+    struct StringTo<int>
+    {
+        static int value(const std::string& s);
+    };
+
+    template <>
+    struct StringTo<double>
+    {
+        static double value(const std::string& s);
+    };
+
+    template <>
+    struct StringTo<std::string>
+    {
+        static std::string value(const std::string& s);
+    };
+
+    int StringTo<int>::value(const std::string& s)
+    {
+        return std::stoi(s);
+    }
+
+    double StringTo<double>::value(const std::string& s)
+    {
+        return std::stod(s);
+    }
+
+    std::string StringTo<std::string>::value(const std::string& s)
+    {
+        return trim(s);
+    }
+
+    namespace VectorValue {
+        template <typename T>
+        std::vector<T> get(const std::string& s, std::true_type)
+        {
+            return split(s);
+        }
+
+        template <typename T>
+        std::vector<T> get(const std::string& s, std::false_type)
+        {
+            const auto tokens = split(s);
+
+            auto ret = std::vector<T>{};
+            ret.reserve(tokens.size());
+            for (const auto& token : tokens) {
+                ret.push_back(StringTo<T>::value(token));
+            }
+
+            return ret;
+        }
+
+        template <typename T>
+        std::vector<T> get(const std::string& s)
+        {
+            return get<T>(s, typename std::is_same<T, std::string>::type());
+        }
+    } // namespace VectorValue
+} // namespace StringUtils
+
+namespace {
+    struct PoreVolume
+    {
+        std::vector<double> data;
+    };
+
+    class VectorDifference
+    {
+    public:
+        using Vector    = std::vector<double>;
+        using size_type = Vector::size_type;
+
+        VectorDifference(const Vector& x, const Vector& y)
+            : x_(x), y_(y)
+        {
+            if (x_.size() != y_.size()) {
+                std::ostringstream os;
+
+                os << "Incompatible Array Sizes: Expected 2x"
+                   << x_.size() << ", but got ("
+                   << x_.size() << ", " << y_.size() << ')';
+
+                throw std::domain_error(os.str());
+            }
+        }
+
+        size_type size() const
+        {
+            return x_.size();
+        }
+
+        bool empty() const
+        {
+            return this->size() == 0;
+        }
+
+        double operator[](const size_type i) const
+        {
+            return x_[i] - y_[i];
+        }
+
+    private:
+        const Vector& x_;
+        const Vector& y_;
+    };
+
+    template <class Vector1, class Vector2>
+    class VectorRatio
+    {
+    public:
+        using size_type = typename std::decay<
+            decltype(std::declval<Vector1>()[0])
+        >::type;
+
+        VectorRatio(const Vector1& x, const Vector2& y)
+            : x_(x), y_(y)
+        {
+            if (x_.size() != y.size()) {
+                std::ostringstream os;
+
+                os << "Incompatible Array Sizes: Expected 2x"
+                   << x_.size() << ", but got ("
+                   << x_.size() << ", " << y_.size() << ')';
+
+                throw std::domain_error(os.str());
+            }
+        }
+
+        size_type size() const
+        {
+            return x_.size();
+        }
+
+        bool empty() const
+        {
+            return x_.empty();
+        }
+
+        double operator[](const size_type i) const
+        {
+            return x_[i] / y_[i];
+        }
+
+    private:
+        const Vector1& x_;
+        const Vector2& y_;
+    };
+
+    struct ErrorMeasurement
+    {
+        double volume;
+        double inf;
+    };
+
+    struct ErrorTolerance
+    {
+        double absolute;
+        double relative;
+    };
+
+    struct AggregateErrors
+    {
+        std::vector<ErrorMeasurement> absolute;
+        std::vector<ErrorMeasurement> relative;
+    };
+
+    struct ReferenceToF
+    {
+        std::vector<double> forward;
+        std::vector<double> reverse;
+    };
+
+    template <class FieldVariable>
+    double volumeMetric(const PoreVolume&    pv,
+                        const FieldVariable& x)
+    {
+        if (x.size() != pv.data.size()) {
+            std::ostringstream os;
+
+            os << "Incompatible Array Sizes: Expected 2x"
+               << pv.data.size() << ", but got ("
+               << pv.data.size() << ", " << x.size() << ')';
+
+            throw std::domain_error(os.str());
+        }
+
+        auto num = 0.0;
+        auto den = 0.0;
+
+        for (decltype(pv.data.size())
+                 i = 0, n = pv.data.size(); i < n; ++i)
+        {
+            num += std::abs(x[i]) * pv.data[i];
+            den +=                  pv.data[i];
+        }
+
+        return num / den;
+    }
+
+    template <class FieldVariable>
+    double pointMetric(const FieldVariable& x)
+    {
+        static_assert(std::is_same<typename std::decay<decltype(std::abs(x[0]))>::type, double>::value,
+                      "Field Variable Value Type Must be 'double'");
+
+        if (x.empty()) {
+            return 0;
+        }
+
+        auto max = 0*x[0] - 1;
+
+        for (decltype(x.size())
+                 i = 0, n = x.size(); i < n; ++i)
+        {
+            const auto t = std::abs(x[i]);
+
+            if (t > max) {
+                max = t;
+            }
+        }
+
+        return max;
+    }
+
+    std::vector<int>
+    availableReportSteps(const example::FilePaths& paths)
+    {
+        using FilePtr = ::ERT::
+            ert_unique_ptr<ecl_file_type, ecl_file_close>;
+
+        const auto rsspec_fn = example::
+            deriveFileName(paths.grid, { ".RSSPEC", ".FRSSPEC" });
+
+        // Read-only, keep open between requests
+        const auto open_flags = 0;
+
+        auto rsspec = FilePtr{
+            ecl_file_open(rsspec_fn.generic_string().c_str(), open_flags)
+        };
+
+        auto* globView = ecl_file_get_global_view(rsspec.get());
+
+        const auto* ITIME_kw = "ITIME";
+        const auto n = ecl_file_view_get_num_named_kw(globView, ITIME_kw);
+
+        auto steps = std::vector<int>(n);
+
+        for (auto i = 0*n; i < n; ++i) {
+            const auto* itime =
+                ecl_file_view_iget_named_kw(globView, ITIME_kw, i);
+
+            const auto* itime_data =
+                static_cast<const int*>(ecl_kw_iget_ptr(itime, 0));
+
+            steps[i] = itime_data[0];
+        }
+
+        return steps;
+    }
+
+    ErrorTolerance
+    testTolerances(const ::Opm::parameter::ParameterGroup& param)
+    {
+        const auto atol = param.getDefault("atol", 1.0e-8);
+        const auto rtol = param.getDefault("rtol", 5.0e-12);
+
+        return ErrorTolerance{ atol, rtol };
+    }
+
+    int numDigits(const std::vector<int>& steps)
+    {
+        if (steps.empty()) {
+            return 1;
+        }
+
+        const auto m =
+            *std::max_element(std::begin(steps), std::end(steps));
+
+        if (m == 0) {
+            return 1;
+        }
+
+        assert (m > 0);
+
+        return std::floor(std::log10(static_cast<double>(m))) + 1;
+    }
+
+    ReferenceToF
+    loadReference(const ::Opm::parameter::ParameterGroup& param,
+                  const int                               step,
+                  const int                               nDigits)
+    {
+        namespace fs = boost::filesystem;
+
+        using VRef = std::reference_wrapper<std::vector<double>>;
+
+        auto fname = fs::path(param.get<std::string>("ref-dir"));
+        {
+            std::ostringstream os;
+
+            os << "tof-" << std::setw(nDigits) << std::setfill('0')
+               << step << ".txt";
+
+            fname /= os.str();
+        }
+
+        fs::ifstream input(fname);
+
+        if (! input) {
+            std::ostringstream os;
+
+            os << "Unable to Open Reference Data File "
+               << fname.filename();
+
+            throw std::domain_error(os.str());
+        }
+
+        auto tof = ReferenceToF{};
+
+        auto ref = std::array<VRef,2>{{ std::ref(tof.forward) ,
+                                        std::ref(tof.reverse) }};
+
+        {
+            auto i = static_cast<decltype(ref[0].get().size())>(0);
+            auto t = 0.0;
+
+            while (input >> t) {
+                ref[i].get().push_back(t);
+
+                i = (i + 1) % 2;
+            }
+        }
+
+        if (tof.forward.size() != tof.reverse.size()) {
+            std::ostringstream os;
+
+            os << "Unable to Read Consistent ToF Reference Data From "
+               << fname.filename();
+
+            throw std::out_of_range(os.str());
+        }
+
+        return tof;
+    }
+
+    void computeErrors(const PoreVolume&                       pv,
+                       const std::vector<double>&              ref,
+                       const ::Opm::FlowDiagnostics::Solution& fd,
+                       AggregateErrors&                        E)
+    {
+        const auto tof  = fd.timeOfFlight();
+        const auto diff = VectorDifference(tof, ref); //  tof - ref
+
+        using Vector1  = std::decay<decltype(diff)>::type;
+        using Vector2  = std::decay<decltype(ref)>::type;
+        using Ratio    = VectorRatio<Vector1, Vector2>;
+
+        const auto rat = Ratio(diff, ref); // (tof - ref) / ref
+
+        auto abs = ErrorMeasurement{};
+        {
+            abs.volume = volumeMetric(pv, diff);
+            abs.inf    = pointMetric (    diff);
+        }
+
+        auto rel = ErrorMeasurement{};
+        {
+            rel.volume = volumeMetric(pv, rat);
+            rel.inf    = pointMetric (    rat);
+        }
+
+        E.absolute.push_back(std::move(abs));
+        E.relative.push_back(std::move(rel));
+    }
+
+    std::array<AggregateErrors, 2>
+    sampleDifferences(example::Setup&&        setup,
+                      const std::vector<int>& steps)
+    {
+        const auto start =
+            std::vector<Opm::FlowDiagnostics::CellSet>{};
+
+        const auto nDigits = numDigits(steps);
+
+        const auto pv = PoreVolume{ setup.graph.poreVolume() };
+
+        auto E = std::array<AggregateErrors, 2>{};
+
+        for (const auto& step : steps) {
+            if (step == 0) {
+                // Ignore initial condition
+                continue;
+            }
+
+            if (! setup.selectReportStep(step)) {
+                continue;
+            }
+
+            const auto ref = loadReference(setup.param, step, nDigits);
+
+            {
+                const auto fwd = setup.toolbox
+                    .computeInjectionDiagnostics(start);
+
+                computeErrors(pv, ref.forward, fwd.fd, E[0]);
+            }
+
+            {
+                const auto rev = setup.toolbox
+                    .computeProductionDiagnostics(start);
+
+                computeErrors(pv, ref.reverse, rev.fd, E[1]);
+            }
+        }
+
+        return E;
+    }
+
+    bool errorAcceptable(const std::vector<ErrorMeasurement>& E,
+                         const double                         tol)
+    {
+        return std::accumulate(std::begin(E), std::end(E), true,
+            [tol](const bool ok, const ErrorMeasurement& e)
+            {
+                // Fine if at least one of .volume or .inf <= tol.
+                return ok && ! ((e.volume > tol) && (e.inf > tol));
+            });
+    }
+
+    bool everythingFine(const AggregateErrors& E,
+                        const ErrorTolerance&  tol)
+    {
+        return errorAcceptable(E.absolute, tol.absolute)
+            && errorAcceptable(E.relative, tol.relative);
+    }
+} // namespace Anonymous
+
+int main(int argc, char* argv[])
+try {
+    auto setup = example::Setup(argc, argv);
+
+    setup.selectReportStep(5);
+
+    const auto tol   = testTolerances(setup.param);
+    const auto press = setup.graph.rawLinearisedCellData<double>("PRESSURE");
+
+    const auto ok = (press.size() == 9220) &&
+        ((press[19] - 360.937286376953e+000) < tol.absolute);
+
+    std::cout << (ok ? "OK" : "FAIL") << '\n';
+
+    if (! ok) {
+        return EXIT_FAILURE;
+    }
+}
+catch (const std::exception& e) {
+    std::cerr << "Caught Exception: " << e.what() << '\n';
+
+    return EXIT_FAILURE;
+}

--- a/tests/runLinearisedCellDataTest.cpp
+++ b/tests/runLinearisedCellDataTest.cpp
@@ -535,12 +535,19 @@ try {
     const auto tol   = testTolerances(setup.param);
     const auto press = setup.graph.rawLinearisedCellData<double>("PRESSURE");
 
+    const auto press_SI = setup.graph
+        .linearisedCellData("PRESSURE", &Opm::ECLUnits::UnitSystem::pressure);
+
     const auto ok = (press.size() == 9220) &&
         ((press[19] - 360.937286376953e+000) < tol.absolute);
 
-    std::cout << (ok ? "OK" : "FAIL") << '\n';
+    const auto ok_SI = (press_SI.size() == 9220) &&
+        (std::abs(press_SI[19] - 36.0937286376953e+006) <
+         std::abs(tol.relative * 36.0937286376953e+006));
 
-    if (! ok) {
+    std::cout << ((ok && ok_SI) ? "OK" : "FAIL") << '\n';
+
+    if (! (ok && ok_SI)) {
         return EXIT_FAILURE;
     }
 }


### PR DESCRIPTION
In particular, class ECLGraph gains a new set of overloads,

    rawLinearisedCellData()
    linearisedCellData()

that return cell data linearised over all the model's active cells. The `raw*` methods return the data untouched while the `linearisedCellData()` method converts the raw result set data to strict SI unit conventions.