### PR TITLE
Correct and update some copyright statements.

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1,6 +1,5 @@
 /*
-  Copyright 2016 SINTEF ICT, Applied Mathematics.
-  Copyright 2016 Statoil ASA.
+  Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
 

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -1,6 +1,5 @@
 /*
-  Copyright 2016 SINTEF ICT, Applied Mathematics.
-  Copyright 2016 Statoil ASA.
+  Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
 

--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -1,6 +1,5 @@
 /*
-  Copyright 2016 SINTEF ICT, Applied Mathematics.
-  Copyright 2016 Statoil ASA.
+  Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
 

--- a/opm/utility/ECLResultData.hpp
+++ b/opm/utility/ECLResultData.hpp
@@ -1,6 +1,5 @@
 /*
-  Copyright 2016 SINTEF ICT, Applied Mathematics.
-  Copyright 2016 Statoil ASA.
+  Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
 

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -1,5 +1,4 @@
 /*
-  Copyright 2017 SINTEF ICT, Applied Mathematics.
   Copyright 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).

--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -1,5 +1,4 @@
 /*
-  Copyright 2017 SINTEF ICT, Applied Mathematics.
   Copyright 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).

--- a/opm/utility/ECLWellSolution.cpp
+++ b/opm/utility/ECLWellSolution.cpp
@@ -1,6 +1,6 @@
 /*
   Copyright 2016 SINTEF ICT, Applied Mathematics.
-  Copyright 2016 Statoil ASA.
+  Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/utility/ECLWellSolution.hpp
+++ b/opm/utility/ECLWellSolution.hpp
@@ -1,6 +1,6 @@
 /*
   Copyright 2016 SINTEF ICT, Applied Mathematics.
-  Copyright 2016 Statoil ASA.
+  Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media project (OPM).
 


### PR DESCRIPTION
These files were written under a contract giving Statoil the copyright, the Sintef copyright is therefore incorrect where removed below. Some files still *do* have Sintef copyrights, because they are based on Sintef-owned source code (usually from other parts of OPM or from MRST).

Will self-merge.