### PR TITLE
Configure: Assume That We Have a New LibECL Only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,35 +73,6 @@ include (${project}-prereqs)
 include (CMakeLists_files.cmake)
 
 macro (config_hook)
-	if (NOT ERT_FOUND)
-		set (HAVE_ERT_ECL_TYPE_H 0)
-	else ()
-		# ERT_FOUND
-		cmake_push_check_state ()
-
-		set (CMAKE_REQUIRED_INCLUDES ${ERT_INCLUDE_DIR})
-		set (CMAKE_REQUIRED_LIBRARIES ${ERT_LIBRARIES})
-
-		check_cxx_source_compiles (
-"
-#include <iostream>
-
-#include <ert/ecl/ecl_kw.h>
-#include <ert/ecl/ecl_type.h>
-
-int main ()
-{
-  ecl_kw_type* kw = nullptr;
-
-  std::cout << ecl_type_get_type(ecl_kw_get_data_type(kw)) << std::endl;
-}
-"
-			HAVE_ERT_ECL_TYPE_H)
-
-		cmake_pop_check_state ()
-	endif ()
-
-	list (APPEND "${project}_CONFIG_VARS" HAVE_ERT_ECL_TYPE_H)
 endmacro (config_hook)
 
 macro (prereqs_hook)

--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -48,12 +48,9 @@
 #include <ert/ecl/ecl_kw.h>
 #include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl/ecl_nnc_export.h>
+#include <ert/ecl/ecl_type.h>
 #include <ert/ecl/ecl_util.h>
 #include <ert/util/ert_unique_ptr.hpp>
-
-#if defined(HAVE_ERT_ECL_TYPE_H) && HAVE_ERT_ECL_TYPE_H
-#include <ert/ecl/ecl_type.h>
-#endif // defined(HAVE_ERT_ECL_TYPE_H) && HAVE_ERT_ECL_TYPE_H
 
 /// \file
 ///
@@ -63,13 +60,7 @@ namespace {
     inline ecl_type_enum
     getKeywordElementType(const ecl_kw_type* kw)
     {
-#if defined(HAVE_ERT_ECL_TYPE_H) && HAVE_ERT_ECL_TYPE_H
         return ecl_type_get_type(ecl_kw_get_data_type(kw));
-
-#else // ! (defined(HAVE_ERT_ECL_TYPE_H) && HAVE_ERT_ECL_TYPE_H)
-
-        return ecl_kw_get_type(kw);
-#endif // defined(HAVE_ERT_ECL_TYPE_H) && HAVE_ERT_ECL_TYPE_H
     }
 
     namespace ECLImpl {


### PR DESCRIPTION
This simplifies retrieving the element-type of a result vector.