### PR TITLE
Remove template qualification for call to haveKeywordData().

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1076,7 +1076,7 @@ ECL::CartesianGridData::
 haveCellData(const ResultSet&   rset,
              const std::string& vector) const
 {
-    return rset.template haveKeywordData(vector, this->gridName());
+    return rset.haveKeywordData(vector, this->gridName());
 }
 
 bool


### PR DESCRIPTION
It is not a template method, so the qualification is wrong. It looks like gcc and clang accepts it anyway, but not Microsoft VC++.