### PR TITLE
Handle multiple completions in one cell.

### DIFF
--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -124,6 +124,11 @@ namespace example {
                 const auto& ijk = completion.ijk;
                 const int cell_index = G.activeCell(ijk, grid_index);
                 if (cell_index >= 0) {
+                    // Since inflow is a std::map, if the key was not
+                    // already present operator[] will insert a
+                    // value-initialized value (as in T() for a type
+                    // T), which is zero for built-in numerical types,
+                    // including double.
                     inflow[cell_index] += completion.reservoir_inflow_rate;
                 }
             }

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -124,7 +124,7 @@ namespace example {
                 const auto& ijk = completion.ijk;
                 const int cell_index = G.activeCell(ijk, grid_index);
                 if (cell_index >= 0) {
-                    inflow.emplace(cell_index, completion.reservoir_inflow_rate);
+                    inflow[cell_index] += completion.reservoir_inflow_rate;
                 }
             }
         }


### PR DESCRIPTION
If two wells are completed in the same cell the current version will yield only one of the wells' rate whereas their sum is the correct answer.

Note that we do not in general handle multi-completion cells in other parts of the code. We could check the start sets, but it has been requested that we do not add such checks yet, to facilitate some more testing from ResInsight (even though we know that we would produce faulty local tracer solutions in that case).