### PR TITLE
ECLGraph: Add Support for Extracting Scenario's Active Phases

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1206,7 +1206,7 @@ public:
     /// Retrieve number of active cells in graph.
     std::size_t numCells() const;
 
-    /// Retrive number of connections in graph.
+    /// Retrieve number of connections in graph.
     std::size_t numConnections() const;
 
     /// Retrieve the simulation scenario's active phases.
@@ -1215,14 +1215,14 @@ public:
     /// flux() may return non-zero values.
     const std::vector<PhaseIndex>& activePhases() const;
 
-    /// Retrive neighbourship relations between active cells.
+    /// Retrieve neighbourship relations between active cells.
     ///
     /// The \c i-th connection is between active cells \code
     /// neighbours()[2*i + 0] \endcode and \code neighbours()[2*i + 1]
     /// \endcode.
     std::vector<int> neighbours() const;
 
-    /// Retrive static pore-volume values on active cells only.
+    /// Retrieve static pore-volume values on active cells only.
     ///
     /// Corresponds to the \c PORV vector in the INIT file, possibly
     /// restricted to those active cells for which the pore-volume is
@@ -1256,7 +1256,7 @@ public:
     /// method selectReportStep().
     const ::Opm::ECLResultData& rawResultData() const;
 
-    /// Retrive phase flux on all connections defined by \code neighbours()
+    /// Retrieve phase flux on all connections defined by \code neighbours()
     /// \endcode.
     ///
     /// \param[in] phase Canonical phase for which to retrive flux.

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -47,6 +47,9 @@ namespace Opm {
     public:
         using Path = boost::filesystem::path;
 
+        /// Enum for indicating requested phase from the flux() method.
+        enum class PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
+
         /// Disabled default constructor.
         ECLGraph() = delete;
 
@@ -125,6 +128,12 @@ namespace Opm {
         /// Retrieve number of connections in graph.
         std::size_t numConnections() const;
 
+        /// Retrieve the simulation scenario's active phases.
+        ///
+        /// Mostly useful to determine the set of \c PhaseIndex values for
+        /// which flux() will return non-zero values if data available.
+        const std::vector<PhaseIndex>& activePhases() const;
+
         /// Retrieve neighbourship relations between active cells.
         ///
         /// The \c i-th connection is between active cells \code
@@ -165,9 +174,6 @@ namespace Opm {
         /// The result set dynamic data corresponds to the most recent call
         /// to method selectReportStep().
         const ::Opm::ECLResultData& rawResultData() const;
-
-        /// Enum for indicating requested phase from the flux() method.
-        enum class PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
 
         /// Retrive phase flux on all connections defined by \code
         /// neighbours() \endcode.

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -175,10 +175,10 @@ namespace Opm {
         /// to method selectReportStep().
         const ::Opm::ECLResultData& rawResultData() const;
 
-        /// Retrive phase flux on all connections defined by \code
+        /// Retrieve phase flux on all connections defined by \code
         /// neighbours() \endcode.
         ///
-        /// \param[in] phase Canonical phase for which to retrive flux.
+        /// \param[in] phase Canonical phase for which to retrieve flux.
         ///
         /// \return Flux values corresponding to selected phase.  Empty if
         ///    unavailable in the result set (e.g., when querying the gas


### PR DESCRIPTION
This change-set introduces a new method,
```C++
const std::vector<PhaseIndex>& ECLGraph::activePhases() const
```
that retrieves the result-set's active phases.  This list is extracted from the .INIT file on the assumption that the active phases does not change throughout the simulation scenario.

Secondly, we also replace multiple instances of "retrive" with the correct "retrieve" in Doxygen documentation.