### PR TITLE
Add Support for Computing Relative Permabilities from ECL Output

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -23,12 +23,14 @@
 list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLFluxCalc.cpp
         opm/utility/ECLGraph.cpp
+        opm/utility/ECLPropTable.cpp
         opm/utility/ECLResultData.cpp
         opm/utility/ECLUnitHandling.cpp
         opm/utility/ECLWellSolution.cpp
         )
 
 list (APPEND TEST_SOURCE_FILES
+        tests/test_eclproptable.cpp
         tests/test_eclunithandling.cpp
         )
 
@@ -46,6 +48,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
 list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLFluxCalc.hpp
         opm/utility/ECLGraph.hpp
+        opm/utility/ECLPropTable.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLUnitHandling.hpp
         opm/utility/ECLWellSolution.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -48,6 +48,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
 list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLFluxCalc.hpp
         opm/utility/ECLGraph.hpp
+        opm/utility/ECLPhaseIndex.hpp
         opm/utility/ECLPropTable.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLUnitHandling.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -21,15 +21,18 @@
 #                             the library needs it.
 
 list (APPEND MAIN_SOURCE_FILES
+        opm/utility/ECLEndPointScaling.cpp
         opm/utility/ECLFluxCalc.cpp
         opm/utility/ECLGraph.cpp
         opm/utility/ECLPropTable.cpp
         opm/utility/ECLResultData.cpp
+        opm/utility/ECLSaturationFunc.cpp
         opm/utility/ECLUnitHandling.cpp
         opm/utility/ECLWellSolution.cpp
         )
 
 list (APPEND TEST_SOURCE_FILES
+        tests/test_eclendpointscaling.cpp
         tests/test_eclproptable.cpp
         tests/test_eclunithandling.cpp
         )
