### PR TITLE
Support non-unified restart files.

### DIFF
--- a/opm/utility/ECLResultData.hpp
+++ b/opm/utility/ECLResultData.hpp
@@ -109,6 +109,10 @@ namespace Opm {
         /// step.
         ///
         /// This is needed when working with dynamic restart data.
+        /// If constructed from a unified restart file, this function
+        /// will check that the requested step is available in the
+        /// file. If constructed from a non-unified restart file, no
+        /// such check is performed.
         ///
         /// \param[in] step Report step number.
         ///


### PR DESCRIPTION
With this, we can support non-unified restart files.

The change has been developed by @bska and myself together, and it has been tested on the single non-unified data example we have, so we will self-merge immediately.