@@ -46,11 +49,13 @@ list (APPEND EXAMPLE_SOURCE_FILES
         )
 
 list (APPEND PUBLIC_HEADER_FILES
+        opm/utility/ECLEndPointScaling.hpp
         opm/utility/ECLFluxCalc.hpp
         opm/utility/ECLGraph.hpp
         opm/utility/ECLPhaseIndex.hpp
         opm/utility/ECLPropTable.hpp
         opm/utility/ECLResultData.hpp
+        opm/utility/ECLSaturationFunc.hpp
         opm/utility/ECLUnitHandling.hpp
         opm/utility/ECLWellSolution.hpp
         )

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -128,7 +128,7 @@ namespace example {
             Opm::ECLFluxCalc calc(G, std::move(satfunc));
 
             auto getFlux = [&calc, &rstrt]
-                (const Opm::ECLOutput::PhaseIndex p)
+                (const Opm::ECLPhaseIndex         p)
             {
                 return calc.flux(rstrt, p);
             };
@@ -137,7 +137,7 @@ namespace example {
         }
 
         auto getFlux = [&G, &rstrt]
-            (const Opm::ECLOutput::PhaseIndex p)
+            (const Opm::ECLPhaseIndex         p)
         {
             return G.flux(rstrt, p);
         };

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -31,6 +31,7 @@
 
 #include <opm/utility/ECLFluxCalc.hpp>
 #include <opm/utility/ECLGraph.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLWellSolution.hpp>
 
@@ -123,7 +124,7 @@ namespace example {
             Opm::ECLFluxCalc calc(G);
 
             auto getFlux = [&calc, &rstrt]
-                (const Opm::ECLGraph::PhaseIndex p)
+                (const Opm::ECLOutput::PhaseIndex p)
             {
                 return calc.flux(rstrt, p);
             };
@@ -132,7 +133,7 @@ namespace example {
         }
 
         auto getFlux = [&G, &rstrt]
-            (const Opm::ECLGraph::PhaseIndex p)
+            (const Opm::ECLOutput::PhaseIndex p)
         {
             return G.flux(rstrt, p);
         };

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -490,7 +490,7 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
 {
     using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
     using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
-    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+    using PhIdx = ::Opm::ECLPhaseIndex;
 
     assert (((! opt.use3PtScaling) || (opt.curve == FCat::CapPress))
             && "Internal Error Selecting EPS Family");
@@ -555,7 +555,7 @@ Create::TwoPoint::unscaledEndPoints(const RTEP& ep, const EPSOpt& opt)
 {
     using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
     using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
-    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+    using PhIdx = ::Opm::ECLPhaseIndex;
 
     assert (((opt.curve == FCat::CapPress) ||
              (! opt.use3PtScaling)) && "Internal Logic Error");
@@ -890,7 +890,7 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
 {
     using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
     using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
-    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+    using PhIdx = ::Opm::ECLPhaseIndex;
 
     assert ((opt.use3PtScaling && (opt.curve == FCat::Relperm))
             && "Internal Error Selecting EPS Family");
@@ -936,7 +936,7 @@ Create::ThreePoint::unscaledEndPoints(const RTEP& ep, const EPSOpt& opt)
 {
     using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
     using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
-    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+    using PhIdx = ::Opm::ECLPhaseIndex;
 
     assert ((opt.use3PtScaling && (opt.curve == FCat::Relperm))
             && "Internal Error Selecting EPS Family");

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -1,0 +1,1163 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <opm/utility/ECLEndPointScaling.hpp>
+
+#include <opm/utility/ECLGraph.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLResultData.hpp>
+
+#include <cassert>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+    std::vector<Opm::SatFunc::EPSEvalInterface::TableEndPoints>
+    unscaledTwoPt(const std::vector<double>& min,
+                  const std::vector<double>& max)
+    {
+        assert ((min.size() == max.size()) && "Internal Logic Error");
+        assert ((! min.empty())            && "Internal Logic Error");
+
+        using TEP = Opm::SatFunc::EPSEvalInterface::TableEndPoints;
+
+        auto tep = std::vector<TEP>{};
+        tep.reserve(min.size());
+
+        for (auto n = min.size(), i = 0*n; i < n; ++i) {
+            const auto smin = min[i];
+
+            // Ignore 'sdisp' in the two-point scaling.
+            tep.push_back(TEP{ smin, smin, max[i] });
+        }
+
+        return tep;
+    }
+
+    std::vector<Opm::SatFunc::EPSEvalInterface::TableEndPoints>
+    unscaledThreePt(const std::vector<double>& min ,
+                    const std::vector<double>& disp,
+                    const std::vector<double>& max )
+    {
+        assert ((min.size() == max .size()) && "Internal Logic Error");
+        assert ((min.size() == disp.size()) && "Internal Logic Error");
+        assert ((! min.empty())             && "Internal Logic Error");
+
+        using TEP = Opm::SatFunc::EPSEvalInterface::TableEndPoints;
+
+        auto tep = std::vector<TEP>{};
+        tep.reserve(min.size());
+
+        for (auto n = min.size(), i = 0*n; i < n; ++i) {
+            tep.push_back(TEP{ min[i], disp[i], max[i] });
+        }
+
+        return tep;
+    }
+}
+
+// ---------------------------------------------------------------------
+// Class Opm::TwoPointScaling::Impl
+// ---------------------------------------------------------------------
+
+class Opm::SatFunc::TwoPointScaling::Impl
+{
+public:
+    Impl(std::vector<double> smin,
+         std::vector<double> smax)
+        : smin_(std::move(smin))
+        , smax_(std::move(smax))
+    {
+        if (this->smin_.size() != this->smax_.size()) {
+            throw std::invalid_argument {
+                "Size Mismatch Between Minimum and "
+                "Maximum Saturation Arrays"
+            };
+        }
+    }
+
+    std::vector<double>
+    eval(const TableEndPoints&   tep,
+         const SaturationPoints& sp) const;
+
+private:
+    std::vector<double> smin_;
+    std::vector<double> smax_;
+};
+
+std::vector<double>
+Opm::SatFunc::TwoPointScaling::
+Impl::eval(const TableEndPoints&   tep,
+           const SaturationPoints& sp) const
+{
+    const auto srng = tep.high - tep.low;
+
+    auto effsat = std::vector<double>{};
+    effsat.reserve(sp.size());
+
+    for (const auto& eval_pt : sp) {
+        const auto cell = eval_pt.cell;
+
+        const auto sLO = this->smin_[cell];
+        const auto sHI = this->smax_[cell];
+
+        effsat.push_back(0.0);
+        auto& s_eff = effsat.back();
+
+        if (! (eval_pt.sat > sLO)) {
+            // s <= sLO
+            s_eff = tep.low;
+        }
+        else if (! (eval_pt.sat < sHI)) {
+            // s >= sHI
+            s_eff = tep.high;
+        }
+        else {
+            // s \in (sLO, sHI)
+            const auto scaled_sat =
+                ((eval_pt.sat - sLO) / (sHI - sLO)) * srng;
+
+            s_eff = tep.low + scaled_sat;
+        }
+    }
+
+    return effsat;
+}
+
+// ---------------------------------------------------------------------
+// Class Opm::ThreePointScaling::Impl
+// ---------------------------------------------------------------------
+
+class Opm::SatFunc::ThreePointScaling::Impl
+{
+public:
+    Impl(std::vector<double> smin ,
+         std::vector<double> sdisp,
+         std::vector<double> smax )
+        : smin_ (std::move(smin ))
+        , sdisp_(std::move(sdisp))
+        , smax_ (std::move(smax ))
+    {
+        if ((this->sdisp_.size() != this->smin_.size()) ||
+            (this->sdisp_.size() != this->smax_.size()))
+        {
+            throw std::invalid_argument {
+                "Size Mismatch Between Minimum, Displacing "
+                "and Maximum Saturation Arrays"
+            };
+        }
+    }
+
+    std::vector<double>
+    eval(const TableEndPoints&   tep,
+         const SaturationPoints& sp) const;
+
+private:
+    std::vector<double> smin_;
+    std::vector<double> sdisp_;
+    std::vector<double> smax_;
+};
+
+std::vector<double>
+Opm::SatFunc::ThreePointScaling::
+Impl::eval(const TableEndPoints&   tep,
+           const SaturationPoints& sp) const
+{
+    auto effsat = std::vector<double>{};
+    effsat.reserve(sp.size());
+
+    for (const auto& eval_pt : sp) {
+        const auto cell = eval_pt.cell;
+
+        effsat.push_back(0.0);
+        auto& s_eff = effsat.back();
+
+        const auto sLO = this->smin_ [cell];
+        const auto sR  = this->sdisp_[cell];
+        const auto sHI = this->smax_ [cell];
+
+        if (! (eval_pt.sat > sLO)) {
+            // s <= sLO
+            s_eff = tep.low;
+        }
+        else if (! (eval_pt.sat < sHI)) {
+            // s >= sHI
+            s_eff = tep.high;
+        }
+        else if (eval_pt.sat < sR) {
+            // s \in (sLO, sR)
+            const auto t = (eval_pt.sat - sLO) / (sR - sLO);
+
+            s_eff = tep.low + t*(tep.disp - tep.low);
+        }
+        else {
+            // s \in (sR, sHI)
+            const auto t = (eval_pt.sat - sR) / (sHI - sR);
+
+            s_eff = tep.disp + t*(tep.high - tep.disp);
+        }
+    }
+
+    return effsat;
+}
+
+// ---------------------------------------------------------------------
+// EPS factory functions for two-point and three-point scaling options
+// ---------------------------------------------------------------------
+
+namespace Create {
+    using EPSOpt = ::Opm::SatFunc::CreateEPS::EPSOptions;
+    using RTEP   = ::Opm::SatFunc::CreateEPS::RawTableEndPoints;
+    using TEP    = ::Opm::SatFunc::EPSEvalInterface::TableEndPoints;
+
+    namespace TwoPoint {
+        using EPS    = ::Opm::SatFunc::TwoPointScaling;
+        using EPSPtr = std::unique_ptr<EPS>;
+
+        struct Kr {
+            static EPSPtr
+            G(const ::Opm::ECLGraph&        G,
+              const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            OG(const ::Opm::ECLGraph&        G,
+               const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            OW(const ::Opm::ECLGraph&        G,
+               const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            W(const ::Opm::ECLGraph&        G,
+              const ::Opm::ECLInitFileData& init);
+        };
+
+        struct Pc {
+            static EPSPtr
+            GO(const ::Opm::ECLGraph&        G,
+               const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            OW(const ::Opm::ECLGraph&        G,
+               const ::Opm::ECLInitFileData& init);
+        };
+
+        static EPSPtr
+        scalingFunction(const ::Opm::ECLGraph&        G,
+                        const ::Opm::ECLInitFileData& init,
+                        const EPSOpt&                 opt);
+
+        static std::vector<TEP>
+        unscaledEndPoints(const RTEP& ep, const EPSOpt& opt);
+    } // namespace TwoPoint
+
+    namespace ThreePoint {
+        using EPS    = ::Opm::SatFunc::ThreePointScaling;
+        using EPSPtr = std::unique_ptr<EPS>;
+
+        struct Kr {
+            static EPSPtr
+            G(const ::Opm::ECLGraph&        G,
+              const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            OG(const ::Opm::ECLGraph&        G,
+               const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            OW(const ::Opm::ECLGraph&        G,
+               const ::Opm::ECLInitFileData& init);
+
+            static EPSPtr
+            W(const ::Opm::ECLGraph&        G,
+              const ::Opm::ECLInitFileData& init);
+        };
+
+        static EPSPtr
+        scalingFunction(const ::Opm::ECLGraph&                       G,
+                        const ::Opm::ECLInitFileData&                init,
+                        const ::Opm::SatFunc::CreateEPS::EPSOptions& opt);
+
+        static std::vector<TEP>
+        unscaledEndPoints(const RTEP& ep, const EPSOpt& opt);
+    } // namespace ThreePoint
+} // namespace Create
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Implementation of Create::TwoPoint::scalingFunction()
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::Kr::G(const ::Opm::ECLGraph&        G,
+                        const ::Opm::ECLInitFileData& init)
+{
+    auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
+    auto sgu  = G.rawLinearisedCellData<double>(init, "SGU");
+
+    if ((sgcr.size() != sgu.size()) ||
+        (sgcr.size() != G.numCells()))
+    {
+        throw std::invalid_argument {
+            "Missing or Mismatching Gas End-Point "
+            "Specifications (SGCR and/or SGU)"
+        };
+    }
+
+    return EPSPtr { new EPS { std::move(sgcr), std::move(sgu) } };
+}
+
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::Kr::OG(const ::Opm::ECLGraph&        G,
+                         const ::Opm::ECLInitFileData& init)
+{
+    auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
+
+    if (sogcr.size() != G.numCells()) {
+        throw std::invalid_argument {
+            "Missing or Mismatching Critical Oil "
+            "Saturation in Oil/Gas System"
+        };
+    }
+
+    auto smax = std::vector<double>(sogcr.size(), 1.0);
+
+    // Adjust maximum S_o for scaled connate gas saturations.
+    {
+        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
+
+        if (sgl.size() != sogcr.size()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Connate Gas "
+                "Saturation in Oil/Gas System"
+            };
+        }
+
+        for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
+            smax[i] -= sgl[i];
+        }
+    }
+
+    // Adjust maximum S_o for scaled connate water saturations (if relevant).
+    {
+        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
+
+        if (swl.size() == sogcr.size()) {
+            for (auto n = swl.size(), i = 0*n; i < n; ++i) {
+                smax[i] -= swl[i];
+            }
+        }
+        else if (! swl.empty()) {
+            throw std::invalid_argument {
+                "Mismatching Connate Water "
+                "Saturation in Oil/Gas System"
+            };
+        }
+    }
+
+    return EPSPtr { new EPS { std::move(sogcr), std::move(smax) } };
+}
+
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::Kr::OW(const ::Opm::ECLGraph&        G,
+                         const ::Opm::ECLInitFileData& init)
+{
+    auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
+
+    if (sowcr.size() != G.numCells()) {
+        throw std::invalid_argument {
+            "Missing or Mismatching Critical Oil "
+            "Saturation in Oil/Water System"
+        };
+    }
+
+    auto smax = std::vector<double>(sowcr.size(), 1.0);
+
+    // Adjust maximum S_o for scaled connate water saturations.
+    {
+        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
+
+        if (swl.size() != sowcr.size()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Connate Water "
+                "Saturation in Oil/Water System"
+            };
+        }
+
+        for (auto n = swl.size(), i = 0*n; i < n; ++i) {
+            smax[i] -= swl[i];
+        }
+    }
+
+    // Adjust maximum S_o for scaled connate gas saturations (if relevant).
+    {
+        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
+
+        if (sgl.size() == sowcr.size()) {
+            for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
+                smax[i] -= sgl[i];
+            }
+        }
+        else if (! sgl.empty()) {
+            throw std::invalid_argument {
+                "Mismatching Connate Gas "
+                "Saturation in Oil/Water System"
+            };
+        }
+    }
+
+    return EPSPtr { new EPS { std::move(sowcr), std::move(smax) } };
+}
+
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::Kr::W(const ::Opm::ECLGraph&        G,
+                        const ::Opm::ECLInitFileData& init)
+{
+    auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
+    auto swu  = G.rawLinearisedCellData<double>(init, "SWU");
+
+    if (swcr.empty() || swu.empty()) {
+        throw std::invalid_argument {
+            "Missing Water End-Point Specifications (SWCR and/or SWU)"
+        };
+    }
+
+    return EPSPtr { new EPS { std::move(swcr), std::move(swu) } };
+}
+
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::Pc::GO(const ::Opm::ECLGraph&        G,
+                         const ::Opm::ECLInitFileData& init)
+{
+    auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
+    auto sgu = G.rawLinearisedCellData<double>(init, "SGU");
+
+    if ((sgl.size() != sgu.size()) ||
+        (sgl.size() != G.numCells()))
+    {
+        throw std::invalid_argument {
+            "Missing or Mismatching Connate or Maximum Gas "
+            "Saturation in Pcgo EPS"
+        };
+    }
+
+    return EPSPtr { new EPS { std::move(sgl), std::move(sgu) } };
+}
+
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::Pc::OW(const ::Opm::ECLGraph&        G,
+                         const ::Opm::ECLInitFileData& init)
+{
+    auto swl = G.rawLinearisedCellData<double>(init, "SWL");
+    auto swu = G.rawLinearisedCellData<double>(init, "SWU");
+
+    if ((swl.size() != swu.size()) ||
+        (swl.size() != G.numCells()))
+    {
+        throw std::invalid_argument {
+            "Missing or Mismatching Connate or Maximum Water "
+            "Saturation in Pcow EPS"
+        };
+    }
+
+    return EPSPtr { new EPS { std::move(swl), std::move(swu) } };
+}
+
+Create::TwoPoint::EPSPtr
+Create::TwoPoint::
+scalingFunction(const ::Opm::ECLGraph&                       G,
+                const ::Opm::ECLInitFileData&                init,
+                const ::Opm::SatFunc::CreateEPS::EPSOptions& opt)
+{
+    using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
+    using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
+    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+
+    assert (((! opt.use3PtScaling) || (opt.curve == FCat::CapPress))
+            && "Internal Error Selecting EPS Family");
+
+    if (opt.curve == FCat::Relperm) {
+        if (opt.subSys == SSys::OilWater) {
+            if (opt.thisPh == PhIdx::Vapour) {
+                throw std::invalid_argument {
+                    "Cannot Create an EPS for Gas Relperm "
+                    "in an Oil/Water System"
+                };
+            }
+
+            if (opt.thisPh == PhIdx::Aqua) {
+                return Create::TwoPoint::Kr::W(G, init);
+            }
+
+            return Create::TwoPoint::Kr::OW(G, init);
+        }
+
+        if (opt.subSys == SSys::OilGas) {
+            if (opt.thisPh == PhIdx::Aqua) {
+                throw std::invalid_argument {
+                    "Cannot Create an EPS for Water Relperm "
+                    "in an Oil/Gas System"
+                };
+            }
+
+            if (opt.thisPh == PhIdx::Vapour) {
+                return Create::TwoPoint::Kr::G(G, init);
+            }
+
+            return Create::TwoPoint::Kr::OG(G, init);
+        }
+    }
+
+    if (opt.curve == FCat::CapPress) {
+        if (opt.thisPh == PhIdx::Liquid) {
+            throw std::invalid_argument {
+                "Creating Capillary Pressure EPS as a Function "
+                "of Oil Saturation is not Supported"
+            };
+        }
+
+        if (opt.thisPh == PhIdx::Vapour) {
+            return Create::TwoPoint::Pc::GO(G, init);
+        }
+
+        if (opt.thisPh == PhIdx::Aqua) {
+            return Create::TwoPoint::Pc::OW(G, init);
+        }
+    }
+
+    // Invalid.
+    return EPSPtr{};
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Implementation of Create::TwoPoint::unscaledEndPoints()
+std::vector<Create::TEP>
+Create::TwoPoint::unscaledEndPoints(const RTEP& ep, const EPSOpt& opt)
+{
+    using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
+    using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
+    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+
+    assert (((opt.curve == FCat::CapPress) ||
+             (! opt.use3PtScaling)) && "Internal Logic Error");
+
+    if (opt.curve == FCat::CapPress) {
+        // Left node is connate saturation, right node is max saturation.
+
+        if (opt.thisPh == PhIdx::Liquid) {
+            throw std::invalid_argument {
+                "No Capillary Pressure Function for Oil"
+            };
+        }
+
+        if (opt.thisPh == PhIdx::Aqua) {
+            return unscaledTwoPt(ep.conn.water, ep.smax.water);
+        }
+
+        if (opt.thisPh == PhIdx::Vapour) {
+            return unscaledTwoPt(ep.conn.gas, ep.smax.gas);
+        }
+    }
+
+    if (opt.curve == FCat::Relperm) {
+        // Left node is critical saturation, right node is max saturation.
+
+        if (opt.subSys == SSys::OilGas) {
+            if (opt.thisPh == PhIdx::Aqua) {
+                throw std::invalid_argument {
+                    "Void Request for Unscaled Water Saturation "
+                    "End-Points in Oil-Gas System"
+                };
+            }
+
+            if (opt.thisPh == PhIdx::Liquid) {
+                return unscaledTwoPt(ep.crit.oil_in_gas, ep.smax.oil);
+            }
+
+            if (opt.thisPh == PhIdx::Vapour) {
+                return unscaledTwoPt(ep.crit.gas, ep.smax.gas);
+            }
+        }
+
+        if (opt.subSys == SSys::OilWater) {
+            if (opt.thisPh == PhIdx::Aqua) {
+                return unscaledTwoPt(ep.crit.water, ep.smax.water);
+            }
+
+            if (opt.thisPh == PhIdx::Liquid) {
+                return unscaledTwoPt(ep.crit.oil_in_water, ep.smax.oil);
+            }
+
+            if (opt.thisPh == PhIdx::Vapour) {
+                throw std::invalid_argument {
+                    "Void Request for Unscaled Gas Saturation "
+                    "End-Points in Oil-Water System"
+                };
+            }
+        }
+    }
+
+    // Invalid.
+    return {};
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Implementation of Create::ThreePoint::scalingFunction()
+
+Create::ThreePoint::EPSPtr
+Create::ThreePoint::Kr::G(const ::Opm::ECLGraph&        G,
+                          const ::Opm::ECLInitFileData& init)
+{
+    auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
+    auto sgu  = G.rawLinearisedCellData<double>(init, "SGU");
+
+    if ((sgcr.size() != sgu.size()) ||
+        (sgcr.size() != G.numCells()))
+    {
+        throw std::invalid_argument {
+            "Missing or Mismatching Gas End-Point "
+            "Specifications (SGCR and/or SGU)"
+        };
+    }
+
+    auto sr = std::vector<double>(G.numCells(), 1.0);
+
+    // Adjust displacing saturation for connate water.
+    {
+        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
+
+        if (swl.size() == sgcr.size()) {
+            for (auto n = swl.size(), i = 0*n; i < n; ++i) {
+                sr[i] -= swl[i];
+            }
+        }
+        else if (! swl.empty()) {
+            throw std::invalid_argument {
+                "Connate Water Saturation Array Mismatch "
+                "in Three-Point Scaling Option"
+            };
+        }
+    }
+
+    // Adjust displacing saturation for critical S_o in O/G system.
+    {
+        const auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
+
+        if (sogcr.size() == sgcr.size()) {
+            for (auto n = sogcr.size(), i = 0*n; i < n; ++i) {
+                sr[i] -= sogcr[i];
+            }
+        }
+        else if (! sogcr.empty()) {
+            throw std::invalid_argument {
+                "Critical Oil Saturation (O/G System) Array "
+                "Size Mismatch in Three-Point Scaling Option"
+            };
+        }
+    }
+
+    return EPSPtr {
+        new EPS { std::move(sgcr), std::move(sr), std::move(sgu) }
+    };
+}
+
+Create::ThreePoint::EPSPtr
+Create::ThreePoint::Kr::OG(const ::Opm::ECLGraph&        G,
+                           const ::Opm::ECLInitFileData& init)
+{
+    auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
+
+    if (sogcr.size() != G.numCells()) {
+        throw std::invalid_argument {
+            "Missing or Mismatching Critical Oil "
+            "Saturation in Oil/Gas System"
+        };
+    }
+
+    auto smax = std::vector<double>(sogcr.size(), 1.0);
+
+    // Adjust maximum S_o for scaled connate gas saturations.
+    {
+        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
+
+        if (sgl.size() != sogcr.size()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Connate Gas "
+                "Saturation in Oil/Gas System"
+            };
+        }
+
+        for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
+            smax[i] -= sgl[i];
+        }
+    }
+
+    auto sdisp = std::vector<double>(sogcr.size(), 1.0);
+
+    // Adjust displacing S_o for scaled critical gas saturation.
+    {
+        const auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
+
+        if (sgcr.size() != sogcr.size()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Scaled Critical Gas "
+                "Saturation in Oil/Gas System"
+            };
+        }
+
+        for (auto n = sgcr.size(), i = 0*n; i < n; ++i) {
+            sdisp[i] -= sgcr[i];
+        }
+    }
+
+    // Adjust displacing and maximum S_o for scaled connate water
+    // saturations (if relevant).
+    {
+        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
+
+        if (swl.size() == sogcr.size()) {
+            for (auto n = swl.size(), i = 0*n; i < n; ++i) {
+                sdisp[i] -= swl[i];
+                smax [i] -= swl[i];
+            }
+        }
+        else if (! swl.empty()) {
+            throw std::invalid_argument {
+                "Mismatching Scaled Connate Water "
+                "Saturation in Oil/Gas System"
+            };
+        }
+    }
+
+    return EPSPtr {
+        new EPS { std::move(sogcr), std::move(sdisp), std::move(smax) }
+    };
+}
+
+Create::ThreePoint::EPSPtr
+Create::ThreePoint::Kr::OW(const ::Opm::ECLGraph&        G,
+                           const ::Opm::ECLInitFileData& init)
+{
+    auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
+
+    if (sowcr.size() != G.numCells()) {
+        throw std::invalid_argument {
+            "Missing or Mismatching Critical Oil "
+            "Saturation in Oil/Water System"
+        };
+    }
+
+    auto smax = std::vector<double>(sowcr.size(), 1.0);
+
+    // Adjust maximum S_o for scaled connate water saturations.
+    {
+        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
+
+        if (swl.size() != sowcr.size()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Connate Water "
+                "Saturation in Oil/Water System"
+            };
+        }
+
+        for (auto n = swl.size(), i = 0*n; i < n; ++i) {
+            smax[i] -= swl[i];
+        }
+    }
+
+    auto sdisp = std::vector<double>(sowcr.size(), 1.0);
+
+    // Adjust displacing S_o for scaled critical water saturations.
+    {
+        const auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
+
+        if (swcr.size() != sowcr.size()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Scaled Critical Water "
+                "Saturation in Oil/Water System"
+            };
+        }
+
+        for (auto n = swcr.size(), i = 0*n; i < n; ++i) {
+            sdisp[i] -= swcr[i];
+        }
+    }
+
+    // Adjust displacing and maximum S_o for scaled connate gas saturations
+    // (if relevant).
+    {
+        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
+
+        if (sgl.size() == sowcr.size()) {
+            for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
+                sdisp[i] -= sgl[i];
+                smax [i] -= sgl[i];
+            }
+        }
+        else if (! sgl.empty()) {
+            throw std::invalid_argument {
+                "Mismatching Connate Gas "
+                "Saturation in Oil/Water System"
+            };
+        }
+    }
+
+    return EPSPtr {
+        new EPS { std::move(sowcr), std::move(sdisp), std::move(smax) }
+    };
+}
+
+Create::ThreePoint::EPSPtr
+Create::ThreePoint::Kr::W(const ::Opm::ECLGraph&        G,
+                          const ::Opm::ECLInitFileData& init)
+{
+    auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
+    auto swu  = G.rawLinearisedCellData<double>(init, "SWU");
+
+    if ((swcr.size() != G.numCells()) ||
+        (swcr.size() != swu.size()))
+    {
+        throw std::invalid_argument {
+            "Missing Water End-Point Specifications (SWCR and/or SWU)"
+        };
+    }
+
+    auto sdisp = std::vector<double>(swcr.size(), 1.0);
+
+    // Adjust displacing S_w for scaled critical oil saturation.
+    {
+        const auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
+
+        if (sowcr.size() == swcr.size()) {
+            for (auto n = sowcr.size(), i = 0*n; i < n; ++i) {
+                sdisp[i] -= sowcr[i];
+            }
+        }
+        else if (! sowcr.empty()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Scaled Critical "
+                "Oil Saturation in Oil/Water System"
+            };
+        }
+    }
+
+    // Adjust displacing S_w for scaled connate gas saturation.
+    {
+        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
+
+        if (sgl.size() == swcr.size()) {
+            for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
+                sdisp[i] -= sgl[i];
+            }
+        }
+        else if (! sgl.empty()) {
+            throw std::invalid_argument {
+                "Missing or Mismatching Scaled Connate "
+                "Gas Saturation in Oil/Water System"
+            };
+        }
+    }
+
+    return EPSPtr {
+        new EPS { std::move(swcr), std::move(sdisp), std::move(swu) }
+    };
+}
+
+Create::ThreePoint::EPSPtr
+Create::ThreePoint::
+scalingFunction(const ::Opm::ECLGraph&                       G,
+                const ::Opm::ECLInitFileData&                init,
+                const ::Opm::SatFunc::CreateEPS::EPSOptions& opt)
+{
+    using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
+    using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
+    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+
+    assert ((opt.use3PtScaling && (opt.curve == FCat::Relperm))
+            && "Internal Error Selecting EPS Family");
+
+    if (opt.subSys == SSys::OilWater) {
+        if (opt.thisPh == PhIdx::Vapour) {
+            throw std::invalid_argument {
+                "Cannot Create a Three-Point EPS for "
+                "Gas Relperm in an Oil/Water System"
+            };
+        }
+
+        if (opt.thisPh == PhIdx::Aqua) {
+            return Create::ThreePoint::Kr::W(G, init);
+        }
+
+        return Create::ThreePoint::Kr::OW(G, init);
+    }
+
+    if (opt.subSys == SSys::OilGas) {
+        if (opt.thisPh == PhIdx::Aqua) {
+            throw std::invalid_argument {
+                "Cannot Create a Three-Point EPS for "
+                "Water Relperm in an Oil/Gas System"
+            };
+        }
+
+        if (opt.thisPh == PhIdx::Vapour) {
+            return Create::ThreePoint::Kr::G(G, init);
+        }
+
+        return Create::ThreePoint::Kr::OG(G, init);
+    }
+
+    // Invalid.
+    return EPSPtr{};
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Implementation of Create::ThreePoint::unscaledEndPoints()
+std::vector<Create::TEP>
+Create::ThreePoint::unscaledEndPoints(const RTEP& ep, const EPSOpt& opt)
+{
+    using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
+    using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
+    using PhIdx = ::Opm::ECLOutput::PhaseIndex;
+
+    assert ((opt.use3PtScaling && (opt.curve == FCat::Relperm))
+            && "Internal Error Selecting EPS Family");
+
+    auto sdisp = [](const std::vector<double>& s1,
+                    const std::vector<double>& s2)
+        -> std::vector<double>
+    {
+        auto sr = std::vector<double>(s1.size(), 1.0);
+
+        for (auto n = s1.size(), i = 0*n; i < n; ++i) {
+            sr[i] -= s1[i] + s2[i];
+        }
+
+        return sr;
+    };
+
+    // Left node is critical saturation, middle node is displacing critical
+    // saturation, and right node is maximum saturation.
+
+    if (opt.subSys == SSys::OilGas) {
+        if (opt.thisPh == PhIdx::Aqua) {
+            throw std::invalid_argument {
+                "Void Request for Unscaled Water Saturation "
+                "End-Points in Oil-Gas System"
+            };
+        }
+
+        if (opt.thisPh == PhIdx::Liquid) {
+            return unscaledThreePt(ep.crit.oil_in_gas,
+                                   sdisp(ep.crit.gas, ep.conn.water),
+                                   ep.smax.oil);
+        }
+
+        if (opt.thisPh == PhIdx::Vapour) {
+            return unscaledThreePt(ep.crit.gas,
+                                   sdisp(ep.crit.oil_in_gas, ep.conn.water),
+                                   ep.smax.gas);
+        }
+    }
+
+    if (opt.subSys == SSys::OilWater) {
+        if (opt.thisPh == PhIdx::Aqua) {
+            return unscaledThreePt(ep.crit.water,
+                                   sdisp(ep.crit.oil_in_water, ep.conn.gas),
+                                   ep.smax.water);
+        }
+
+        if (opt.thisPh == PhIdx::Liquid) {
+            return unscaledThreePt(ep.crit.oil_in_water,
+                                   sdisp(ep.crit.water, ep.conn.gas),
+                                   ep.smax.oil);
+        }
+
+        if (opt.thisPh == PhIdx::Vapour) {
+            throw std::invalid_argument {
+                "Void Request for Unscaled Gas Saturation "
+                "End-Points in Oil-Water System"
+            };
+        }
+    }
+
+    // Invalid.
+    return {};
+}
+
+// #####################################################################
+// =====================================================================
+// Public Interface Below Separator
+// =====================================================================
+// #####################################################################
+
+// Class Opm::SatFunc::EPSEvalInterface
+Opm::SatFunc::EPSEvalInterface::~EPSEvalInterface()
+{}
+
+// ---------------------------------------------------------------------
+
+// Class Opm::SatFunc::TwoPointScaling
+Opm::SatFunc::TwoPointScaling::
+TwoPointScaling(std::vector<double> smin,
+                std::vector<double> smax)
+    : pImpl_(new Impl(std::move(smin), std::move(smax)))
+{}
+
+Opm::SatFunc::TwoPointScaling::~TwoPointScaling()
+{}
+
+Opm::SatFunc::TwoPointScaling::
+TwoPointScaling(const TwoPointScaling& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::SatFunc::TwoPointScaling::
+TwoPointScaling(TwoPointScaling&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::SatFunc::TwoPointScaling&
+Opm::SatFunc::TwoPointScaling::operator=(const TwoPointScaling& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+Opm::SatFunc::TwoPointScaling&
+Opm::SatFunc::TwoPointScaling::operator=(TwoPointScaling&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::SatFunc::TwoPointScaling::eval(const TableEndPoints&   tep,
+                                    const SaturationPoints& sp) const
+{
+    return this->pImpl_->eval(tep, sp);
+}
+
+std::unique_ptr<Opm::SatFunc::EPSEvalInterface>
+Opm::SatFunc::TwoPointScaling::clone() const
+{
+    return std::unique_ptr<TwoPointScaling>(new TwoPointScaling(*this));
+}
+
+// ---------------------------------------------------------------------
+
+// Class Opm::SatFunc::ThreePointScaling
+Opm::SatFunc::ThreePointScaling::
+ThreePointScaling(std::vector<double> smin,
+                  std::vector<double> sdisp,
+                  std::vector<double> smax)
+    : pImpl_(new Impl(std::move(smin), std::move(sdisp), std::move(smax)))
+{}
+
+Opm::SatFunc::ThreePointScaling::~ThreePointScaling()
+{}
+
+Opm::SatFunc::ThreePointScaling::
+ThreePointScaling(const ThreePointScaling& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::SatFunc::ThreePointScaling::ThreePointScaling(ThreePointScaling&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::SatFunc::ThreePointScaling&
+Opm::SatFunc::ThreePointScaling::operator=(const ThreePointScaling& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+Opm::SatFunc::ThreePointScaling&
+Opm::SatFunc::ThreePointScaling::operator=(ThreePointScaling&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::SatFunc::ThreePointScaling::eval(const TableEndPoints&   tep,
+                                      const SaturationPoints& sp) const
+{
+    return this->pImpl_->eval(tep, sp);
+}
+
+std::unique_ptr<Opm::SatFunc::EPSEvalInterface>
+Opm::SatFunc::ThreePointScaling::clone() const
+{
+    return std::unique_ptr<ThreePointScaling>(new ThreePointScaling(*this));
+}
+
+// ---------------------------------------------------------------------
+// Factory function Opm::SatFunc::CreateEPS::fromECLOutput()
+
+std::unique_ptr<Opm::SatFunc::EPSEvalInterface>
+Opm::SatFunc::CreateEPS::
+fromECLOutput(const ECLGraph&        G,
+              const ECLInitFileData& init,
+              const EPSOptions&      opt)
+{
+    if ((opt.curve == FunctionCategory::CapPress) ||
+        (! opt.use3PtScaling))
+    {
+        return Create::TwoPoint::scalingFunction(G, init, opt);
+    }
+
+    if ((opt.curve == FunctionCategory::Relperm) && opt.use3PtScaling)
+    {
+        return Create::ThreePoint::scalingFunction(G, init, opt);
+    }
+
+    // Invalid
+    return std::unique_ptr<Opm::SatFunc::EPSEvalInterface>{};
+}
+
+// ---------------------------------------------------------------------
+// Factory function Opm::SatFunc::CreateEPS::unscaledEndPoints()
+
+std::vector<Opm::SatFunc::EPSEvalInterface::TableEndPoints>
+Opm::SatFunc::CreateEPS::
+unscaledEndPoints(const RawTableEndPoints& ep,
+                  const EPSOptions&        opt)
+{
+    if ((opt.curve == FunctionCategory::CapPress) ||
+        (! opt.use3PtScaling))
+    {
+        return Create::TwoPoint::unscaledEndPoints(ep, opt);
+    }
+
+    if ((opt.curve == FunctionCategory::Relperm) && opt.use3PtScaling)
+    {
+        return Create::ThreePoint::unscaledEndPoints(ep, opt);
+    }
+
+    // Invalid
+    return {};
+}

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -313,11 +313,11 @@ namespace Opm { namespace SatFunc {
             ///   opt.use3PtScaling = false;
             ///   opt.curve         = FunctionCategory::Relperm;
             ///   opt.subSys        = SubSystem::OilGas;
-            ///   opt.thisPh        = ECLOutput::PhaseIndex::Oil;
+            ///   opt.thisPh        = ECLPhaseIndex::Oil;
             ///
             ///   auto eps = CreateEPS::fromECLOutput(G, init, opt);
             /// \endcode
-            ::Opm::ECLOutput::PhaseIndex thisPh;
+            ::Opm::ECLPhaseIndex thisPh;
         };
 
         /// Collection of raw saturation table end points.

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -1,0 +1,431 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLENDPOINTSCALING_HEADER_INCLUDED
+#define OPM_ECLENDPOINTSCALING_HEADER_INCLUDED
+
+#include <opm/utility/ECLPhaseIndex.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+    class ECLGraph;
+    class ECLInitFileData;
+
+} // namespace Opm
+
+namespace Opm { namespace SatFunc {
+
+    /// Protocol for computing scaled saturation values.
+    class EPSEvalInterface
+    {
+    public:
+        /// Static (unscaled) end-points of a particular, tabulated
+        /// saturation function.
+        struct TableEndPoints {
+            /// Critical or connate/minimum saturation, depending on
+            /// subsequent function evaluation context.
+            ///
+            /// Use critical saturation when computing look-up values for
+            /// relative permeability and connate/minimum saturation when
+            /// computing look-up values for capillary pressure.
+            double low;
+
+            /// Displacing saturation (3-pt option only).
+            double disp;
+
+            /// Maximum (high) saturation point.
+            double high;
+        };
+
+        /// Associate a saturation value to a specific cell.
+        struct SaturationAssoc {
+            /// Cell to which to connect a saturation value.
+            std::vector<int>::size_type cell;
+
+            /// Saturation value.
+            double sat;
+        };
+
+        /// Convenience type alias.
+        using SaturationPoints = std::vector<SaturationAssoc>;
+
+        /// Derive scaled saturations--inputs to subsequent evaluation of
+        /// saturation functions--corresponding to a sequence of unscaled
+        /// saturation values.
+        ///
+        /// \param[in] tep Static end points that identify the saturation
+        ///    scaling intervals of a particular tabulated saturation
+        ///    function.
+        ///
+        /// \param[in] sp Sequence of saturation points.
+        ///
+        /// \return Sequence of scaled saturation values in order of the
+        ///    input sequence.  In particular the \c i-th element of this
+        ///    result is the scaled version of \code sp[i].sat \endcode.
+        virtual std::vector<double>
+        eval(const TableEndPoints&   tep,
+             const SaturationPoints& sp) const = 0;
+
+        virtual std::unique_ptr<EPSEvalInterface> clone() const = 0;
+
+        /// Destructor.  Must be virtual.
+        virtual ~EPSEvalInterface();
+    };
+
+    /// Implementation of ECLIPSE's standard, two-point, saturation scaling
+    /// option.
+    class TwoPointScaling : public EPSEvalInterface
+    {
+    public:
+        /// Constructor.
+        ///
+        /// Typically set up to define the end-point scaling of all active
+        /// cells in a model, but could alternatively be used as a means to
+        /// computing the effective saturation function of a single cell.
+        ///
+        /// \param[in] smin Left end points for a set of cells.
+        ///
+        /// \param[in] smax Right end points for a set of cells.
+        TwoPointScaling(std::vector<double> smin,
+                        std::vector<double> smax);
+
+        /// Destructor.
+        ~TwoPointScaling();
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Existing object.
+        TwoPointScaling(const TwoPointScaling& rhs);
+
+        /// Move constructor.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing object.
+        TwoPointScaling(TwoPointScaling&& rhs);
+
+        /// Assignment operator.
+        ///
+        /// Replaces current implementation with a copy of existing object's
+        /// implementation details.
+        ///
+        /// \param[in] rhs Existing object.
+        ///
+        /// \return \code *this \endcode.
+        TwoPointScaling&
+        operator=(const TwoPointScaling& rhs);
+
+        /// Move assingment operator.
+        ///
+        /// Subsumes existing object's implementation details and uses those
+        /// to replace the current implementation.
+        ///
+        /// \return \code *this \endcode.
+        TwoPointScaling&
+        operator=(TwoPointScaling&& rhs);
+
+        /// Derive scaled saturations using the two-point scaling definition
+        /// from a sequence of unscaled saturation values.
+        ///
+        /// \param[in] tep Static end points that identify the saturation
+        ///    scaling intervals of a particular tabulated saturation
+        ///    function.  The evaluation procedure considers only \code
+        ///    tep.low \endcode and \code tep.high \endcode.  The value of
+        ///    \code tep.disp \endcode is never read.
+        ///
+        /// \param[in] sp Sequence of saturation points.  The maximum cell
+        ///    index (\code sp[i].cell \endcode) must be strictly less than
+        ///    the size of the input arrays that define the current
+        ///    saturation regions.
+        ///
+        /// \return Sequence of scaled saturation values in order of the
+        ///    input sequence.  In particular the \c i-th element of this
+        ///    result is the scaled version of \code sp[i].sat \endcode.
+        virtual std::vector<double>
+        eval(const TableEndPoints&   tep,
+             const SaturationPoints& sp) const override;
+
+        virtual std::unique_ptr<EPSEvalInterface> clone() const override;
+
+    private:
+        /// Implementation class.
+        class Impl;
+
+        /// Pimpl idiom.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Implementation of ECLIPSE's alternative, three-point, saturation
+    /// scaling option.
+    class ThreePointScaling : public EPSEvalInterface
+    {
+    public:
+        /// Constructor.
+        ///
+        /// Typically set up to define the end-point scaling of all active
+        /// cells in a model, but could alternatively be used as a means to
+        /// computing the effective saturation function of a single cell.
+        ///
+        /// \param[in] smin Left end points for a set of cells.
+        ///
+        /// \param[in] sdisp Intermediate--displacing saturation--end points
+        ///    for a set of cells.
+        ///
+        /// \param[in] smax Right end points for a set of cells.
+        ThreePointScaling(std::vector<double> smin,
+                          std::vector<double> sdisp,
+                          std::vector<double> smax);
+
+        /// Destructor.
+        ~ThreePointScaling();
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Existing object.
+        ThreePointScaling(const ThreePointScaling& rhs);
+
+        /// Move constructor.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing object.
+        ThreePointScaling(ThreePointScaling&& rhs);
+
+        /// Assignment operator.
+        ///
+        /// Replaces current implementation with a copy of existing object's
+        /// implementation details.
+        ///
+        /// \param[in] rhs Existing object.
+        ///
+        /// \return \code *this \endcode.
+        ThreePointScaling&
+        operator=(const ThreePointScaling& rhs);
+
+        /// Move assingment operator.
+        ///
+        /// Subsumes existing object's implementation details and uses those
+        /// to replace the current implementation.
+        ///
+        /// \return \code *this \endcode.
+        ThreePointScaling&
+        operator=(ThreePointScaling&& rhs);
+
+        /// Derive scaled saturations using the three-point scaling
+        /// definition from a sequence of unscaled saturation values.
+        ///
+        /// \param[in] tep Static end points that identify the saturation
+        ///    scaling intervals of a particular tabulated saturation
+        ///    function.  The evaluation procedure considers only \code
+        ///    tep.low \endcode and \code tep.high \endcode.  The value of
+        ///    \code tep.disp \endcode is never read.
+        ///
+        /// \param[in] sp Sequence of saturation points.  The maximum cell
+        ///    index (\code sp[i].cell \endcode) must be strictly less than
+        ///    the size of the input arrays that define the current
+        ///    saturation regions.
+        ///
+        /// \return Sequence of scaled saturation values in order of the
+        ///    input sequence.  In particular the \c i-th element of this
+        ///    result is the scaled version of \code sp[i].sat \endcode.
+        virtual std::vector<double>
+        eval(const TableEndPoints&   tep,
+             const SaturationPoints& sp) const override;
+
+        virtual std::unique_ptr<EPSEvalInterface> clone() const override;
+
+    private:
+        /// Implementation class.
+        class Impl;
+
+        /// Pimpl idiom.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Named constructors for enabling saturation end-point scaling from an
+    /// ECL result set (see class \c ECLInitFileData).
+    struct CreateEPS
+    {
+        /// Category of function for which to create an EPS evaluator.
+        enum class FunctionCategory {
+            /// This EPS is for relative permeability.  Possibly uses
+            /// three-point (alternative) formulation.
+            Relperm,
+
+            /// This EPS is for capillary pressure.  Two-point option only.
+            CapPress,
+        };
+
+        /// Categories of saturation function systems for which to create an
+        /// EPS evaluator.
+        enum class SubSystem {
+            /// Create an EPS for a curve in the Oil-Water (sub-) system.
+            OilWater,
+
+            /// Create an EPS for a curve in the Oil-Gas (sub-) system.
+            OilGas,
+        };
+
+        /// Set of options that uniquely define a single EPS operation.
+        struct EPSOptions {
+            /// Whether or not to employ the alternative (i.e., 3-pt) scaling
+            /// procedure.  Only applicable to FunctionCategory::Relperm and
+            /// ignored in the case of FunctionCategory::CapPress.
+            bool use3PtScaling;
+
+            /// Curve-type for which to create an EPS.
+            FunctionCategory curve;
+
+            /// Part of global fluid system for which to create an EPS.
+            SubSystem subSys;
+
+            /// Phase for whose \c curve in which \c subSys to create an
+            /// EPS.
+            ///
+            /// Example: Create a standard (two-point) EPS for the relative
+            ///    permeability of oil in the oil-gas subsystem of an
+            ///    oil-gas-water active phase system.
+            ///
+            /// \code
+            ///   auto opt = EPSOptions{};
+            ///
+            ///   opt.use3PtScaling = false;
+            ///   opt.curve         = FunctionCategory::Relperm;
+            ///   opt.subSys        = SubSystem::OilGas;
+            ///   opt.thisPh        = ECLOutput::PhaseIndex::Oil;
+            ///
+            ///   auto eps = CreateEPS::fromECLOutput(G, init, opt);
+            /// \endcode
+            ::Opm::ECLOutput::PhaseIndex thisPh;
+        };
+
+        /// Collection of raw saturation table end points.
+        struct RawTableEndPoints {
+            /// Collection of connate (minimum) saturation end points.
+            struct Connate {
+                /// Connate oil saturation for each table in total set of
+                /// tabulated saturation functions.
+                std::vector<double> oil;
+
+                /// Connate gas saturation for each table in total set of
+                /// tabulated saturation functions.
+                std::vector<double> gas;
+
+                /// Connate water saturation for each table in total set of
+                /// tabulated saturation functions.
+                std::vector<double> water;
+            };
+
+            /// Collection of critical saturations.  Used in deriving scaled
+            /// displacing saturations in the alternative (three-point)
+            /// scaling procedure.
+            struct Critical {
+                /// Critical oil saturation in 2p OG system from total set
+                /// of tabulated saturation functions.
+                std::vector<double> oil_in_gas;
+
+                /// Critical oil saturation in 2p OW system from total set
+                /// of tabulated saturation functions.
+                std::vector<double> oil_in_water;
+
+                /// Critical gas saturation in 2p OG or 3p OGW system from
+                /// total set of tabulated saturation functions.
+                std::vector<double> gas;
+
+                /// Critical water saturation in 2p OW or 3p OGW system from
+                /// total set of tabulated saturation functions.
+                std::vector<double> water;
+            };
+
+            /// Collection of maximum saturation end points.
+            struct Maximum {
+                /// Maximum oil saturation for each table in total set of
+                /// tabulated saturation functions.
+                std::vector<double> oil;
+
+                /// Maximum gas saturation for each table in total set of
+                /// tabulated saturation functions.
+                std::vector<double> gas;
+
+                /// Maximum water saturation for each table in total set of
+                /// tabulated saturation functions.
+                std::vector<double> water;
+            };
+
+            /// Minimum saturation end points for all tabulated saturation
+            /// functions.
+            Connate conn;
+
+            /// Critical saturations for all tabulated saturation functions.
+            Critical crit;
+
+            /// Maximum saturation end points for all tabulated saturation
+            /// functions.
+            Maximum smax;
+        };
+
+        /// Construct an EPS evaluator from a particular ECL result set.
+        ///
+        /// \param[in] G Connected topology of current model's active cells.
+        ///    Needed to linearise table end-points that may be distributed
+        ///    on local grids to all of the model's active cells (\code
+        ///    member function G.rawLinearisedCellData() \endcode).
+        ///
+        /// \param[in] init Container of tabulated saturation functions and
+        ///    saturation table end points for all active cells.
+        ///
+        /// \param[in] opt Options that identify a particular end-point
+        ///    scaling behaviour of a particular saturation function curve.
+        ///
+        /// \return EPS evaluator for the particular curve defined by the
+        ///    input options.
+        static std::unique_ptr<EPSEvalInterface>
+        fromECLOutput(const ECLGraph&        G,
+                      const ECLInitFileData& init,
+                      const EPSOptions&      opt);
+
+        /// Extract table end points relevant to a particular EPS evaluator
+        /// from raw tabulated saturation functions.
+        ///
+        /// \param[in] ep Collection of all raw table saturation end points
+        ///    for all tabulated saturation functions.  Typically computed
+        ///    by direct calls to the \code connateSat() \endcode, \code
+        ///    criticalSat() \endcode, and \code maximumSat() \endcode of
+        ///    the currently active \code Opm::SatFuncInterpolant \code
+        ///    objects.
+        ///
+        /// \param[in] opt Options that identify a particular end-point
+        ///    scaling behaviour of a particular saturation function curve.
+        ///
+        /// \return Subset of the input end points in a format intended for
+        ///    passing as the first argument of member function \code eval()
+        ///    \endcode of the \code EPSEvalInterface \endcode that
+        ///    corresponds to the input options.
+        static std::vector<EPSEvalInterface::TableEndPoints>
+        unscaledEndPoints(const RawTableEndPoints& ep,
+                          const EPSOptions&        opt);
+    };
+}} // namespace Opm::SatFunc
+
+#endif // OPM_ECLENDPOINTSCALING_HEADER_INCLUDED

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -42,7 +42,7 @@ namespace Opm
 
     std::vector<double>
     ECLFluxCalc::flux(const ECLRestartData& rstrt,
-                      const ECLOutput::PhaseIndex phase) const
+                      const ECLPhaseIndex         phase) const
     {
         // Obtain dynamic data.
         DynamicData dyn_data;

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -38,7 +38,7 @@ namespace Opm
 
     std::vector<double>
     ECLFluxCalc::flux(const ECLRestartData& rstrt,
-                      const PhaseIndex /* phase */) const
+                      const ECLOutput::PhaseIndex /* phase */) const
     {
         // Obtain dynamic data.
         DynamicData dyn_data;

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -74,8 +74,11 @@ namespace Opm
         const double transmissibility = transmissibility_[connection];
         const double viscosity = 1.0 * prefix::centi * unit::Poise;
         const auto& pressure = dyn_data.pressure;
-        const double avg_kr = (dyn_data.relperm[c1] + dyn_data.relperm[c2]) / 2.0;
-        const double mobility = avg_kr / viscosity;
+
+        const int upwind_cell = (pressure[c2] > pressure[c1]) ? c2 : c1;
+        const double kr = dyn_data.relperm[upwind_cell];
+
+        const double mobility = kr / viscosity;
         return mobility * transmissibility * (pressure[c1] - pressure[c2]);
     }
 

--- a/opm/utility/ECLFluxCalc.hpp
+++ b/opm/utility/ECLFluxCalc.hpp
@@ -43,14 +43,17 @@ namespace Opm
         /// Retrive phase flux on all connections defined by \code
         /// graph.neighbours() \endcode.
         ///
+        /// \param[in] rstrt ECL Restart data set from which to extract
+        ///            relevant data per cell.
+        ///
         /// \param[in] phase Canonical phase for which to retrive flux.
         ///
         /// \return Flux values corresponding to selected phase.
         ///         Empty if required data is missing.
         ///         Numerical values in SI units (rm^3/s).
         std::vector<double>
-        flux(const ECLRestartData&       rstrt,
-             const ECLOutput::PhaseIndex phase) const;
+        flux(const ECLRestartData& rstrt,
+             const ECLPhaseIndex   phase) const;
 
     private:
         struct DynamicData

--- a/opm/utility/ECLFluxCalc.hpp
+++ b/opm/utility/ECLFluxCalc.hpp
@@ -21,6 +21,8 @@
 #define OPM_ECLFLUXCALC_HEADER_INCLUDED
 
 #include <opm/utility/ECLGraph.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
+
 #include <vector>
 
 namespace Opm
@@ -36,8 +38,6 @@ namespace Opm
         /// \param[in] graph Connectivity data, as well as providing a means to read data from the restart file.
         explicit ECLFluxCalc(const ECLGraph& graph);
 
-        using PhaseIndex = ECLGraph::PhaseIndex;
-
         /// Retrive phase flux on all connections defined by \code
         /// graph.neighbours() \endcode.
         ///
@@ -47,8 +47,8 @@ namespace Opm
         ///         Empty if required data is missing.
         ///         Numerical values in SI units (rm^3/s).
         std::vector<double>
-        flux(const ECLRestartData& rstrt,
-             const PhaseIndex      phase) const;
+        flux(const ECLRestartData&       rstrt,
+             const ECLOutput::PhaseIndex phase) const;
 
     private:
         struct DynamicData

--- a/opm/utility/ECLFluxCalc.hpp
+++ b/opm/utility/ECLFluxCalc.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/utility/ECLGraph.hpp>
 #include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLSaturationFunc.hpp>
 
 #include <vector>
 
@@ -36,7 +37,8 @@ namespace Opm
         /// Construct from ECLGraph.
         ///
         /// \param[in] graph Connectivity data, as well as providing a means to read data from the restart file.
-        explicit ECLFluxCalc(const ECLGraph& graph);
+        explicit ECLFluxCalc(const ECLGraph&     graph,
+                             ECLSaturationFunc&& satfunc);
 
         /// Retrive phase flux on all connections defined by \code
         /// graph.neighbours() \endcode.
@@ -54,12 +56,14 @@ namespace Opm
         struct DynamicData
         {
             std::vector<double> pressure;
+            std::vector<double> relperm;
         };
 
         double singleFlux(const int connection,
                           const DynamicData& dyn_data) const;
 
         const ECLGraph& graph_;
+        ECLSaturationFunc satfunc_;
         std::vector<int> neighbours_;
         std::vector<double> transmissibility_;
     };

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1278,7 +1278,7 @@ public:
     ///
     /// Mostly useful to determine the set of \c PhaseIndex values for which
     /// flux() may return non-zero values.
-    const std::vector<ECLOutput::PhaseIndex>& activePhases() const;
+    const std::vector<ECLPhaseIndex>& activePhases() const;
 
     /// Retrieve the simulation scenario's set of active grids.
     ///
@@ -1321,8 +1321,8 @@ public:
     /// reported due to report frequencies or no flux values are output at
     /// all).
     std::vector<double>
-    flux(const ECLRestartData&       rstrt,
-         const ECLOutput::PhaseIndex phase) const;
+    flux(const ECLRestartData& rstrt,
+         const ECLPhaseIndex   phase) const;
 
     /// Retrieve result set vector from current view linearised on active
     /// cells.
@@ -1609,7 +1609,7 @@ private:
     /// Set of active phases in result set.  Derived from .INIT on the
     /// assumption that the set of active phases does not change throughout
     /// the simulation run.
-    std::vector<ECLOutput::PhaseIndex> activePhases_;
+    std::vector<ECLPhaseIndex> activePhases_;
 
     /// Set of active grids in result set.
     std::vector<std::string> activeGrids_;
@@ -1639,7 +1639,7 @@ private:
     /// \return Basename for ECl vector corresponding to particular phase
     /// flux.
     std::string
-    flowVector(const ECLOutput::PhaseIndex phase) const;
+    flowVector(const ECLPhaseIndex phase) const;
 
     /// Extract flux values corresponding to particular result set vector
     /// for all identified non-neighbouring connections.
@@ -1940,7 +1940,7 @@ Opm::ECLGraph::Impl::numConnections() const
     return nconn + this->nnc_.numConnections();
 }
 
-const std::vector<Opm::ECLOutput::PhaseIndex>&
+const std::vector<Opm::ECLPhaseIndex>&
 Opm::ECLGraph::Impl::activePhases() const
 {
     return this->activePhases_;
@@ -2027,8 +2027,8 @@ Opm::ECLGraph::Impl::transmissibility() const
 }
 
 std::vector<double>
-Opm::ECLGraph::Impl::flux(const ECLRestartData&       rstrt,
-                          const ECLOutput::PhaseIndex phase) const
+Opm::ECLGraph::Impl::flux(const ECLRestartData& rstrt,
+                          const ECLPhaseIndex   phase) const
 {
     auto fluxUnit = [&rstrt](const std::string& gridID)
     {
@@ -2226,12 +2226,12 @@ defineActivePhases(const ::Opm::ECLInitFileData& init)
     const auto phaseMask =
         static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
 
-    using Check = std::pair<ECLOutput::PhaseIndex, unsigned int>;
+    using Check = std::pair<ECLPhaseIndex, unsigned int>;
 
     const auto allPhases = std::vector<Check> {
-        { ECLOutput::PhaseIndex::Aqua  , (1u << 1) },
-        { ECLOutput::PhaseIndex::Liquid, (1u << 0) },
-        { ECLOutput::PhaseIndex::Vapour, (1u << 2) },
+        { ECLPhaseIndex::Aqua  , (1u << 1) },
+        { ECLPhaseIndex::Liquid, (1u << 0) },
+        { ECLPhaseIndex::Vapour, (1u << 2) },
     };
 
     this->activePhases_.clear();
@@ -2243,19 +2243,19 @@ defineActivePhases(const ::Opm::ECLInitFileData& init)
 }
 
 std::string
-Opm::ECLGraph::Impl::flowVector(const ECLOutput::PhaseIndex phase) const
+Opm::ECLGraph::Impl::flowVector(const ECLPhaseIndex phase) const
 {
     const auto vector = std::string("FLR"); // Flow-rate, reservoir
 
-    if (phase == ECLOutput::PhaseIndex::Aqua) {
+    if (phase == ECLPhaseIndex::Aqua) {
         return vector + "WAT";
     }
 
-    if (phase == ECLOutput::PhaseIndex::Liquid) {
+    if (phase == ECLPhaseIndex::Liquid) {
         return vector + "OIL";
     }
 
-    if (phase == ECLOutput::PhaseIndex::Vapour) {
+    if (phase == ECLPhaseIndex::Vapour) {
         return vector + "GAS";
     }
 
@@ -2322,7 +2322,7 @@ std::size_t Opm::ECLGraph::numConnections() const
     return this->pImpl_->numConnections();
 }
 
-const std::vector<Opm::ECLOutput::PhaseIndex>&
+const std::vector<Opm::ECLPhaseIndex        >&
 Opm::ECLGraph::activePhases() const
 {
     return this->pImpl_->activePhases();
@@ -2350,8 +2350,8 @@ std::vector<double> Opm::ECLGraph::transmissibility() const
 }
 
 std::vector<double>
-Opm::ECLGraph::flux(const ECLRestartData&       rstrt,
-                    const ECLOutput::PhaseIndex phase) const
+Opm::ECLGraph::flux(const ECLRestartData& rstrt,
+                    const ECLPhaseIndex   phase) const
 {
     return this->pImpl_->flux(rstrt, phase);
 }

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -1278,7 +1278,7 @@ public:
     ///
     /// Mostly useful to determine the set of \c PhaseIndex values for which
     /// flux() may return non-zero values.
-    const std::vector<PhaseIndex>& activePhases() const;
+    const std::vector<ECLOutput::PhaseIndex>& activePhases() const;
 
     /// Retrieve the simulation scenario's set of active grids.
     ///
@@ -1321,8 +1321,8 @@ public:
     /// reported due to report frequencies or no flux values are output at
     /// all).
     std::vector<double>
-    flux(const ECLRestartData& rstrt,
-         const PhaseIndex      phase) const;
+    flux(const ECLRestartData&       rstrt,
+         const ECLOutput::PhaseIndex phase) const;
 
     /// Retrieve result set vector from current view linearised on active
     /// cells.
@@ -1609,7 +1609,7 @@ private:
     /// Set of active phases in result set.  Derived from .INIT on the
     /// assumption that the set of active phases does not change throughout
     /// the simulation run.
-    std::vector<PhaseIndex> activePhases_;
+    std::vector<ECLOutput::PhaseIndex> activePhases_;
 
     /// Set of active grids in result set.
     std::vector<std::string> activeGrids_;
@@ -1639,7 +1639,7 @@ private:
     /// \return Basename for ECl vector corresponding to particular phase
     /// flux.
     std::string
-    flowVector(const PhaseIndex phase) const;
+    flowVector(const ECLOutput::PhaseIndex phase) const;
 
     /// Extract flux values corresponding to particular result set vector
     /// for all identified non-neighbouring connections.
@@ -1940,7 +1940,7 @@ Opm::ECLGraph::Impl::numConnections() const
     return nconn + this->nnc_.numConnections();
 }
 
-const std::vector<Opm::ECLGraph::PhaseIndex>&
+const std::vector<Opm::ECLOutput::PhaseIndex>&
 Opm::ECLGraph::Impl::activePhases() const
 {
     return this->activePhases_;
@@ -2027,8 +2027,8 @@ Opm::ECLGraph::Impl::transmissibility() const
 }
 
 std::vector<double>
-Opm::ECLGraph::Impl::flux(const ECLRestartData& rstrt,
-                          const PhaseIndex      phase) const
+Opm::ECLGraph::Impl::flux(const ECLRestartData&       rstrt,
+                          const ECLOutput::PhaseIndex phase) const
 {
     auto fluxUnit = [&rstrt](const std::string& gridID)
     {
@@ -2226,12 +2226,12 @@ defineActivePhases(const ::Opm::ECLInitFileData& init)
     const auto phaseMask =
         static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
 
-    using Check = std::pair<PhaseIndex, unsigned int>;
+    using Check = std::pair<ECLOutput::PhaseIndex, unsigned int>;
 
     const auto allPhases = std::vector<Check> {
-        { PhaseIndex::Aqua  , (1u << 1) },
-        { PhaseIndex::Liquid, (1u << 0) },
-        { PhaseIndex::Vapour, (1u << 2) },
+        { ECLOutput::PhaseIndex::Aqua  , (1u << 1) },
+        { ECLOutput::PhaseIndex::Liquid, (1u << 0) },
+        { ECLOutput::PhaseIndex::Vapour, (1u << 2) },
     };
 
     this->activePhases_.clear();
@@ -2243,19 +2243,19 @@ defineActivePhases(const ::Opm::ECLInitFileData& init)
 }
 
 std::string
-Opm::ECLGraph::Impl::flowVector(const PhaseIndex phase) const
+Opm::ECLGraph::Impl::flowVector(const ECLOutput::PhaseIndex phase) const
 {
     const auto vector = std::string("FLR"); // Flow-rate, reservoir
 
-    if (phase == PhaseIndex::Aqua) {
+    if (phase == ECLOutput::PhaseIndex::Aqua) {
         return vector + "WAT";
     }
 
-    if (phase == PhaseIndex::Liquid) {
+    if (phase == ECLOutput::PhaseIndex::Liquid) {
         return vector + "OIL";
     }
 
-    if (phase == PhaseIndex::Vapour) {
+    if (phase == ECLOutput::PhaseIndex::Vapour) {
         return vector + "GAS";
     }
 
@@ -2322,7 +2322,7 @@ std::size_t Opm::ECLGraph::numConnections() const
     return this->pImpl_->numConnections();
 }
 
-const std::vector<Opm::ECLGraph::PhaseIndex>&
+const std::vector<Opm::ECLOutput::PhaseIndex>&
 Opm::ECLGraph::activePhases() const
 {
     return this->pImpl_->activePhases();
@@ -2350,8 +2350,8 @@ std::vector<double> Opm::ECLGraph::transmissibility() const
 }
 
 std::vector<double>
-Opm::ECLGraph::flux(const ECLRestartData& rstrt,
-                    const PhaseIndex      phase) const
+Opm::ECLGraph::flux(const ECLRestartData&       rstrt,
+                    const ECLOutput::PhaseIndex phase) const
 {
     return this->pImpl_->flux(rstrt, phase);
 }

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -123,7 +123,7 @@ namespace Opm {
         ///
         /// Mostly useful to determine the set of \c PhaseIndex values for
         /// which flux() will return non-zero values if data available.
-        const std::vector<ECLOutput::PhaseIndex>& activePhases() const;
+        const std::vector<ECLPhaseIndex>& activePhases() const;
 
         /// Retrieve the simulation scenario's set of active grids.
         ///
@@ -164,8 +164,8 @@ namespace Opm {
         ///    output to the restart file).  Numerical values in SI units
         ///    (rm^3/s).
         std::vector<double>
-        flux(const ECLRestartData&       rstrt,
-             const ECLOutput::PhaseIndex phase) const;
+        flux(const ECLRestartData& rstrt,
+             const ECLPhaseIndex   phase) const;
 
         /// Retrieve result set vector from current view (e.g., particular
         /// report step) linearised on active cells.

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_ECLGRAPH_HEADER_INCLUDED
 #define OPM_ECLGRAPH_HEADER_INCLUDED
 
+#include <opm/utility/ECLPhaseIndex.hpp>
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
@@ -45,9 +46,6 @@ namespace Opm {
     class ECLGraph
     {
     public:
-        /// Enum for indicating requested phase from the flux() method.
-        enum class PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
-
         /// Disabled default constructor.
         ECLGraph() = delete;
 
@@ -125,7 +123,7 @@ namespace Opm {
         ///
         /// Mostly useful to determine the set of \c PhaseIndex values for
         /// which flux() will return non-zero values if data available.
-        const std::vector<PhaseIndex>& activePhases() const;
+        const std::vector<ECLOutput::PhaseIndex>& activePhases() const;
 
         /// Retrieve the simulation scenario's set of active grids.
         ///
@@ -166,8 +164,8 @@ namespace Opm {
         ///    output to the restart file).  Numerical values in SI units
         ///    (rm^3/s).
         std::vector<double>
-        flux(const ECLRestartData& rstrt,
-             const PhaseIndex      phase) const;
+        flux(const ECLRestartData&       rstrt,
+             const ECLOutput::PhaseIndex phase) const;
 
         /// Retrieve result set vector from current view (e.g., particular
         /// report step) linearised on active cells.

--- a/opm/utility/ECLPhaseIndex.hpp
+++ b/opm/utility/ECLPhaseIndex.hpp
@@ -1,0 +1,32 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPHASEINDEX_HEADER_INCLUDED
+#define OPM_ECLPHASEINDEX_HEADER_INCLUDED
+
+namespace Opm { namespace ECLOutput {
+
+    /// Enum for indicating the phase--or set of phases--on which to apply a
+    /// phase-dependent operation (e.g., extracting flux data from a result
+    /// set or computing relative permeabilities from tabulated functions).
+    enum class PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
+
+}} // namespace Opm::ECLOutput
+
+#endif // OPM_ECLPHASEINDEX_HEADER_INCLUDED

--- a/opm/utility/ECLPhaseIndex.hpp
+++ b/opm/utility/ECLPhaseIndex.hpp
@@ -20,13 +20,13 @@
 #ifndef OPM_ECLPHASEINDEX_HEADER_INCLUDED
 #define OPM_ECLPHASEINDEX_HEADER_INCLUDED
 
-namespace Opm { namespace ECLOutput {
+namespace Opm {
 
     /// Enum for indicating the phase--or set of phases--on which to apply a
     /// phase-dependent operation (e.g., extracting flux data from a result
     /// set or computing relative permeabilities from tabulated functions).
-    enum class PhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
+    enum class ECLPhaseIndex { Aqua = 0, Liquid = 1, Vapour = 2 };
 
-}} // namespace Opm::ECLOutput
+} // namespace Opm
 
 #endif // OPM_ECLPHASEINDEX_HEADER_INCLUDED

--- a/opm/utility/ECLPropTable.cpp
+++ b/opm/utility/ECLPropTable.cpp
@@ -1,0 +1,221 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLPropTable.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <iterator>
+#include <stdexcept>
+#include <utility>
+
+Opm::ECLPropTable1D::SingleTable::
+SingleTable(ElmIt               xBegin,
+            ElmIt               xEnd,
+            std::vector<ElmIt>& colIt)
+{
+    // There must be at least one dependent variable/result variable.
+    assert (colIt.size() >= 1);
+
+    const auto nRows = std::distance(xBegin, xEnd);
+
+    this->x_.reserve(nRows);
+    this->y_.reserve(nRows * colIt.size());
+
+    auto keyValid = [](const double xi)
+    {
+        // Indep. variable values <= -1.0e20 or >= 1.0e20 signal "unused"
+        // table nodes (rows).  These nodes are in the table to fill out the
+        // allocated size if one particular sub-table does not use all
+        // nodes.  The magic value 1.0e20 is documented in the Fileformats
+        // Reference Manual.
+        return std::abs(xi) < 1.0e20;
+    };
+
+    while (xBegin != xEnd) {
+        // Extract relevant portion of the table.  Preallocated rows that
+        // are not actually part of the result set (i.e., those that are set
+        // to a sentinel value) are discarded.
+        if (keyValid(*xBegin)) {
+            this->x_.push_back(*xBegin);
+
+            for (auto ci : colIt) {
+                // Store 'y_' with column index cycling most rapidly.
+                this->y_.push_back(*ci);
+            }
+        }
+
+        // -------------------------------------------------------------
+        // Advance iterators.
+
+        // 1) Independent variable.
+        ++xBegin;
+
+        // 2) Dependent/result/columns.
+        for (auto& ci : colIt) {
+            ++ci;
+        }
+    }
+
+    // Dispose of any excess capacity.
+    if (this->x_.size() < static_cast<decltype(this->x_.size())>(nRows)) {
+        this->x_.shrink_to_fit();
+        this->y_.shrink_to_fit();
+    }
+
+    if (this->x_.size() < 2) {
+        // Table has no interval that supports interpolation.  Either just a
+        // single node or no nodes at all.  We can't do anything useful
+        // here, so don't pretend that this is okay.
+
+        throw std::invalid_argument {
+            "No Interpolation Intervals of Non-Zero Size"
+        };
+    }
+}
+
+double
+Opm::ECLPropTable1D::SingleTable::
+y(const ECLPropTableRawData::SizeType nCols,
+  const ECLPropTableRawData::SizeType row,
+  const ResultColumn&                 c) const
+{
+    assert (row * nCols < this->y_.size());
+    assert (c.i < nCols);
+
+    // Recall: 'y_' stored with column index cycling the most rapidly (row
+    // major ordering).
+    return this->y_[row*nCols + c.i];
+}
+
+std::vector<double>
+Opm::ECLPropTable1D::SingleTable::
+interpolate(const ECLPropTableRawData::SizeType nCols,
+            const ResultColumn&                 c,
+            const std::vector<double>&          x) const
+{
+    auto y = std::vector<double>{};  y.reserve(x.size());
+
+    auto yval = [nCols, c, this]
+        (const ECLPropTableRawData::SizeType i)
+    {
+        return this->y(nCols, i, c);
+    };
+
+    const auto first = ECLPropTableRawData::SizeType{ 0 };
+    const auto last  = ECLPropTableRawData::SizeType{ this->x_.size() - 1 };
+
+    for (const auto& xi : x) {
+        y.push_back(0.0);
+        auto& yi = y.back();
+
+        if (! (xi > this->x_.front())) {
+            // Constant extrapolation to the left of range.
+            yi = yval(first);
+        }
+        else if (! (xi < this->x_.back())) {
+            // Constant extrapolation to the right of range.
+            yi = yval(last);
+        }
+        else {
+            // Somewhere in [min(x_), max(x_)].  Primary key (indep. var) is
+            // sorted range.  Recall: lower_bound() returns insertion point,
+            // which translates to the *upper* (right-hand) end-point of the
+            // interval in this context.
+            auto b = std::begin(this->x_);
+            auto p = std::lower_bound(b, std::end(this->x_), xi);
+
+            assert ((p != b) && "Logic Error Left End-Point");
+            assert ((p != std::end(this->x_)) &&
+                    "Logic Error Right End-Point");
+
+            const auto i  = p - b;
+            const auto xl = this->x_[i - 1];
+            const auto yl = yval(i - 1);
+            const auto yr = yval(i + 0);
+
+            const auto t = (xi - xl) / (this->x_[i + 0] - xl);
+
+            yi = (1.0 - t)*yl + t*yr;
+        }
+    }
+
+    return y;
+}
+
+// =====================================================================
+
+Opm::ECLPropTable1D::ECLPropTable1D(const ECLPropTableRawData& raw)
+    : nResCols_(raw.numCols - 1)
+{
+    if (raw.numCols < 2) {
+        throw std::invalid_argument {
+            "Malformed Property Table"
+        };
+    }
+
+    this->table_.reserve(raw.numTables);
+
+    // Table format: numRows*numTables values of first column (indep. var)
+    // followed by numCols-1 dependent variable (function value result)
+    // columns of numRows*numTables values each, one column at a time.
+    const auto colStride = raw.numRows * raw.numTables;
+
+    // Position
+    auto xBegin = std::begin(raw.data);
+    auto colIt  = std::vector<decltype(xBegin)>{ xBegin + colStride };
+    for (auto col = 0*raw.numCols + 1; col < raw.numCols - 1; ++col) {
+        colIt.push_back(colIt.back() + colStride);
+    }
+
+    for (auto t = 0*raw.numTables;
+              t <   raw.numTables;
+         ++t, xBegin += raw.numRows)
+    {
+        auto xEnd = xBegin + raw.numRows;
+
+        // Note: The SingleTable ctor advances each 'colIt' across numRows
+        // entries.  That is a bit of a layering violation, but helps in the
+        // implementation of this loop.
+        this->table_.push_back(SingleTable(xBegin, xEnd, colIt));
+    }
+}
+
+std::vector<double>
+Opm::ECLPropTable1D::interpolate(const InTable&             t,
+                                 const ResultColumn&        c,
+                                 const std::vector<double>& x) const
+{
+    if (t.i >= this->table_.size()) {
+        throw std::invalid_argument {
+            "Invalid Table ID"
+        };
+    }
+
+    if (c.i >= this->nResCols_) {
+        throw std::invalid_argument {
+            "Invalid Result Column ID"
+        };
+    }
+
+    return this->table_[t.i].interpolate(this->nResCols_, c, x);
+}

--- a/opm/utility/ECLPropTable.hpp
+++ b/opm/utility/ECLPropTable.hpp
@@ -1,5 +1,4 @@
 /*
-  Copyright 2017 SINTEF ICT, Applied Mathematics.
   Copyright 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
@@ -61,13 +60,13 @@ namespace Opm {
 
     /// Collection of 1D interpolants from tabulated functions (e.g., the
     /// saturation functions).
-    class ECLPropTable1D
+    class SatFuncInterpolant
     {
     public:
         /// Constructor.
         ///
         /// \param[in] raw Raw table data for this collection.
-        explicit ECLPropTable1D(const ECLPropTableRawData& raw);
+        explicit SatFuncInterpolant(const ECLPropTableRawData& raw);
 
         /// Wrapper type to disambiguate API usage.  Represents a table ID.
         struct InTable {
@@ -96,6 +95,16 @@ namespace Opm {
                     const ResultColumn&        c,
                     const std::vector<double>& x) const;
 
+        /// Retrieve connate saturation from all tables.
+        std::vector<double> connateSat() const;
+
+        /// Retrieve critical saturation for particular result column in all
+        /// tables.
+        std::vector<double> criticalSat(const ResultColumn& c) const;
+
+        /// Retrieve maximum saturation in all tables.
+        std::vector<double> maximumSat() const;
+
     private:
         /// Single tabulated 1D interpolant.
         class SingleTable
@@ -105,12 +114,18 @@ namespace Opm {
 
             /// Constructor.
             ///
-            /// \param[in] tBegin Beginning (initial element) of a single
-            ///    table.
+            /// \param[in] xBegin Beginning (initial element) of linar range
+            ///    of independent variable values.
             ///
-            /// \param[in] nRows Number of allocated table rows.
+            /// \param[in] xEnd One past the end of linear range of
+            ///    independent variable values.
             ///
-            /// \param[in] nCols Number of table columns.
+            /// \param[in,out] colIt Dependent/column range iterators.  On
+            ///    input, point to the beginnings of ranges of results
+            ///    pertinent to a single table.  On output, each iterator is
+            ///    advanced across all rows of the SingleTable (including
+            ///    sentinel/invalid nodes) which makes the pointers valid
+            ///    for the next table if relevant (and called in a loop).
             SingleTable(ElmIt               xBegin,
                         ElmIt               xEnd,
                         std::vector<ElmIt>& colIt);
@@ -129,6 +144,17 @@ namespace Opm {
             interpolate(const ECLPropTableRawData::SizeType nCols,
                         const ResultColumn&                 c,
                         const std::vector<double>&          x) const;
+
+            /// Retrieve connate saturation in table.
+            double connateSat() const;
+
+            /// Retrieve critical saturation for particular result column in
+            /// table.
+            double criticalSat(const ECLPropTableRawData::SizeType nCols,
+                               const ResultColumn&                 c) const;
+
+            /// Retrieve maximum saturation in table.
+            double maximumSat() const;
 
         private:
             /// Independent variable.

--- a/opm/utility/ECLPropTable.hpp
+++ b/opm/utility/ECLPropTable.hpp
@@ -1,0 +1,156 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPROPTABLE_HEADER_INCLUDED
+#define OPM_ECLPROPTABLE_HEADER_INCLUDED
+
+#include <vector>
+
+/// \file
+///
+/// ECL Tabulated Functions (e.g., saturation functions).
+
+namespace Opm {
+
+    /// Raw table data from which to construct collection of interpolants.
+    struct ECLPropTableRawData
+    {
+        /// Representation of the raw table data.  1D array with implicit
+        /// substructure.
+        using DataVector = std::vector<double>;
+
+        /// Size type for subsets of table data.
+        using SizeType = DataVector::size_type;
+
+        /// Iterator to table elements.  Must be random access.
+        using ElementIterator = DataVector::const_iterator;
+
+        /// Raw table data.  Column major (Fortran) order.  Typically
+        /// copied/extracted directly from TAB vector of INIT result-set.
+        DataVector data;
+
+        /// Number of rows allocated in the result set for each individual
+        /// table.  Typically corresponds to setting in one of the *DIMS
+        /// keywords.  Should normally be at least two.
+        SizeType numRows;
+
+        /// Number of columns in this table.  Varies by keyword/table.
+        SizeType numCols;
+
+        /// Number of tables of this type.  Must match the corresponding
+        /// region keyword.
+        SizeType numTables;
+    };
+
+    /// Collection of 1D interpolants from tabulated functions (e.g., the
+    /// saturation functions).
+    class ECLPropTable1D
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] raw Raw table data for this collection.
+        explicit ECLPropTable1D(const ECLPropTableRawData& raw);
+
+        /// Wrapper type to disambiguate API usage.  Represents a table ID.
+        struct InTable {
+            /// Table ID.
+            ECLPropTableRawData::SizeType i;
+        };
+
+        /// Wrapper type to disambiguate API usage.  Represents a column ID.
+        struct ResultColumn {
+            /// Column ID.
+            ECLPropTableRawData::SizeType i;
+        };
+
+        /// Evaluate 1D interpolant in sequence of points.
+        ///
+        /// \param[in] t ID of sub-table of interpolant.
+        ///
+        /// \param[in] c ID of result column/dependent variable.
+        ///
+        /// \param[in] x Points at which to evaluate interpolant.
+        ///
+        /// \return Function values of dependent variable \p c evaluated at
+        ///    points \p x in table \p t.
+        std::vector<double>
+        interpolate(const InTable&             t,
+                    const ResultColumn&        c,
+                    const std::vector<double>& x) const;
+
+    private:
+        /// Single tabulated 1D interpolant.
+        class SingleTable
+        {
+        public:
+            using ElmIt = ECLPropTableRawData::ElementIterator;
+
+            /// Constructor.
+            ///
+            /// \param[in] tBegin Beginning (initial element) of a single
+            ///    table.
+            ///
+            /// \param[in] nRows Number of allocated table rows.
+            ///
+            /// \param[in] nCols Number of table columns.
+            SingleTable(ElmIt               xBegin,
+                        ElmIt               xEnd,
+                        std::vector<ElmIt>& colIt);
+
+            /// Evaluate 1D interpolant in sequence of points.
+            ///
+            /// \param[in] nCols Number of table columns.
+            ///
+            /// \param[in] c ID of result column/dependent variable.
+            ///
+            /// \param[in] x Points at which to evaluate interpolant.
+            ///
+            /// \return Function values of dependent variable \p c evaluated
+            ///    at points \p x.
+            std::vector<double>
+            interpolate(const ECLPropTableRawData::SizeType nCols,
+                        const ResultColumn&                 c,
+                        const std::vector<double>&          x) const;
+
+        private:
+            /// Independent variable.
+            std::vector<double> x_;
+
+            /// Dependent variable (or variables).  Row major (i.e., C)
+            /// ordering.  Number of elements: x_.size() * host.nCols_.
+            std::vector<double> y_;
+
+            /// Value of dependent variable at position (row,c).
+            double y(const ECLPropTableRawData::SizeType nCols,
+                     const ECLPropTableRawData::SizeType row,
+                     const ResultColumn&                 c) const;
+        };
+
+        /// Number of result/dependent variables (== #table cols - 1).
+        ECLPropTableRawData::SizeType nResCols_;
+
+        /// Sequence of individual tables, indexed by *NUM-type vectors.
+        std::vector<SingleTable> table_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_ECLPROPTABLE_HEADER_INCLUDED

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -276,7 +276,7 @@ namespace Relperm {
                 return this->kroImpl(regID, so_g, sg, so_w, sw);
             }
 
-            virtual std::unique_ptr<KrFunction> clone() = 0;
+            virtual std::unique_ptr<KrFunction> clone() const = 0;
 
         protected:
             std::vector<double>
@@ -358,7 +358,7 @@ namespace Relperm {
                 , subsys_   (subsys)
             {}
 
-            virtual std::unique_ptr<KrFunction> clone()
+            virtual std::unique_ptr<KrFunction> clone() const override
             {
                 return std::unique_ptr<KrFunction>(new TwoPhase(*this));
             }
@@ -395,7 +395,7 @@ namespace Relperm {
                 , swco_     (std::move(swco))
             {}
 
-            virtual std::unique_ptr<KrFunction> clone()
+            virtual std::unique_ptr<KrFunction> clone() const override
             {
                 return std::unique_ptr<KrFunction>(new ECLStdThreePhase(*this));
             }

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -571,7 +571,7 @@ public:
     std::vector<double>
     relperm(const ECLGraph&             G,
             const ECLRestartData&       rstrt,
-            const ECLOutput::PhaseIndex p) const;
+            const ECLPhaseIndex         p) const;
 
 private:
     class EPSEvaluator
@@ -644,7 +644,7 @@ private:
     private:
         using Create = ::Opm::SatFunc::CreateEPS;
         using SSys   = ::Opm::SatFunc::CreateEPS::SubSystem;
-        using PhIdx  = ::Opm::ECLOutput::PhaseIndex;
+        using PhIdx  = ::Opm::ECLPhaseIndex;
 
         using EPSInterface = ::Opm::SatFunc::EPSEvalInterface;
         using EPSEndPts    = ::Opm::SatFunc::EPSEvalInterface::TableEndPoints;
@@ -1045,18 +1045,18 @@ Opm::ECLSaturationFunc::Impl::Impl(const Impl& rhs)
 
 std::vector<double>
 Opm::ECLSaturationFunc::Impl::
-relperm(const ECLGraph&             G,
-        const ECLRestartData&       rstrt,
-        const ECLOutput::PhaseIndex p) const
+relperm(const ECLGraph&       G,
+        const ECLRestartData& rstrt,
+        const ECLPhaseIndex   p) const
 {
     switch (p) {
-    case ECLOutput::PhaseIndex::Aqua:
+    case ECLPhaseIndex::Aqua:
         return this->krw(G, rstrt);
 
-    case ECLOutput::PhaseIndex::Liquid:
+    case ECLPhaseIndex::Liquid:
         return this->kro(G, rstrt);
 
-    case ECLOutput::PhaseIndex::Vapour:
+    case ECLPhaseIndex::Vapour:
         return this->krg(G, rstrt);
     }
 
@@ -1264,9 +1264,9 @@ Opm::ECLSaturationFunc::operator=(const ECLSaturationFunc& rhs)
 
 std::vector<double>
 Opm::ECLSaturationFunc::
-relperm(const ECLGraph&             G,
-        const ECLRestartData&       rstrt,
-        const ECLOutput::PhaseIndex p) const
+relperm(const ECLGraph&       G,
+        const ECLRestartData& rstrt,
+        const ECLPhaseIndex   p) const
 {
     return this->pImpl_->relperm(G, rstrt, p);
 }

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -1,0 +1,1274 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <opm/utility/ECLSaturationFunc.hpp>
+
+#include <opm/utility/ECLEndPointScaling.hpp>
+#include <opm/utility/ECLGraph.hpp>
+#include <opm/utility/ECLPropTable.hpp>
+#include <opm/utility/ECLResultData.hpp>
+
+#include <opm/utility/graph/AssembledConnections.hpp>
+#include <opm/utility/graph/AssembledConnectionsIteration.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <utility>
+
+#include <ert/ecl/ecl_kw_magic.h>
+
+namespace {
+    std::vector<double>
+    oil_saturation(const std::vector<double>&   sg,
+                   const std::vector<double>&   sw,
+                   const ::Opm::ECLGraph&       G,
+                   const ::Opm::ECLRestartData& rstrt)
+    {
+        auto so = G.rawLinearisedCellData<double>(rstrt, "SOIL");
+
+        if (so.size() == G.numCells()) {
+            // Use "SOIL" directly if available.
+            return so;
+        }
+
+        // SOIL vector not provided.  Compute from SWAT and/or SGAS.
+
+        so.assign(G.numCells(), 1.0);
+
+        auto adjust_So_for_other_phase =
+            [&so](const std::vector<double>& s)
+        {
+            std::transform(std::begin(so), std::end(so),
+                           std::begin(s) ,
+                           std::begin(so), std::minus<double>());
+        };
+
+        if (sg.size() == G.numCells()) {
+            adjust_So_for_other_phase(sg);
+        }
+
+        if (sw.size() == G.numCells()) {
+            adjust_So_for_other_phase(sw);
+        }
+
+        return so;
+    }
+} // Anonymous
+
+class RegionMapping
+{
+private:
+    using Map     = ::Opm::AssembledConnections;
+    using NeighIt = Map::Neighbours::const_iterator;
+    using MapIdx  = Map::Offset;
+
+public:
+    RegionMapping(const std::size_t       numCells,
+                  const std::vector<int>& regIdx);
+
+    using NeighRng = ::Opm::SimpleIteratorRange<NeighIt>;
+
+    MapIdx numRegions() const
+    {
+        return this->map_.numRows();
+    }
+
+    NeighRng cells(const MapIdx regId) const
+    {
+        assert (regId < this->numRegions());
+
+        const auto& start = this->map_.startPointers();
+        const auto& neigh = this->map_.neighbourhood();
+
+        auto b = std::begin(neigh) + start[regId + 0];
+        auto e = std::begin(neigh) + start[regId + 1];
+
+        return { b, e };
+    }
+
+private:
+    Opm::AssembledConnections map_;
+};
+
+RegionMapping::RegionMapping(const std::size_t       numCells,
+                             const std::vector<int>& regIdx)
+{
+    if (regIdx.empty()) {
+        // No explicit region mapping.  Put all active cells in single
+        // region (region ID 0).  This is somewhat roundabout since class
+        // AssembledConnections does not have a direct way of expressing
+        // this case.
+        const auto nc = static_cast<int>(numCells);
+
+        for (auto c = 0*nc; c < nc; ++c) {
+            this->map_.addConnection(0, c);
+        }
+
+        this->map_.compress(1);
+    }
+    else if (regIdx.size() != numCells) {
+        throw std::invalid_argument {
+            "Region Array Size Does Not "
+            "Match Number of Active Cells"
+        };
+    }
+    else {
+        // Caller provided explicit region mapping for all active cells.
+        // Assume that the region IDs themselves are one-based indices
+        // (e.g., SATNUM) and adjust accordingly.
+
+        auto maxReg = -1;
+        auto c      =  0;
+
+        for (const auto& regId : regIdx) {
+            const auto regId_0based = regId - 1;
+
+            this->map_.addConnection(regId_0based, c++);
+
+            if (regId_0based > maxReg) { maxReg = regId_0based; }
+        }
+
+        this->map_.compress(maxReg + 1);
+    }
+}
+
+// =====================================================================
+
+namespace Relperm {
+    namespace Gas {
+        namespace Details {
+            Opm::ECLPropTableRawData
+            tableData(const std::vector<int>&    tabdims,
+                      const std::vector<double>& tab);
+        }
+
+        class KrFunction
+        {
+        public:
+            KrFunction(const std::vector<int>&    tabdims,
+                       const std::vector<double>& tab)
+                : func_(Details::tableData(tabdims, tab))
+            {}
+
+            std::vector<double> sgco() const
+            {
+                return this->func_.connateSat();
+            }
+
+            std::vector<double> sgcr() const
+            {
+                return this->func_.criticalSat(this->krcol());
+            }
+
+            std::vector<double> sgmax() const
+            {
+                return this->func_.maximumSat();
+            }
+
+            std::vector<double>
+            krg(const std::size_t          regID,
+                const std::vector<double>& sg) const
+            {
+                const auto t = this->table(regID);
+                const auto c = this->krcol();
+
+                return this->func_.interpolate(t, c, sg);
+            }
+
+        private:
+            ::Opm::SatFuncInterpolant func_;
+
+            Opm::SatFuncInterpolant::InTable
+            table(const Opm::ECLPropTableRawData::SizeType regID) const
+            {
+                return ::Opm::SatFuncInterpolant::InTable{regID};
+            }
+
+            Opm::SatFuncInterpolant::ResultColumn krcol() const
+            {
+                return ::Opm::SatFuncInterpolant::ResultColumn{0};
+            }
+        };
+    } // namespace Gas
+
+    namespace Oil {
+        namespace Details {
+            Opm::ECLPropTableRawData
+            tableData(const std::vector<int>&    tabdims,
+                      const bool                 isTwoP,
+                      const std::vector<double>& tab);
+        } // namespace Details
+
+        class KrFunction
+        {
+        public:
+            KrFunction(const std::vector<int>&    tabdims,
+                       const bool                 isTwoP,
+                       const std::vector<double>& tab)
+                : func_(Details::tableData(tabdims, isTwoP, tab))
+                , twop_(isTwoP)
+            {}
+
+            virtual ~KrFunction() {}
+
+            std::vector<double> soco() const
+            {
+                return this->func_.connateSat();
+            }
+
+            std::vector<double> sogcr() const
+            {
+                return this->func_.criticalSat(this->gas_column());
+            }
+
+            std::vector<double> sowcr() const
+            {
+                return this->func_.criticalSat(this->wat_column());
+            }
+
+            std::vector<double> somax() const
+            {
+                return this->func_.maximumSat();
+            }
+
+            struct SGas {
+                std::vector<double> data;
+            };
+
+            struct SWat {
+                std::vector<double> data;
+            };
+
+            struct SOil {
+                std::vector<double> data;
+            };
+
+            std::vector<double>
+            kro(const std::size_t regID,
+                const SOil&       so_g,
+                const SGas&       sg,
+                const SOil&       so_w,
+                const SWat&       sw) const
+            {
+                return this->kroImpl(regID, so_g, sg, so_w, sw);
+            }
+
+        protected:
+            std::vector<double>
+            krog(const std::size_t          regID,
+                 const std::vector<double>& so) const
+            {
+                return this->eval(regID, this->gas_column(), so);
+            }
+
+            std::vector<double>
+            krow(const std::size_t          regID,
+                 const std::vector<double>& so) const
+            {
+                return this->eval(regID, this->wat_column(), so);
+            }
+
+        private:
+            using ResCol = ::Opm::SatFuncInterpolant::ResultColumn;
+
+            Opm::SatFuncInterpolant func_;
+            bool                    twop_;
+
+            Opm::SatFuncInterpolant::InTable
+            table(const Opm::ECLPropTableRawData::SizeType regID) const
+            {
+                return ::Opm::SatFuncInterpolant::InTable{regID};
+            }
+
+            ResCol gas_column() const
+            {
+                // Table format:
+                //
+                //    So kro          in two-phase runs
+                //    So krow krog    in three-phase runs
+                //
+                // Therefore kro(so) in the O/G subsystem is result column
+                // (dependent variable) zero in two-phase runs and result
+                // column 1 in three-phase runs.
+                const auto colID =
+                    static_cast<Opm::ECLPropTableRawData::SizeType>
+                    (this->twop_ ? 0 : 1);
+
+                return { colID };
+            }
+
+            ResCol wat_column() const
+            {
+                // Note: kro(so) in the O/W subsystem is dependent variable
+                // (result column) zero in two-phase runs and three-phase
+                // runs.
+                return ResCol{0};
+            }
+
+            std::vector<double>
+            eval(const std::size_t          regID,
+                 const ResCol               c,
+                 const std::vector<double>& so) const
+            {
+                return this->func_.interpolate(this->table(regID), c, so);
+            }
+
+            virtual std::vector<double>
+            kroImpl(const std::size_t regID,
+                    const SOil&       so_g,
+                    const SGas&       sg,
+                    const SOil&       so_w,
+                    const SWat&       sw) const = 0;
+        };
+
+        class TwoPhase : public KrFunction
+        {
+        public:
+            enum class SubSys { OilGas, OilWater };
+
+            TwoPhase(const SubSys               subsys,
+                     const std::vector<int>&    tabdims,
+                     const std::vector<double>& tab)
+                : KrFunction(tabdims, true, tab)
+                , subsys_   (subsys)
+            {}
+
+        private:
+            SubSys subsys_;
+
+            virtual std::vector<double>
+            kroImpl(const std::size_t regID,
+                    const SOil&       so_g,
+                    const SGas&    /* sg */,
+                    const SOil&       so_w,
+                    const SWat&    /* sw */) const override
+            {
+                switch (this->subsys_) {
+                case SubSys::OilGas:
+                    return this->krog(regID, so_g.data);
+
+                case SubSys::OilWater:
+                    return this->krow(regID, so_w.data);
+                }
+
+                return {};
+            }
+        };
+
+        class ECLStdThreePhase : public KrFunction
+        {
+        public:
+            ECLStdThreePhase(const std::vector<int>&    tabdims,
+                             const std::vector<double>& tab,
+                             std::vector<double>        swco)
+                : KrFunction(tabdims, false, tab)
+                , swco_     (std::move(swco))
+            {}
+
+        private:
+            std::vector<double> swco_;
+
+            virtual std::vector<double>
+            kroImpl(const std::size_t regID,
+                    const SOil&       so_g,
+                    const SGas&       sg,
+                    const SOil&       so_w,
+                    const SWat&       sw) const override
+            {
+                const auto kr_og = this->krog(regID, so_g.data);
+                const auto kr_ow = this->krow(regID, so_w.data);
+
+                const auto swco = this->swco_[regID];
+
+                auto kro = std::vector<double>{};
+                kro.reserve(sw.data.size());
+
+                for (auto n = sw.data.size(), i = 0*n; i < n; ++i) {
+                    const auto den = sg.data[i] + sw.data[i] - swco;
+
+                    const auto xg = sg.data[i] / den;
+                    const auto xw = (sw.data[i] + swco) / den;
+
+                    kro.push_back(xg*kr_og[i] + xw*kr_ow[i]);
+                }
+
+                return kro;
+            }
+        };
+    } // namespace Oil
+
+    namespace Water {
+        namespace Details {
+            Opm::ECLPropTableRawData
+            tableData(const std::vector<int>&    tabdims,
+                      const std::vector<double>& tab);
+        } // namespace Details
+
+        class KrFunction
+        {
+        public:
+            KrFunction(const std::vector<int>&    tabdims,
+                       const std::vector<double>& tab)
+                : func_(Details::tableData(tabdims, tab))
+            {}
+
+            std::vector<double> swco() const
+            {
+                return this->func_.connateSat();
+            }
+
+            std::vector<double> swcr() const
+            {
+                return this->func_.criticalSat(this->krcol());
+            }
+
+            std::vector<double> swmax() const
+            {
+                return this->func_.maximumSat();
+            }
+
+            std::vector<double>
+            krw(const std::size_t          regID,
+                const std::vector<double>& sw) const
+            {
+                const auto t = this->table(regID);
+                const auto c = this->krcol();
+
+                return this->func_.interpolate(t, c, sw);
+            }
+
+        private:
+            ::Opm::SatFuncInterpolant func_;
+
+            Opm::SatFuncInterpolant::InTable
+            table(const Opm::ECLPropTableRawData::SizeType regID) const
+            {
+                return ::Opm::SatFuncInterpolant::InTable{regID};
+            }
+
+            Opm::SatFuncInterpolant::ResultColumn krcol() const
+            {
+                return ::Opm::SatFuncInterpolant::ResultColumn{0};
+            }
+        };
+    } // namespace Water
+} // namespace Relperm
+
+Opm::ECLPropTableRawData
+Relperm::Gas::Details::tableData(const std::vector<int>&    tabdims,
+                                 const std::vector<double>& tab)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.numCols   = 3;            // Sg, Krg, Pcgo
+    t.numRows   = tabdims[ TABDIMS_NSSGFN_ITEM ];
+    t.numTables = tabdims[ TABDIMS_NTSGFN_ITEM ];
+
+    const auto nTabElems = t.numRows * t.numTables * t.numCols;
+
+    // Subtract one to account for offset being one-based index.
+    const auto start = tabdims[ TABDIMS_IBSGFN_OFFSET_ITEM ] - 1;
+
+    t.data.assign(&tab[start], &tab[start] + nTabElems);
+
+    return t;
+}
+
+Opm::ECLPropTableRawData
+Relperm::Oil::Details::tableData(const std::vector<int>&    tabdims,
+                                 const bool                 isTwoP,
+                                 const std::vector<double>& tab)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.numCols = isTwoP
+        ? 2                     // So, Kro
+        : 3;                    // So, Krow, Krog
+
+    t.numRows   = tabdims[ TABDIMS_NSSOFN_ITEM ];
+    t.numTables = tabdims[ TABDIMS_NTSOFN_ITEM ];
+
+    const auto nTabElems = t.numRows * t.numTables * t.numCols;
+
+    // Subtract one to account for offset being one-based index.
+    const auto start = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
+
+    t.data.assign(&tab[start], &tab[start] + nTabElems);
+
+    return t;
+}
+
+Opm::ECLPropTableRawData
+Relperm::Water::Details::tableData(const std::vector<int>&    tabdims,
+                                   const std::vector<double>& tab)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.numCols   = 3;            // Sw, Krw, Pcow
+    t.numRows   = tabdims[ TABDIMS_NSSWFN_ITEM ];
+    t.numTables = tabdims[ TABDIMS_NTSWFN_ITEM ];
+
+    const auto nTabElems = t.numRows * t.numTables * t.numCols;
+
+    // Subtract one to account for offset being one-based index.
+    const auto start = tabdims[ TABDIMS_IBSWFN_OFFSET_ITEM ] - 1;
+
+    t.data.assign(&tab[start], &tab[start] + nTabElems);
+
+    return t;
+}
+
+// =====================================================================
+
+class Opm::ECLSaturationFunc::Impl
+{
+public:
+    Impl(const ECLGraph&        G,
+         const ECLInitFileData& init);
+
+    Impl(Impl&& rhs);
+    Impl(const Impl& rhs);
+
+    void init(const ECLGraph&        G,
+              const ECLInitFileData& init,
+              const bool             useEPS);
+
+    std::vector<double>
+    relperm(const ECLGraph&             G,
+            const ECLRestartData&       rstrt,
+            const ECLOutput::PhaseIndex p) const;
+
+private:
+    class EPSEvaluator
+    {
+    public:
+        using RawTEP  = ::Opm::SatFunc::CreateEPS::RawTableEndPoints;
+        using FuncCat = ::Opm::SatFunc::CreateEPS::FunctionCategory;
+
+        struct ActPh
+        {
+            ActPh(const unsigned int iphs)
+                : oil((iphs & (1u << 0)) != 0)
+                , gas((iphs & (1u << 2)) != 0)
+                , wat((iphs & (1u << 1)) != 0)
+            {}
+
+            bool oil;
+            bool gas;
+            bool wat;
+        };
+
+        void define(const ECLGraph&        G,
+                    const ECLInitFileData& init,
+                    const RawTEP&          ep,
+                    const bool             use3PtScaling,
+                    const FuncCat          curve,
+                    const ActPh&           active)
+        {
+            auto opt = Create::EPSOptions{};
+            opt.use3PtScaling = use3PtScaling;
+            opt.curve         = curve;
+
+            if (active.oil) {
+                this->create_oil_eps(G, init, ep, active, opt);
+            }
+
+            if (active.gas) {
+                this->create_gas_eps(G, init, ep, opt);
+            }
+
+            if (active.wat) {
+                this->create_wat_eps(G, init, ep, opt);
+            }
+        }
+
+        void scaleOG(const RegionMapping& rmap,
+                     std::vector<double>& so) const
+        {
+            this->scale(this->oil_in_og_, rmap, so);
+        }
+
+        void scaleOW(const RegionMapping& rmap,
+                     std::vector<double>& so) const
+        {
+            this->scale(this->oil_in_ow_, rmap, so);
+        }
+
+        void scaleGas(const RegionMapping& rmap,
+                      std::vector<double>& sg) const
+        {
+            this->scale(this->gas_, rmap, sg);
+        }
+
+        void scaleWat(const RegionMapping& rmap,
+                      std::vector<double>& sw) const
+        {
+            this->scale(this->wat_, rmap, sw);
+        }
+
+    private:
+        using Create = ::Opm::SatFunc::CreateEPS;
+        using SSys   = ::Opm::SatFunc::CreateEPS::SubSystem;
+        using PhIdx  = ::Opm::ECLOutput::PhaseIndex;
+
+        using EPSInterface = ::Opm::SatFunc::EPSEvalInterface;
+        using EPSEndPts    = ::Opm::SatFunc::EPSEvalInterface::TableEndPoints;
+        using EPSEndPtVec  = std::vector<EPSEndPts>;
+
+        using EPSPtr    = std::unique_ptr<EPSInterface>;
+        using EndPtsPtr = std::unique_ptr<EPSEndPtVec>;
+
+        struct EPS {
+            EPS() {}
+
+            EPS(const EPS& rhs)
+            {
+                if (rhs.scaling) {
+                    this->scaling = rhs.scaling->clone();
+                }
+
+                if (rhs.tep) {
+                    this->tep = EndPtsPtr(new EPSEndPtVec(*rhs.tep));
+                }
+            }
+
+            EPS(EPS&& rhs)
+                : scaling(std::move(rhs.scaling))
+                , tep    (std::move(rhs.tep))
+            {}
+
+            EPS& operator=(const EPS& rhs)
+            {
+                if (rhs.scaling) {
+                    this->scaling = rhs.scaling->clone();
+                }
+
+                if (rhs.tep) {
+                    this->tep = EndPtsPtr(new EPSEndPtVec(*rhs.tep));
+                }
+
+                return *this;
+            }
+
+            EPS& operator=(EPS&& rhs)
+            {
+                this->scaling = std::move(rhs.scaling);
+                this->tep     = std::move(rhs.tep);
+
+                return *this;
+            }
+
+            EPSPtr    scaling;
+            EndPtsPtr tep;
+        };
+
+        EPS oil_in_og_;
+        EPS oil_in_ow_;
+        EPS gas_;
+        EPS wat_;
+
+        void scale(const EPS&           eps,
+                   const RegionMapping& rmap,
+                   std::vector<double>& s) const
+        {
+            if (! eps.scaling) {
+                // No end-point scaling defined for this curve.  Return
+                // unchanged.
+                return;
+            }
+
+            if (! eps.tep) {
+                throw std::logic_error {
+                    "Cannot Perform EPS in Absence of "
+                    "Table End-Point Data"
+                };
+            }
+
+            if (rmap.numRegions() == 1) {
+                this->scaleSingleRegion(eps, s);
+            }
+            else {
+                this->scaleMultiRegion(eps, rmap, s);
+            }
+        }
+
+        void scaleSingleRegion(const EPS& eps, std::vector<double>& s) const
+        {
+            assert (eps.tep->size() == 1);
+
+            using Assoc  = EPSInterface::SaturationAssoc;
+            using CellID = decltype(std::declval<Assoc>().cell);
+
+            auto sp = EPSInterface::SaturationPoints{};
+
+            sp.reserve(s.size());
+
+            auto cell = static_cast<CellID>(0);
+            for (const auto& si : s) {
+                sp.push_back(Assoc{ cell++, si });
+            }
+
+            s = eps.scaling->eval((*eps.tep)[0], sp);
+        }
+
+        void scaleMultiRegion(const EPS&           eps,
+                              const RegionMapping& rmap,
+                              std::vector<double>& s) const
+        {
+            const auto nreg = rmap.numRegions();
+
+            assert (eps.tep->size() == nreg);
+
+            using Assoc  = EPSInterface::SaturationAssoc;
+            using CellID = decltype(std::declval<Assoc>().cell);
+
+            for (auto reg = 0*nreg; reg < nreg; ++reg) {
+                auto sp = EPSInterface::SaturationPoints{};
+
+                for (const auto& cell : rmap.cells(reg)) {
+                    sp.push_back(Assoc{CellID(cell), s[cell]});
+                }
+
+                const auto& sr =
+                    eps.scaling->eval((*eps.tep)[reg], sp);
+
+                auto i = static_cast<decltype(sr.size())>(0);
+                for (const auto& cell : rmap.cells(reg)) {
+                    s[cell] = sr[i++];
+                }
+            }
+        }
+
+        void create_oil_eps(const ECLGraph&        G,
+                            const ECLInitFileData& init,
+                            const RawTEP&          ep,
+                            const ActPh&           active,
+                            Create::EPSOptions&    opt)
+        {
+            opt.thisPh = PhIdx::Liquid;
+
+            if (active.gas) {
+                opt.subSys = SSys::OilGas;
+
+                this->oil_in_og_.scaling =
+                    Create::fromECLOutput(G, init, opt);
+
+                this->oil_in_og_.tep = this->endPoints(ep, opt);
+            }
+
+            if (active.wat) {
+                opt.subSys = SSys::OilWater;
+
+                this->oil_in_ow_.scaling =
+                    Create::fromECLOutput(G, init, opt);
+
+                this->oil_in_ow_.tep = this->endPoints(ep, opt);
+            }
+        }
+
+        void create_gas_eps(const ECLGraph&        G,
+                            const ECLInitFileData& init,
+                            const RawTEP&          ep,
+                            Create::EPSOptions&    opt)
+        {
+            opt.thisPh = PhIdx::Vapour;
+            opt.subSys = SSys::OilGas;
+
+            this->gas_.scaling =
+                Create::fromECLOutput(G, init, opt);
+
+            this->gas_.tep = this->endPoints(ep, opt);
+        }
+
+        void create_wat_eps(const ECLGraph&        G,
+                            const ECLInitFileData& init,
+                            const RawTEP&          ep,
+                            Create::EPSOptions&    opt)
+        {
+            opt.thisPh = PhIdx::Aqua;
+            opt.subSys = SSys::OilWater;
+
+            this->wat_.scaling =
+                Create::fromECLOutput(G, init, opt);
+
+            this->wat_.tep = this->endPoints(ep, opt);
+        }
+
+        EndPtsPtr
+        endPoints(const RawTEP& ep, const Create::EPSOptions& opt)
+        {
+            return EndPtsPtr {
+                new EPSEndPtVec(Create::unscaledEndPoints(ep, opt))
+            };
+        }
+    };
+
+    using RegionID =
+        decltype(std::declval<RegionMapping>().numRegions());
+
+    RegionMapping rmap_;
+
+    std::unique_ptr<Relperm::Oil::KrFunction>   oil_;
+    std::unique_ptr<Relperm::Gas::KrFunction>   gas_;
+    std::unique_ptr<Relperm::Water::KrFunction> wat_;
+
+    std::unique_ptr<EPSEvaluator> eps_;
+
+    void initRelPermInterp(const EPSEvaluator::ActPh& active,
+                           const ECLInitFileData&     init);
+
+    void initEPS(const EPSEvaluator::ActPh& active,
+                 const bool                 use3PtScaling,
+                 const ECLGraph&            G,
+                 const ECLInitFileData&     init);
+
+    std::vector<double>
+    kro(const ECLGraph&       G,
+        const ECLRestartData& rstrt) const;
+
+    std::vector<double>
+    krg(const ECLGraph&       G,
+        const ECLRestartData& rstrt) const;
+
+    std::vector<double>
+    krw(const ECLGraph&       G,
+        const ECLRestartData& rstrt) const;
+
+    EPSEvaluator::RawTEP
+    extractRawTableEndPoints(const EPSEvaluator::ActPh& active) const;
+
+    template <typename T>
+    std::vector<T>
+    gatherRegionSubset(const RegionID        reg,
+                       const std::vector<T>& x) const
+    {
+        auto y = std::vector<T>{};
+
+        if (x.empty()) {
+            return y;
+        }
+
+        for (const auto& cell : this->rmap_.cells(reg)) {
+            y.push_back(x[cell]);
+        }
+
+        return y;
+    }
+
+    template <typename T>
+    void scatterRegionResults(const RegionID        reg,
+                              const std::vector<T>& x_reg,
+                              std::vector<T>&       x) const
+    {
+        auto i = static_cast<decltype(x_reg.size())>(0);
+
+        for (const auto& cell : this->rmap_.cells(reg)) {
+            x[cell] = x_reg[i++];
+        }
+    }
+
+    template <class RegionOperation>
+    void regionLoop(RegionOperation&& regOp) const
+    {
+        for (auto nreg = this->rmap_.numRegions(),
+                  reg  = 0*nreg; reg < nreg; ++reg)
+        {
+            regOp(reg);
+        }
+    }
+};
+
+Opm::ECLSaturationFunc::Impl::Impl(const ECLGraph&        G,
+                                   const ECLInitFileData& init)
+    : rmap_(G.numCells(), G.rawLinearisedCellData<int>(init, "SATNUM"))
+{
+}
+
+Opm::ECLSaturationFunc::Impl::Impl(Impl&& rhs)
+    : rmap_(std::move(rhs.rmap_))
+    , oil_ (std::move(rhs.oil_ ))
+    , gas_ (std::move(rhs.gas_ ))
+    , wat_ (std::move(rhs.wat_ ))
+{}
+
+// ---------------------------------------------------------------------
+
+void
+Opm::ECLSaturationFunc::Impl::init(const ECLGraph&        G,
+                                   const ECLInitFileData& init,
+                                   const bool             useEPS)
+{
+    // Extract INTEHEAD from main grid
+    const auto& ih   = init.keywordData<int>(INTEHEAD_KW);
+    const auto  iphs = static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
+
+    const auto active = EPSEvaluator::ActPh{iphs};
+
+    this->initRelPermInterp(active, init);
+
+    if (useEPS) {
+        const auto& lh = init.keywordData<bool>(LOGIHEAD_KW);
+
+        const auto haveEPS = static_cast<bool>(
+            lh[LOGIHEAD_ENDPOINT_SCALING_INDEX]);
+
+        if (haveEPS) {
+            const auto use3PtScaling = static_cast<bool>(
+                lh[LOGIHEAD_ALT_ENDPOINT_SCALING_INDEX]);
+
+            // Must be called *after* initRelPermInterp().
+            this->initEPS(active, use3PtScaling, G, init);
+        }
+    }
+}
+
+void
+Opm::ECLSaturationFunc::
+Impl::initRelPermInterp(const EPSEvaluator::ActPh& active,
+                        const ECLInitFileData&     init)
+{
+    const auto isThreePh =
+        active.oil && active.gas && active.wat;
+
+    // Extract tabular data from main grid
+    const auto& tabdims = init.keywordData<int>("TABDIMS");
+    const auto& tab     = init.keywordData<double>("TAB");
+
+    if (active.gas) {
+        this->gas_.reset(new Relperm::Gas::KrFunction(tabdims, tab));
+    }
+
+    if (active.wat) {
+        this->wat_.reset(new Relperm::Water::KrFunction(tabdims, tab));
+    }
+
+    if (active.oil) {
+        if (! isThreePh) {
+            using KrModel = Relperm::Oil::TwoPhase;
+
+            if (active.gas) {
+                const auto subsys = KrModel::SubSys::OilGas;
+
+                this->oil_.reset(new KrModel(subsys, tabdims, tab));
+            }
+            else if (active.wat) {
+                const auto subsys = KrModel::SubSys::OilWater;
+
+                this->oil_.reset(new KrModel(subsys, tabdims, tab));
+            }
+            else {
+                throw std::invalid_argument {
+                    "Single-Phase Oil System Not Supported"
+                };
+            }
+        }
+
+        if (isThreePh) {
+            using KrModel = Relperm::Oil::ECLStdThreePhase;
+
+            this->oil_.reset(new KrModel(tabdims, tab, this->wat_->swco()));
+        }
+    }
+}
+
+void Opm::ECLSaturationFunc::
+Impl::initEPS(const EPSEvaluator::ActPh& active,
+              const bool                 use3PtScaling,
+              const ECLGraph&            G,
+              const ECLInitFileData&     init)
+{
+    const auto ep = this->extractRawTableEndPoints(active);
+
+    const auto curve = ::Opm::SatFunc::CreateEPS::
+        FunctionCategory::Relperm;
+
+    this->eps_.reset(new EPSEvaluator());
+
+    this->eps_->define(G, init, ep, use3PtScaling, curve, active);
+}
+
+// #####################################################################
+
+// Copy Constructor.  Pay attention here, especially for the oil relperm
+// case.  Prefer move constructor if possible.
+Opm::ECLSaturationFunc::Impl::Impl(const Impl& rhs)
+    : rmap_(rhs.rmap_)
+{
+    if (rhs.oil_) {
+        // Now tread carefully.  Here be dragons.
+        using TwoP   = Relperm::Oil::TwoPhase;
+        using ThreeP = Relperm::Oil::ECLStdThreePhase;
+
+        const auto* kro = rhs.oil_.get();
+
+        if (auto* impl = dynamic_cast<const TwoP*>(kro)) {
+            // Two-phase run
+            this->oil_.reset(new TwoP(*impl));
+        }
+        else if (auto* impl = dynamic_cast<const ThreeP*>(kro)) {
+            // Three-phase run
+            this->oil_.reset(new ThreeP(*impl));
+        }
+    }
+
+    if (rhs.gas_) {
+        this->gas_.reset(new Relperm::Gas::KrFunction(*rhs.gas_));
+    }
+
+    if (rhs.wat_) {
+        this->wat_.reset(new Relperm::Water::KrFunction(*rhs.wat_));
+    }
+}
+
+// #####################################################################
+
+std::vector<double>
+Opm::ECLSaturationFunc::Impl::
+relperm(const ECLGraph&             G,
+        const ECLRestartData&       rstrt,
+        const ECLOutput::PhaseIndex p) const
+{
+    switch (p) {
+    case ECLOutput::PhaseIndex::Aqua:
+        return this->krw(G, rstrt);
+
+    case ECLOutput::PhaseIndex::Liquid:
+        return this->kro(G, rstrt);
+
+    case ECLOutput::PhaseIndex::Vapour:
+        return this->krg(G, rstrt);
+    }
+
+    return {};
+}
+
+std::vector<double>
+Opm::ECLSaturationFunc::Impl::
+kro(const ECLGraph&       G,
+    const ECLRestartData& rstrt) const
+{
+    auto kr = std::vector<double>{};
+
+    if (! this->oil_) {
+        return kr;
+    }
+
+    const auto& sg = G.rawLinearisedCellData<double>(rstrt, "SGAS");
+    const auto& sw = G.rawLinearisedCellData<double>(rstrt, "SWAT");
+
+    auto so_g = oil_saturation(sg, sw, G, rstrt);
+    auto so_w = so_g;
+
+    if (this->eps_) {
+        // Independent scaling of So in O/G and O/W sub-systems of an O/G/W
+        // run.  Performs duplicate work in a two-phase case.  Need to take
+        // action if this becomes a bottleneck.
+        this->eps_->scaleOG(this->rmap_, so_g);
+        this->eps_->scaleOW(this->rmap_, so_w);
+    }
+
+    // Allocate result.  Member function scatterRegionResult() depends on
+    // having an allocated result vector into which to write the values from
+    // a single region.
+    kr.resize(so_g.size(), 0.0);
+
+    // Compute relative permeability per region.
+    this->regionLoop([this, &so_g, &so_w, &sg, &sw, &kr]
+        (const RegionID reg)
+    {
+        const auto So_g = Relperm::Oil::KrFunction::SOil {
+            this->gatherRegionSubset(reg, so_g)
+        };
+
+        const auto So_w = Relperm::Oil::KrFunction::SOil {
+            this->gatherRegionSubset(reg, so_w)
+        };
+
+        const auto Sg = Relperm::Oil::KrFunction::SGas {
+            // Empty in case of Oil/Water system
+            this->gatherRegionSubset(reg, sg)
+        };
+
+        const auto Sw = Relperm::Oil::KrFunction::SWat {
+            // Empty in case of Oil/Gas system
+            this->gatherRegionSubset(reg, sw)
+        };
+
+        const auto& kro_reg =
+            this->oil_->kro(reg, So_g, Sg, So_w, Sw);
+
+        this->scatterRegionResults(reg, kro_reg, kr);
+    });
+
+    return kr;
+}
+
+std::vector<double>
+Opm::ECLSaturationFunc::Impl::
+krg(const ECLGraph&       G,
+    const ECLRestartData& rstrt) const
+{
+    auto kr = std::vector<double>{};
+
+    if (! this->gas_) {
+        return kr;
+    }
+
+    auto sg = G.rawLinearisedCellData<double>(rstrt, "SGAS");
+
+    if (this->eps_) {
+        this->eps_->scaleGas(this->rmap_, sg);
+    }
+
+    // Allocate result.  Member function scatterRegionResult() depends on
+    // having an allocated result vector into which to write the values from
+    // a single region.
+    kr.resize(sg.size(), 0.0);
+
+    // Compute relative permeability per region.
+    this->regionLoop([this, &sg, &kr](const RegionID reg)
+    {
+        const auto sg_reg = this->gatherRegionSubset(reg, sg);
+
+        const auto krg_reg =
+            this->gas_->krg(reg, sg_reg);
+
+        this->scatterRegionResults(reg, krg_reg, kr);
+    });
+
+    return kr;
+}
+
+std::vector<double>
+Opm::ECLSaturationFunc::Impl::
+krw(const ECLGraph&       G,
+    const ECLRestartData& rstrt) const
+{
+    auto kr = std::vector<double>{};
+
+    if (! this->wat_) {
+        return kr;
+    }
+
+    auto sw = G.rawLinearisedCellData<double>(rstrt, "SWAT");
+
+    if (this->eps_) {
+        this->eps_->scaleWat(this->rmap_, sw);
+    }
+
+    // Allocate result.  Member function scatterRegionResult() depends on
+    // having an allocated result vector into which to write the values from
+    // a single region.
+    kr.resize(sw.size(), 0.0);
+
+    // Compute relative permeability per region.
+    this->regionLoop([this, &sw, &kr](const RegionID reg)
+    {
+        const auto sw_reg = this->gatherRegionSubset(reg, sw);
+
+        const auto krw_reg =
+            this->wat_->krw(reg, sw_reg);
+
+        this->scatterRegionResults(reg, krw_reg, kr);
+    });
+
+    return kr;
+}
+
+Opm::ECLSaturationFunc::Impl::EPSEvaluator::RawTEP
+Opm::ECLSaturationFunc::Impl::
+extractRawTableEndPoints(const EPSEvaluator::ActPh& active) const
+{
+    auto ep = EPSEvaluator::RawTEP{};
+
+    if (active.oil) {
+        ep.conn.oil          = this->oil_->soco();
+        ep.crit.oil_in_gas   = this->oil_->sogcr();
+        ep.crit.oil_in_water = this->oil_->sowcr();
+        ep.smax.oil          = this->oil_->somax();
+    }
+
+    if (active.gas) {
+        ep.conn.gas = this->gas_->sgco();
+        ep.crit.gas = this->gas_->sgcr();
+        ep.smax.gas = this->gas_->sgmax();
+    }
+
+    if (active.wat) {
+        ep.conn.water = this->wat_->swco();
+        ep.crit.water = this->wat_->swcr();
+        ep.smax.water = this->wat_->swmax();
+    }
+
+    return ep;
+}
+
+// =====================================================================
+
+Opm::ECLSaturationFunc::
+ECLSaturationFunc(const ECLGraph&        G,
+                  const ECLInitFileData& init,
+                  const bool             useEPS)
+    : pImpl_(new Impl(G, init))
+{
+    this->pImpl_->init(G, init, useEPS);
+}
+
+Opm::ECLSaturationFunc::~ECLSaturationFunc()
+{}
+
+Opm::ECLSaturationFunc::ECLSaturationFunc(ECLSaturationFunc&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::ECLSaturationFunc::ECLSaturationFunc(const ECLSaturationFunc& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::ECLSaturationFunc&
+Opm::ECLSaturationFunc::operator=(ECLSaturationFunc&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+Opm::ECLSaturationFunc&
+Opm::ECLSaturationFunc::operator=(const ECLSaturationFunc& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+std::vector<double>
+Opm::ECLSaturationFunc::
+relperm(const ECLGraph&             G,
+        const ECLRestartData&       rstrt,
+        const ECLOutput::PhaseIndex p) const
+{
+    return this->pImpl_->relperm(G, rstrt, p);
+}

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -1,0 +1,139 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLSATURATIONFUNC_HEADER_INCLUDED
+#define OPM_ECLSATURATIONFUNC_HEADER_INCLUDED
+
+#include <opm/utility/ECLPhaseIndex.hpp>
+
+#include <memory>
+#include <vector>
+
+/// \file
+///
+/// Public interface to relative permeability evaluation machinery.  The
+/// back-end is aware of ECLIPSE's standard three-phase model for relative
+/// permeability of oil and the two- and three-point saturation end-point
+/// scaling options.  Vertical scaling of relative permeability is not
+/// supported at present.
+
+namespace Opm {
+    class ECLGraph;
+    class ECLRestartData;
+    class ECLInitFileData;
+
+    /// Gateway to engine for computing relative permeability values based
+    /// on tabulated saturation functions in ECL output.
+    class ECLSaturationFunc
+    {
+    public:
+        /// Constructor
+        ///
+        /// \param[in] G Connected topology of current model's active cells.
+        ///    Needed to linearise region mapping (e.g., SATNUM) that is
+        ///    distributed on local grids to all of the model's active cells
+        ///    (\code member function G.rawLinearisedCellData() \endcode).
+        ///
+        /// \param[in] init Container of tabulated saturation functions and
+        ///    saturation table end points, if applicable, for all active
+        ///    cells in the model \p G.
+        ///
+        /// \param[in] useEPS Whether or not to include effects of
+        ///    saturation end-point scaling.  No effect if the INIT result
+        ///    set does not actually include saturation end-point scaling
+        ///    data.  Otherwise, enables turning EPS off even if associate
+        ///    data is present in the INIT result set.
+        ///
+        ///    Default value (\c true) means that effects of EPS are
+        ///    included if requisite data is present in the INIT result.
+        ECLSaturationFunc(const ECLGraph&        G,
+                          const ECLInitFileData& init,
+                          const bool             useEPS = true);
+
+        /// Destructor.
+        ~ECLSaturationFunc();
+
+        /// Move constructor.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing engine for saturation function
+        ///    evaluation.  Does not have a valid implementation when the
+        ///    constructor completes.
+        ECLSaturationFunc(ECLSaturationFunc&& rhs);
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Existing engine for saturation function
+        ///    evaluation.
+        ECLSaturationFunc(const ECLSaturationFunc& rhs);
+
+        /// Move assignment operator.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing engine for saturation function
+        ///    evaluation.  Does not have a valid implementation when the
+        ///    constructor completes.
+        ///
+        /// \return \code *this \endcode.
+        ECLSaturationFunc& operator=(ECLSaturationFunc&& rhs);
+
+        /// Assignment operator.
+        ///
+        /// \param[in] rhs Existing engine for saturation function
+        ///    evaluation.
+        ///
+        /// \return \code *this \endcode.
+        ECLSaturationFunc& operator=(const ECLSaturationFunc& rhs);
+
+        /// Compute relative permeability values in all active cells for a
+        /// single phase.
+        ///
+        /// \param[in] G Connected topology of current model's active cells.
+        ///    Needed to linearise phase saturations (e.g., SOIL) that are
+        ///    distributed on local grids to all of the model's active cells
+        ///    (\code member function G.rawLinearisedCellData() \endcode).
+        ///
+        /// \param[in] rstrt ECLIPSE restart vectors.  Result set view
+        ///    assumed to be positioned at a particular report step of
+        ///    interest.
+        ///
+        /// \param[in] p Phase for which to compute relative permeability
+        ///    values.
+        ///
+        /// \return Derived relative permeability values of active phase \p
+        ///    p for all active cells in model \p G.  Empty if phase \p p is
+        ///    not actually active in the current result set.
+        std::vector<double>
+        relperm(const ECLGraph&             G,
+                const ECLRestartData&       rstrt,
+                const ECLOutput::PhaseIndex p) const;
+
+    private:
+        /// Implementation backend.
+        class Impl;
+
+        /// Pointer to actual backend/engine object.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_ECLSATURATIONFUNC_HEADER_INCLUDED

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -122,9 +122,9 @@ namespace Opm {
         ///    p for all active cells in model \p G.  Empty if phase \p p is
         ///    not actually active in the current result set.
         std::vector<double>
-        relperm(const ECLGraph&             G,
-                const ECLRestartData&       rstrt,
-                const ECLOutput::PhaseIndex p) const;
+        relperm(const ECLGraph&       G,
+                const ECLRestartData& rstrt,
+                const ECLPhaseIndex   p) const;
 
     private:
         /// Implementation backend.

--- a/tests/runLinearisedCellDataTest.cpp
+++ b/tests/runLinearisedCellDataTest.cpp
@@ -554,6 +554,14 @@ namespace {
         return errorAcceptable(E.absolute, tol.absolute)
             && errorAcceptable(E.relative, tol.relative);
     }
+
+    ::Opm::ECLGraph
+    constructGraph(const example::FilePaths& pth)
+    {
+        const auto I = ::Opm::ECLInitFileData(pth.init);
+
+        return ::Opm::ECLGraph::load(pth.grid, I);
+    }
 } // namespace Anonymous
 
 int main(int argc, char* argv[])
@@ -564,7 +572,7 @@ try {
 
     const auto rstrt = ::Opm::ECLRestartData(pth.restart);
     const auto steps = availableReportSteps(pth);
-    const auto graph = example::initGraph(pth);
+    const auto graph = constructGraph(pth);
 
     auto all_ok = true;
     for (const auto& quant : testQuantities(prm)) {

--- a/tests/runTransTest.cpp
+++ b/tests/runTransTest.cpp
@@ -206,13 +206,21 @@ namespace {
         return ! ((pointMetric(diff) > tol.absolute) ||
                   (pointMetric(rat)  > tol.relative));
     }
+
+    ::Opm::ECLGraph
+    constructGraph(const example::FilePaths& pth)
+    {
+        const auto I = ::Opm::ECLInitFileData(pth.init);
+
+        return ::Opm::ECLGraph::load(pth.grid, I);
+    }
 } // namespace Anonymous
 
 int main(int argc, char* argv[])
 try {
     const auto prm = example::initParam(argc, argv);
     const auto pth = example::FilePaths(prm);
-    const auto G   = example::initGraph(pth);
+    const auto G   = constructGraph(pth);
     const auto T   = G.transmissibility();
     const auto ok  = transfieldAcceptable(prm, T);
 

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -1,0 +1,469 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ECLENDPOINTSCALING
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/utility/ECLEndPointScaling.hpp>
+
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+    template <class Collection1, class Collection2>
+    void check_is_close(const Collection1& c1, const Collection2& c2)
+    {
+        BOOST_REQUIRE_EQUAL(c1.size(), c2.size());
+
+        if (! c1.empty()) {
+            auto i1 = c1.begin(), e1 = c1.end();
+            auto i2 = c2.begin();
+
+            for (; i1 != e1; ++i1, ++i2) {
+                BOOST_CHECK_CLOSE(*i1, *i2, 1.0e-10);
+            }
+        }
+    }
+
+    ::Opm::SatFunc::EPSEvalInterface::SaturationPoints
+    associate(const std::vector<double>& s)
+    {
+        using SatAssoc = ::Opm::SatFunc::
+            EPSEvalInterface::SaturationAssoc;
+
+        auto sp = ::Opm::SatFunc::
+            EPSEvalInterface::SaturationPoints{};
+
+        sp.reserve(s.size());
+
+        for (const auto& si : s) {
+            sp.push_back(SatAssoc{ 0, si });
+        }
+
+        return sp;
+    }
+} // Namespace Anonymous
+
+// =====================================================================
+// Two-point scaling
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (TwoPointScaling_FullRange)
+
+BOOST_AUTO_TEST_CASE (NoScaling)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.0, 0.0, 1.0 };
+
+    const auto smin = std::vector<double>{ 0.0 };
+    const auto smax = std::vector<double>{ 1.0 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledConnate)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.2, 1.0] maps to [ 0.0, 1.0 ]
+    const auto smin = std::vector<double>{ 0.2 };
+    const auto smax = std::vector<double>{ 1.0 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.0, 0.0, 1.0 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0,
+        0,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledMax)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.0, 0.8] maps to [ 0.0, 1.0 ]
+    const auto smin = std::vector<double>{ 0.0 };
+    const auto smax = std::vector<double>{ 0.8 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.0, 0.0, 1.0 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.0,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledBoth)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.2, 0.8] maps to [ 0.0, 1.0 ]
+    const auto smin = std::vector<double>{ 0.2 };
+    const auto smax = std::vector<double>{ 0.8 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.0, 0.0, 1.0 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0,
+        0.0,
+        1.0 / 3.0,
+        2.0 / 3.0,
+        1.0,
+        1.0,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (TwoPointScaling_ReducedRange)
+
+BOOST_AUTO_TEST_CASE (NoScaling)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    const auto smin = std::vector<double>{ 0.2 };
+    const auto smax = std::vector<double>{ 0.8 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.2, 0.0, 0.8 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0.2,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        0.8,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledConnate)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.0, 1.0] maps to [ 0.2, 0.8 ]
+    // s_eff = 0.6*s + 0.2
+    const auto smin = std::vector<double>{ 0.0 };
+    const auto smax = std::vector<double>{ 1.0 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.2, 0.0, 0.8 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0.20,
+        0.32,
+        0.44,
+        0.56,
+        0.68,
+        0.80,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledMax)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.2, 0.8] maps to [ 0.0, 1.0 ]
+    // s_eff = max(0.75*s + 0.05, 0.2)
+    const auto smin = std::vector<double>{ 0.2 };
+    const auto smax = std::vector<double>{ 1.0 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.2, 0.0, 0.8 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0.20,
+        0.20,
+        0.35,
+        0.50,
+        0.65,
+        0.80,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledBoth)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.2, 0.8] maps to [ 0.5, 0.7 ]
+    // s_eff = min(max(0.2, 3*s - 13/10), 0.8)
+    const auto smin = std::vector<double>{ 0.5 };
+    const auto smax = std::vector<double>{ 0.7 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.2, 0.0, 0.8 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0.2,
+        0.2,
+        0.2,
+        0.5,
+        0.8,
+        0.8,
+    };
+
+    const auto eps = SF::TwoPointScaling{ smin, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Three-point (alternative) scaling, applicable to relperm only.
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (ThreePointScaling_FullRange)
+
+BOOST_AUTO_TEST_CASE (NoScaling)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.0, 0.2, 1.0 };
+
+    const auto smin  = std::vector<double>{ 0.0 };
+    const auto sdisp = std::vector<double>{ 0.2 };
+    const auto smax  = std::vector<double>{ 1.0 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto eps = SF::ThreePointScaling{ smin, sdisp, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_CASE (ScaledConnate)
+{
+    namespace SF = ::Opm::SatFunc;
+
+    // Mobile Range: [0.4, 1.0] maps to [ 0.0, 1.0 ]
+    const auto smin  = std::vector<double>{ 0.1 };
+    const auto sdisp = std::vector<double>{ 0.4 };
+    const auto smax  = std::vector<double>{ 1.0 };
+
+    const auto tep = SF::EPSEvalInterface::
+        TableEndPoints { 0.0, 0.2, 1.0 };
+
+    const auto s = std::vector<double> {
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    };
+
+    const auto sp     = associate(s);
+    const auto expect = std::vector<double> {
+        0,
+        1.0  / 15,
+        0.2,
+        7.0  / 15,
+        11.0 / 15,
+        1.0,
+    };
+
+    const auto eps = SF::ThreePointScaling{ smin, sdisp, smax };
+
+    const auto s_eff = eps.eval(tep, sp);
+
+    check_is_close(s_eff, expect);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclproptable.cpp
+++ b/tests/test_eclproptable.cpp
@@ -1,0 +1,894 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ECLPROPTABLE
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/utility/ECLPropTable.hpp>
+
+#include <exception>
+#include <stdexcept>
+
+namespace {
+    template <class Collection1, class Collection2>
+    void check_is_close(const Collection1& c1, const Collection2& c2)
+    {
+        BOOST_REQUIRE_EQUAL(c1.size(), c2.size());
+
+        if (! c1.empty()) {
+            auto i1 = c1.begin(), e1 = c1.end();
+            auto i2 = c2.begin();
+
+            for (; i1 != e1; ++i1, ++i2) {
+                BOOST_CHECK_CLOSE(*i1, *i2, 1.0e-10);
+            }
+        }
+    }
+
+    Opm::ECLPropTableRawData
+    toRawTableFormat(Opm::ECLPropTableRawData t)
+    {
+        // Note: Raw table format is nTab*nRows consecutive values for one
+        // column followed by nTab*nRows consecutive values for the next
+        // column &c.
+
+        const auto d          = t.data;
+        const auto rTabStride = t.numRows * t.numCols;
+        const auto wColStride = t.numRows * t.numTables;
+
+        for (auto c = 0*t.numCols; c < t.numCols; ++c) {
+            const auto wStart = c * wColStride;
+
+            for (auto k = 0*t.numTables; k < t.numTables; ++k) {
+                const auto rStart = k * rTabStride;
+                const auto wOff   = k * t.numRows;
+
+                for (auto i = 0*t.numRows; i < t.numRows; ++i) {
+                    t.data[wStart + wOff + i] =
+                        d [rStart + i*t.numCols + c];
+                }
+            }
+        }
+
+        return t;
+    }
+} // Namespace Anonymous
+
+// =====================================================================
+// Invalid tables (error handling/input validation)
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (InvalidTables)
+
+BOOST_AUTO_TEST_CASE (EmptyTable)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+    };
+
+    t.numRows   = 0;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (SingleNode)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.3 , 0.1 , 0.0,
+    };
+
+    t.numRows   = 1;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (NoResultColumns)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s
+        0.2,
+        0.3,
+        0.7,
+        0.8,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 1;
+    t.numTables = 1;
+
+    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (EmptyTableLargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s    , kr      , pc
+        -1.0e+20, -1.0e+20, 0.0,
+        -1.0e+20, -1.0e+20, 0.0,
+        -1.0e+20, -1.0e+20, 0.0,
+        -1.0e+20, -1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+    };
+
+    t.numRows   = 8;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (SingleNodeLargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s    , kr      , pc
+        -1.0e+20, -1.0e+20, 0.0,
+        -1.0e+20, -1.0e+20, 0.0,
+        -1.0e+20, -1.0e+20, 0.0,
+        -1.0e+20, -1.0e+20, 0.0,
+        0.3     ,  0.1    , 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+        1.0e+20 ,  1.0e+20, 0.0,
+    };
+
+    t.numRows   = 9;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (NoResultColumnsLargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s
+        -1.0e+20,
+        -1.0e+20,
+        -1.0e+20,
+        -1.0e+20,
+        0.2,
+        0.3,
+        0.7,
+        0.8,
+        1.0e+20,
+        1.0e+20,
+        1.0e+20,
+        1.0e+20,
+    };
+
+    t.numRows   = 12;
+    t.numCols   =  1;
+    t.numTables =  1;
+
+    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Single table (i.e., a single region).
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (InterpolationSingleTable)
+
+BOOST_AUTO_TEST_CASE (AtNodes)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s         = std::vector<double>{ 0.8, 0.3, 0.3, 0.2 };
+    const auto kr_expect = std::vector<double>{ 0.5, 0.1, 0.1, 0.0 };
+    const auto pc_expect = std::vector<double>{ 0.0, 0.0, 0.0, 0.0 };
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
+    const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
+
+    check_is_close(kr, kr_expect);
+    check_is_close(pc, pc_expect);
+
+    // Check error handling
+
+    // Table ID out of range.
+    BOOST_CHECK_THROW(swfunc.interpolate(InTable{10}, ResultColumn{0}, s),
+                      std::invalid_argument);
+
+    // Result Column ID out of range.
+    BOOST_CHECK_THROW(swfunc.interpolate(InTable{0}, ResultColumn{2}, s),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (AboveAndBelow)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s         = std::vector<double>{ 0.80000001, 0.9, 0.199999999, 0.1 };
+    const auto kr_expect = std::vector<double>{ 0.5,        0.5, 0.0,         0.0 };
+    const auto pc_expect = std::vector<double>{ 0.0,        0.0, 0.0,         0.0 };
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
+    const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
+
+    check_is_close(kr, kr_expect);
+    check_is_close(pc, pc_expect);
+}
+
+BOOST_AUTO_TEST_CASE (Interpolation)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s = std::vector<double>{
+        0.2000,
+        0.2300,
+        0.2600,
+        0.2900,
+        0.3200,
+        0.3500,
+        0.3800,
+        0.4100,
+        0.4400,
+        0.4700,
+        0.5000,
+        0.5300,
+        0.5600,
+        0.5900,
+        0.6200,
+        0.6500,
+        0.6800,
+        0.7100,
+        0.7400,
+        0.7700,
+        0.8000,
+    };
+
+    const auto kr_expect = std::vector<double>{
+        0,
+        0.0300,
+        0.0600,
+        0.0900,
+        0.1160,
+        0.1400,
+        0.1640,
+        0.1880,
+        0.2120,
+        0.2360,
+        0.2600,
+        0.2840,
+        0.3080,
+        0.3320,
+        0.3560,
+        0.3800,
+        0.4040,
+        0.4280,
+        0.4520,
+        0.4760,
+        0.5000,
+    };
+
+    const auto pc_expect = std::vector<double>(s.size(), 0.0);
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
+    const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
+
+    check_is_close(kr, kr_expect);
+    check_is_close(pc, pc_expect);
+}
+
+BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.8    , 0.5      , 0.0, //  8
+        1.0e20 , 1.0e+100 , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+    };
+
+    t.numRows   = 15;
+    t.numCols   =  3;
+    t.numTables =  1;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s = std::vector<double>{
+        0.0000,
+        0.1000,
+        0.1500,
+        0.1900,
+        0.2000,
+        0.2300,
+        0.2600,
+        0.2900,
+        0.3200,
+        0.3500,
+        0.3800,
+        0.4100,
+        0.4400,
+        0.4700,
+        0.5000,
+        0.5300,
+        0.5600,
+        0.5900,
+        0.6200,
+        0.6500,
+        0.6800,
+        0.7100,
+        0.7400,
+        0.7700,
+        0.8000,
+        0.8100,
+        0.8500,
+        0.9000,
+        1.0000,
+    };
+
+    const auto kr_expect = std::vector<double>{
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.0300,
+        0.0600,
+        0.0900,
+        0.1160,
+        0.1400,
+        0.1640,
+        0.1880,
+        0.2120,
+        0.2360,
+        0.2600,
+        0.2840,
+        0.3080,
+        0.3320,
+        0.3560,
+        0.3800,
+        0.4040,
+        0.4280,
+        0.4520,
+        0.4760,
+        0.5000,
+        0.5000,
+        0.5000,
+        0.5000,
+        0.5000,
+    };
+
+    const auto pc_expect = std::vector<double>(s.size(), 0.0);
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
+    const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
+
+    check_is_close(kr, kr_expect);
+    check_is_close(pc, pc_expect);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Multiple tables (i.e., multiple regions).
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (InterpolationFourTables)
+
+BOOST_AUTO_TEST_CASE (AtNodes)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // Table 0
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 1
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 2
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 3
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s         = std::vector<double>{ 0.8, 0.3, 0.3, 0.2 };
+    const auto kr_expect = std::vector<double>{ 0.5, 0.1, 0.1, 0.0 };
+    const auto pc_expect = std::vector<double>{ 0.0, 0.0, 0.0, 0.0 };
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
+        const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
+        const auto pc = swfunc.interpolate(InTable{ti}, ResultColumn{1}, s);
+
+        check_is_close(kr, kr_expect);
+        check_is_close(pc, pc_expect);
+
+        // Check error handling
+
+        // Table ID out of range.
+        BOOST_CHECK_THROW(swfunc.interpolate(InTable{10}, ResultColumn{0}, s),
+                          std::invalid_argument);
+
+        // Result Column ID out of range.
+        BOOST_CHECK_THROW(swfunc.interpolate(InTable{0}, ResultColumn{2}, s),
+                          std::invalid_argument);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (AboveAndBelow)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // Table 0
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 1
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 2
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 3
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s         = std::vector<double>{ 0.80000001, 0.9, 0.199999999, 0.1 };
+    const auto kr_expect = std::vector<double>{ 0.5,        0.5, 0.0,         0.0 };
+    const auto pc_expect = std::vector<double>{ 0.0,        0.0, 0.0,         0.0 };
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
+        const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
+        const auto pc = swfunc.interpolate(InTable{ti}, ResultColumn{1}, s);
+
+        check_is_close(kr, kr_expect);
+        check_is_close(pc, pc_expect);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Interpolation)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // Table 0
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 1
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 2
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // Table 3
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s = std::vector<double>{
+        0.2000,
+        0.2300,
+        0.2600,
+        0.2900,
+        0.3200,
+        0.3500,
+        0.3800,
+        0.4100,
+        0.4400,
+        0.4700,
+        0.5000,
+        0.5300,
+        0.5600,
+        0.5900,
+        0.6200,
+        0.6500,
+        0.6800,
+        0.7100,
+        0.7400,
+        0.7700,
+        0.8000,
+    };
+
+    const auto kr_expect = std::vector<double>{
+        0,
+        0.0300,
+        0.0600,
+        0.0900,
+        0.1160,
+        0.1400,
+        0.1640,
+        0.1880,
+        0.2120,
+        0.2360,
+        0.2600,
+        0.2840,
+        0.3080,
+        0.3320,
+        0.3560,
+        0.3800,
+        0.4040,
+        0.4280,
+        0.4520,
+        0.4760,
+        0.5000,
+    };
+
+    const auto pc_expect = std::vector<double>(s.size(), 0.0);
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
+        const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
+        const auto pc = swfunc.interpolate(InTable{ti}, ResultColumn{1}, s);
+
+        check_is_close(kr, kr_expect);
+        check_is_close(pc, pc_expect);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // Table 0
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.7    , 0.15     , 0.0, //  8
+        0.8    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+
+        // Table 1
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.7    , 0.15     , 0.0, //  8
+        0.8    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+
+        // Table 2
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.7    , 0.15     , 0.0, //  8
+        0.8    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+
+        // Table 3
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.7    , 0.15     , 0.0, //  8
+        0.8    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+    };
+
+    t.numRows   = 15;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+
+    const auto s = std::vector<double>{
+        0.0000,
+        0.1000,
+        0.1500,
+        0.1900,
+        0.2000,
+        0.2300,
+        0.2600,
+        0.2900,
+        0.3200,
+        0.3500,
+        0.3800,
+        0.4100,
+        0.4400,
+        0.4700,
+        0.5000,
+        0.5300,
+        0.5600,
+        0.5900,
+        0.6200,
+        0.6500,
+        0.6800,
+        0.7100,
+        0.7400,
+        0.7700,
+        0.8000,
+        0.8100,
+        0.8500,
+        0.9000,
+        1.0000,
+    };
+
+    const auto kr_expect = std::vector<double>{
+        0,
+        0,
+        0,
+        0,
+        0,
+        3.0000e-02,
+        6.0000e-02,
+        9.0000e-02,
+        1.0250e-01,
+        1.0625e-01,
+        1.1000e-01,
+        1.1375e-01,
+        1.1750e-01,
+        1.2125e-01,
+        1.2500e-01,
+        1.2875e-01,
+        1.3250e-01,
+        1.3625e-01,
+        1.4000e-01,
+        1.4375e-01,
+        1.4750e-01,
+        1.8500e-01,
+        2.9000e-01,
+        3.9500e-01,
+        5.0000e-01,
+        5.0000e-01,
+        5.0000e-01,
+        5.0000e-01,
+        5.0000e-01,
+    };
+
+    const auto pc_expect = std::vector<double>(s.size(), 0.0);
+
+    using InTable      = Opm::ECLPropTable1D::InTable;
+    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+
+    for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
+        const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
+        const auto pc = swfunc.interpolate(InTable{ti}, ResultColumn{1}, s);
+
+        check_is_close(kr, kr_expect);
+        check_is_close(pc, pc_expect);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclproptable.cpp
+++ b/tests/test_eclproptable.cpp
@@ -1,5 +1,4 @@
 /*
-  Copyright 2017 SINTEF ICT, Applied Mathematics.
   Copyright 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
@@ -102,7 +101,7 @@ BOOST_AUTO_TEST_CASE (EmptyTable)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
                       std::invalid_argument);
 }
 
@@ -119,7 +118,7 @@ BOOST_AUTO_TEST_CASE (SingleNode)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
                       std::invalid_argument);
 }
 
@@ -139,7 +138,7 @@ BOOST_AUTO_TEST_CASE (NoResultColumns)
     t.numCols   = 1;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
                       std::invalid_argument);
 }
 
@@ -163,7 +162,7 @@ BOOST_AUTO_TEST_CASE (EmptyTableLargeNodeAlloc)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
                       std::invalid_argument);
 }
 
@@ -188,7 +187,7 @@ BOOST_AUTO_TEST_CASE (SingleNodeLargeNodeAlloc)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
                       std::invalid_argument);
 }
 
@@ -216,7 +215,7 @@ BOOST_AUTO_TEST_CASE (NoResultColumnsLargeNodeAlloc)
     t.numCols   =  1;
     t.numTables =  1;
 
-    BOOST_CHECK_THROW(Opm::ECLPropTable1D(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
                       std::invalid_argument);
 }
 
@@ -246,14 +245,16 @@ BOOST_AUTO_TEST_CASE (AtNodes)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s         = std::vector<double>{ 0.8, 0.3, 0.3, 0.2 };
     const auto kr_expect = std::vector<double>{ 0.5, 0.1, 0.1, 0.0 };
     const auto pc_expect = std::vector<double>{ 0.0, 0.0, 0.0, 0.0 };
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    // Check interpolation
 
     const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
     const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
@@ -290,14 +291,14 @@ BOOST_AUTO_TEST_CASE (AboveAndBelow)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s         = std::vector<double>{ 0.80000001, 0.9, 0.199999999, 0.1 };
     const auto kr_expect = std::vector<double>{ 0.5,        0.5, 0.0,         0.0 };
     const auto pc_expect = std::vector<double>{ 0.0,        0.0, 0.0,         0.0 };
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
     const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
@@ -324,7 +325,7 @@ BOOST_AUTO_TEST_CASE (Interpolation)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s = std::vector<double>{
         0.2000,
@@ -376,8 +377,8 @@ BOOST_AUTO_TEST_CASE (Interpolation)
 
     const auto pc_expect = std::vector<double>(s.size(), 0.0);
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
     const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
@@ -417,7 +418,7 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s = std::vector<double>{
         0.0000,
@@ -485,8 +486,8 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
 
     const auto pc_expect = std::vector<double>(s.size(), 0.0);
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     const auto kr = swfunc.interpolate(InTable{0}, ResultColumn{0}, s);
     const auto pc = swfunc.interpolate(InTable{0}, ResultColumn{1}, s);
@@ -540,14 +541,14 @@ BOOST_AUTO_TEST_CASE (AtNodes)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s         = std::vector<double>{ 0.8, 0.3, 0.3, 0.2 };
     const auto kr_expect = std::vector<double>{ 0.5, 0.1, 0.1, 0.0 };
     const auto pc_expect = std::vector<double>{ 0.0, 0.0, 0.0, 0.0 };
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
         const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
@@ -605,14 +606,14 @@ BOOST_AUTO_TEST_CASE (AboveAndBelow)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s         = std::vector<double>{ 0.80000001, 0.9, 0.199999999, 0.1 };
     const auto kr_expect = std::vector<double>{ 0.5,        0.5, 0.0,         0.0 };
     const auto pc_expect = std::vector<double>{ 0.0,        0.0, 0.0,         0.0 };
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
         const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
@@ -661,7 +662,7 @@ BOOST_AUTO_TEST_CASE (Interpolation)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s = std::vector<double>{
         0.2000,
@@ -713,8 +714,8 @@ BOOST_AUTO_TEST_CASE (Interpolation)
 
     const auto pc_expect = std::vector<double>(s.size(), 0.0);
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
         const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
@@ -811,7 +812,7 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::ECLPropTable1D(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
 
     const auto s = std::vector<double>{
         0.0000,
@@ -879,8 +880,8 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
 
     const auto pc_expect = std::vector<double>(s.size(), 0.0);
 
-    using InTable      = Opm::ECLPropTable1D::InTable;
-    using ResultColumn = Opm::ECLPropTable1D::ResultColumn;
+    using InTable      = Opm::SatFuncInterpolant::InTable;
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
     for (auto ti = 0*t.numTables; ti < t.numTables; ++ti) {
         const auto kr = swfunc.interpolate(InTable{ti}, ResultColumn{0}, s);
@@ -889,6 +890,1528 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
         check_is_close(kr, kr_expect);
         check_is_close(pc, pc_expect);
     }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Single Table End-Points
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (SingleTableEndPoints)
+
+BOOST_AUTO_TEST_CASE (SWFN_CritIsConn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2 };
+    const auto scrit_expect = std::vector<double>{ 0.2 };
+    const auto smax_expect  = std::vector<double>{ 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SWFN_CritIsConn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.8    , 0.5      , 0.0, //  8
+        1.0e20 , 1.0e+100 , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+    };
+
+    t.numRows   = 15;
+    t.numCols   =  3;
+    t.numTables =  1;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2 };
+    const auto scrit_expect = std::vector<double>{ 0.2 };
+    const auto smax_expect  = std::vector<double>{ 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SWFN)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2  };
+    const auto scrit_expect = std::vector<double>{ 0.21 };
+    const auto smax_expect  = std::vector<double>{ 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SWFN_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.21   , 0.0      , 0.0, //  7
+        0.3    , 0.1      , 0.0, //  8
+        0.8    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+        1.0e20 , 1.0e+100 , 0.0, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  1;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2 };
+    const auto scrit_expect = std::vector<double>{ 0.21 };
+    const auto smax_expect  = std::vector<double>{ 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_CritIsConn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2 };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2 };
+    const auto smax_expect       = std::vector<double>{ 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_CritIsConn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.3    ,  0.1     ,  0.5,      //  7
+        0.8    ,  0.5     ,  0.8,      //  8
+        1.0e20 ,  1.0e+100,  1.0e+100, //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+    };
+
+    t.numRows   = 15;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2 };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2 };
+    const auto smax_expect       = std::vector<double>{ 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.1,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2  };
+    const auto smax_expect       = std::vector<double>{ 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.0     ,  0.1,      //  7
+        0.3    ,  0.1     ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2  };
+    const auto smax_expect       = std::vector<double>{ 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.1 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2  };
+    const auto scrit_krog_expect = std::vector<double>{ 0.21 };
+    const auto smax_expect       = std::vector<double>{ 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.1     ,  0.0,      //  7
+        0.3    ,  0.1     ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2  };
+    const auto scrit_krog_expect = std::vector<double>{ 0.21 };
+    const auto smax_expect       = std::vector<double>{ 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2  , 0.0 , 0.0,
+        0.205, 0.0 , 0.0,
+        0.21 , 0.0 , 0.1,
+        0.25 , 0.1 , 0.2,
+        0.3  , 0.1 , 0.5,
+        0.8  , 0.5 , 0.8,
+    };
+
+    t.numRows   = 6;
+    t.numCols   = 3;
+    t.numTables = 1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2   };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21  };
+    const auto scrit_krog_expect = std::vector<double>{ 0.205 };
+    const auto smax_expect       = std::vector<double>{ 0.8   };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.2    ,  0.0     ,  0.0     , //  5
+        0.205  ,  0.0     ,  0.0     , //  6
+        0.21   ,  0.0     ,  0.1     , //  7
+        0.25   ,  0.1     ,  0.2     , //  8
+        0.3    ,  0.1     ,  0.5     , //  9
+        0.8    ,  0.5     ,  0.8     , // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  1;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2   };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21  };
+    const auto scrit_krog_expect = std::vector<double>{ 0.205 };
+    const auto smax_expect       = std::vector<double>{ 0.8   };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Table End-Points in Multiple Tables
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (TableEndPointsMultiTable)
+
+BOOST_AUTO_TEST_CASE (SWFN_CritIsConn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto scrit_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto smax_expect  = std::vector<double>{ 0.8, 0.8, 0.8, 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SWFN_CritIsConn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.8    , 0.5      , 0.0, //  8
+        1.0e20 , 1.0e+100 , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.8    , 0.5      , 0.0, //  8
+        1.0e20 , 1.0e+100 , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.8    , 0.5      , 0.0, //  8
+        1.0e20 , 1.0e+100 , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.3    , 0.1      , 0.0, //  7
+        0.8    , 0.5      , 0.0, //  8
+        1.0e20 , 1.0e+100 , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+    };
+
+    t.numRows   = 15;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto scrit_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto smax_expect  = std::vector<double>{ 0.8, 0.8, 0.8, 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SWFN)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+
+        // s, kr  , pc
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.0,
+        0.3 , 0.1 , 0.0,
+        0.8 , 0.5 , 0.0,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
+    const auto scrit_expect = std::vector<double>{ 0.21, 0.21, 0.21, 0.21 };
+    const auto smax_expect  = std::vector<double>{ 0.8 , 0.8 , 0.8 , 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SWFN_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    // 1e20 is a sentinel value that counts as row "ignored".
+    t.data = std::vector<double>{
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        -1.0e20, -1.0e+100, 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.21   , 0.0      , 0.0, //  7
+        0.3    , 0.1      , 0.0, //  8
+        0.7    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+        1.0e20 , 1.0e+100 , 0.0, // 16
+
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        0.1    , 0.0      , 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.21   , 0.0      , 0.0, //  7
+        0.3    , 0.1      , 0.0, //  8
+        0.8    , 0.5      , 0.0, //  9
+        1.0e20 , 1.0e+100 , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+        1.0e20 , 1.0e+100 , 0.0, // 16
+
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        -1.0e20, -1.0e+100, 0.0, //  4
+        0.1    , 0.0      , 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.21   , 0.0      , 0.0, //  7
+        0.3    , 0.1      , 0.0, //  8
+        0.5    , 0.35     , 0.0, //  9
+        0.9    , 0.5      , 0.0, // 10
+        1.0e20 , 1.0e+100 , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+        1.0e20 , 1.0e+100 , 0.0, // 16
+
+        // s   , kr       , pc
+        -1.0e20, -1.0e+100, 0.0, //  1
+        -1.0e20, -1.0e+100, 0.0, //  2
+        -1.0e20, -1.0e+100, 0.0, //  3
+        0.0    , 0.0      , 0.0, //  4
+        0.1    , 0.0      , 0.0, //  5
+        0.2    , 0.0      , 0.0, //  6
+        0.21   , 0.0      , 0.0, //  7
+        0.3    , 0.1      , 0.0, //  8
+        0.5    , 0.35     , 0.0, //  9
+        0.8    , 0.5      , 0.0, // 10
+        0.95   , 0.5      , 0.0, // 11
+        1.0e20 , 1.0e+100 , 0.0, // 12
+        1.0e20 , 1.0e+100 , 0.0, // 13
+        1.0e20 , 1.0e+100 , 0.0, // 14
+        1.0e20 , 1.0e+100 , 0.0, // 15
+        1.0e20 , 1.0e+100 , 0.0, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Table end-points
+    const auto sconn_expect = std::vector<double>{ 0.2 , 0.1 , 0.1 , 0.0  };
+    const auto scrit_expect = std::vector<double>{ 0.21, 0.21, 0.21, 0.21 };
+    const auto smax_expect  = std::vector<double>{ 0.7 , 0.8 , 0.9 , 0.95 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn = swfunc.connateSat();
+    const auto scrit = swfunc.criticalSat(ResultColumn{0});
+    const auto smax  = swfunc.maximumSat();
+
+    check_is_close(sconn, sconn_expect);
+    check_is_close(scrit, scrit_expect);
+    check_is_close(smax , smax_expect );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_CritIsConn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+    };
+
+    t.numRows   = 3;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto smax_expect       = std::vector<double>{ 0.8, 0.8, 0.8, 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_CritIsConn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.3    ,  0.1     ,  0.5,      //  7
+        0.8    ,  0.5     ,  0.8,      //  8
+        1.0e20 ,  1.0e+100,  1.0e+100, //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.1    ,  0.0     ,  0.0,      //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.3    ,  0.1     ,  0.5,      //  7
+        0.8    ,  0.5     ,  0.8,      //  8
+        1.0e20 ,  1.0e+100,  1.0e+100, //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        0.0    ,  0.0     ,  0.0,      //  4
+        0.15   ,  0.0     ,  0.0,      //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.3    ,  0.1     ,  0.5,      //  7
+        0.7    ,  0.35    ,  0.8,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.1    ,  0.0     ,  0.0,      //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.3    ,  0.1     ,  0.5,      //  7
+        0.8    ,  0.5     ,  0.8,      //  8
+        0.9    ,  0.85    ,  0.8,      //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+    };
+
+    t.numRows   = 15;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2, 0.1, 0.0, 0.1 };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
+    const auto smax_expect       = std::vector<double>{ 0.8, 0.8, 0.8, 0.9 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.1,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.1,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.1,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.0 , 0.1,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21, 0.21, 0.21, 0.21 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
+    const auto smax_expect       = std::vector<double>{ 0.8 , 0.8 , 0.8 , 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.0     ,  0.1,      //  7
+        0.3    ,  0.1     ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.0     ,  0.1,      //  7
+        0.25   ,  0.0     ,  0.5,      //  8
+        0.3    ,  0.1     ,  0.5,      //  9
+        0.8    ,  0.5     ,  0.8,      // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.1    ,  0.0     ,  0.0,      //  5
+        0.2    ,  0.0     ,  0.00001,  //  6
+        0.21   ,  0.0     ,  0.1,      //  7
+        0.3    ,  0.1     ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        0.9    ,  0.75    ,  0.9,      // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.0     ,  0.1,      //  7
+        0.3    ,  0.0     ,  0.25,     //  8
+        0.4    ,  0.00001 ,  0.30,     //  9
+        0.5    ,  0.1     ,  0.5,      // 10
+        0.8    ,  0.5     ,  0.8,      // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.1 , 0.2 };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21, 0.25, 0.21, 0.3 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.2 , 0.2 , 0.1 , 0.2 };
+    const auto smax_expect       = std::vector<double>{ 0.8 , 0.8 , 0.9 , 0.8 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.1 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.1 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.1 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2 , 0.0 , 0.0,
+        0.21, 0.1 , 0.0,
+        0.3 , 0.1 , 0.5,
+        0.8 , 0.5 , 0.8,
+    };
+
+    t.numRows   = 4;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
+    const auto scrit_krog_expect = std::vector<double>{ 0.21, 0.21, 0.21, 0.21 };
+    const auto smax_expect       = std::vector<double>{ 0.8 , 0.8 , 0.8 , 0.8  };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.1     ,  0.0,      //  7
+        0.3    ,  0.1     ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        1.0e20 ,  1.0e+100,  1.0e+100, // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.1     ,  0.0,      //  7
+        0.25   ,  0.15    ,  0.0,      //  8
+        0.3    ,  0.1     ,  0.5,      //  9
+        0.8    ,  0.5     ,  0.8,      // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.0    ,  0.0     ,  0.0,      //  5
+        0.1    ,  0.000001,  0.0,      //  6
+        0.21   ,  0.1     ,  0.0,      //  7
+        0.3    ,  0.15    ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        0.82   ,  0.6     ,  0.8,      // 10
+        0.9    ,  0.8     ,  0.89,     // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        -1.0e20, -1.0e+100, -1.0e+100, //  5
+        0.2    ,  0.0     ,  0.0,      //  6
+        0.21   ,  0.1     ,  0.0,      //  7
+        0.3    ,  0.1     ,  0.5,      //  8
+        0.8    ,  0.5     ,  0.8,      //  9
+        0.80001,  0.500001,  0.8,      // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.0 , 0.2     };
+    const auto scrit_krow_expect = std::vector<double>{ 0.2 , 0.2 , 0.0 , 0.2     };
+    const auto scrit_krog_expect = std::vector<double>{ 0.21, 0.25, 0.21, 0.21    };
+    const auto smax_expect       = std::vector<double>{ 0.8 , 0.8 , 0.9 , 0.80001 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s, krow, krog
+        0.2  , 0.0 , 0.0,
+        0.205, 0.0 , 0.0,
+        0.21 , 0.0 , 0.1,
+        0.25 , 0.1 , 0.2,
+        0.3  , 0.1 , 0.5,
+        0.8  , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2  , 0.0 , 0.0,
+        0.206, 0.0 , 0.0,
+        0.211, 0.0 , 0.1,
+        0.25 , 0.1 , 0.2,
+        0.3  , 0.1 , 0.5,
+        0.8  , 0.5 , 0.8,
+
+        // s, krow, krog
+        0.2  , 0.0 , 0.0,
+        0.207, 0.0 , 0.0,
+        0.212, 0.0 , 0.1,
+        0.25 , 0.1 , 0.2,
+        0.3  , 0.1 , 0.5,
+        0.85 , 0.6 , 0.8,
+
+        // s, krow, krog
+        0.2  , 0.0 , 0.0,
+        0.209, 0.0 , 0.0,
+        0.225, 0.0 , 0.1,
+        0.25 , 0.1 , 0.2,
+        0.3  , 0.1 , 0.5,
+        0.9  , 0.8 , 0.9,
+    };
+
+    t.numRows   = 6;
+    t.numCols   = 3;
+    t.numTables = 4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2  , 0.2  , 0.2  , 0.2   };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21 , 0.211, 0.212, 0.225 };
+    const auto scrit_krog_expect = std::vector<double>{ 0.205, 0.206, 0.207, 0.209 };
+    const auto smax_expect       = std::vector<double>{ 0.8  , 0.8  , 0.85 , 0.9   };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
+}
+
+BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn_LargeNodeAlloc)
+{
+    auto t = Opm::ECLPropTableRawData{};
+
+    t.data = std::vector<double>{
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.2    ,  0.0     ,  0.0     , //  5
+        0.205  ,  0.0     ,  0.0     , //  6
+        0.21   ,  0.0     ,  0.1     , //  7
+        0.25   ,  0.1     ,  0.2     , //  8
+        0.3    ,  0.1     ,  0.5     , //  9
+        0.8    ,  0.5     ,  0.8     , // 10
+        1.0e20 ,  1.0e+100,  1.0e+100, // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        0.1    ,  0.0     ,  0.0     , //  4
+        0.2    ,  0.0     ,  0.0     , //  5
+        0.205  ,  0.0     ,  0.0     , //  6
+        0.21   ,  0.0     ,  0.1     , //  7
+        0.25   ,  0.1     ,  0.2     , //  8
+        0.3    ,  0.15    ,  0.5     , //  9
+        0.5    ,  0.25    ,  0.6     , // 10
+        0.8    ,  0.5     ,  0.8     , // 11
+        0.9    ,  0.75    ,  0.9     , // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.2    ,  0.0     ,  0.0     , //  5
+        0.205  ,  0.000001,  0.000001, //  6
+        0.21   ,  0.000002,  0.1     , //  7
+        0.25   ,  0.1     ,  0.2     , //  8
+        0.3    ,  0.1     ,  0.5     , //  9
+        0.8    ,  0.5     ,  0.8     , // 10
+        0.825  ,  0.75    ,  0.825   , // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+
+        // s   ,  krow    ,  krog
+        -1.0e20, -1.0e+100, -1.0e+100, //  1
+        -1.0e20, -1.0e+100, -1.0e+100, //  2
+        -1.0e20, -1.0e+100, -1.0e+100, //  3
+        -1.0e20, -1.0e+100, -1.0e+100, //  4
+        0.2    ,  0.0     ,  0.0     , //  5
+        0.205  ,  0.0     ,  0.0     , //  6
+        0.21   ,  0.0     ,  0.0     , //  7
+        0.25   ,  0.0     ,  0.0     , //  8
+        0.3    ,  0.0     ,  0.000001, //  9
+        0.8    ,  0.0     ,  0.8     , // 10
+        0.99   ,  0.000001,  0.99    , // 11
+        1.0e20 ,  1.0e+100,  1.0e+100, // 12
+        1.0e20 ,  1.0e+100,  1.0e+100, // 13
+        1.0e20 ,  1.0e+100,  1.0e+100, // 14
+        1.0e20 ,  1.0e+100,  1.0e+100, // 15
+        1.0e20 ,  1.0e+100,  1.0e+100, // 16
+    };
+
+    t.numRows   = 16;
+    t.numCols   =  3;
+    t.numTables =  4;
+
+    // Table end-points
+    const auto sconn_expect      = std::vector<double>{ 0.2  , 0.1  , 0.2  , 0.2  };
+    const auto scrit_krow_expect = std::vector<double>{ 0.21 , 0.21 , 0.2  , 0.8  };
+    const auto scrit_krog_expect = std::vector<double>{ 0.205, 0.205, 0.2  , 0.25 };
+    const auto smax_expect       = std::vector<double>{ 0.8  , 0.9  , 0.825, 0.99 };
+
+    // Note: Need to convert input table to column major (Fortran) order
+    // because that is the format in which PropTable1D expects the tabular
+    // data.
+    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+
+    using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
+
+    const auto sconn      = swfunc.connateSat();
+    const auto scrit_krow = swfunc.criticalSat(ResultColumn{0});
+    const auto scrit_krog = swfunc.criticalSat(ResultColumn{1});
+    const auto smax       = swfunc.maximumSat();
+
+    check_is_close(sconn     , sconn_expect     );
+    check_is_close(scrit_krow, scrit_krow_expect);
+    check_is_close(scrit_krog, scrit_krog_expect);
+    check_is_close(smax      , smax_expect      );
 }
 
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
This change-set adds a set of interfaces that enable computing relative permeability values for active phases in an ECL result set.  The main gateway to this facility is function
```C++
std::vector<double>
Opm::ECLSaturationFunc::relperm(const ECLGraph&             G,
                                const ECLRestartData&       rstrt,
                                const ECLOutput::PhaseIndex p) const
```
that computes the relative permeability of phase `p` from the result set `rstrt` in all active cells of model `G`.

This function is currently aware of ECL's standard model for three-phase relative permeability for oil.  Stone's models can be added if needed.  Otherwise it uses the traditional piecewise linear interpolants for the relevant two-phase subsystems (O/G and O/W).  Two-phase G/W is not supported at this time.

The client may additionally enable horizontal end-point scaling (EPS) of the input values to the low-level interpolants through a constructor argument to class `Opm::ECLSaturationFunc`.  This will activate EPS if the result set itself uses EPS (item 17 of `LOGIHEAD` in the main grid).  Otherwise, the request to activate EPS will be ignored.  The EPS backend supports both the traditional (two-point) and alternative (three-point) scaling methods, but does currently not support vertical scaling of the relative permeability values.