### PR TITLE
Preliminary work on accessing relperm tables

### DIFF
--- a/opm/utility/ECLPropTable.cpp
+++ b/opm/utility/ECLPropTable.cpp
@@ -206,6 +206,28 @@ Opm::SatFuncInterpolant::SingleTable::maximumSat() const
     return this->x_.back();
 }
 
+std::vector<double>
+Opm::SatFuncInterpolant::SingleTable::abcissa() const
+{
+    return this->x_;
+}
+
+std::vector<double>
+Opm::SatFuncInterpolant::SingleTable::ordinate(const ECLPropTableRawData::SizeType nCols,
+                                               const ResultColumn& c) const
+{
+    assert (c.i < nCols);
+
+    // Recall: 'y_' stored with column index cycling the most rapidly (row
+    // major ordering).
+    const int nRows = this->y_.size() / nCols;
+    std::vector<double> ord(nRows);
+    for (int row = 0; row < nRows; ++row) {
+        ord[row] = this->y_[row*nCols + c.i];
+    }
+    return ord;
+}
+
 // =====================================================================
 
 Opm::SatFuncInterpolant::SatFuncInterpolant(const ECLPropTableRawData& raw)
@@ -302,4 +324,24 @@ Opm::SatFuncInterpolant::maximumSat() const
     }
 
     return smax;
+}
+
+std::pair<std::vector<double>, std::vector<double>>
+Opm::SatFuncInterpolant::rawTableData(const InTable& t,
+                                      const ResultColumn& c) const
+{
+    if (t.i >= this->table_.size()) {
+        throw std::invalid_argument {
+            "Invalid Table ID"
+        };
+    }
+
+    if (c.i >= this->nResCols_) {
+        throw std::invalid_argument {
+            "Invalid Result Column ID"
+        };
+    }
+
+    return { this->table_[t.i].abcissa(),
+             this->table_[t.i].ordinate(nResCols_, c) };
 }

--- a/opm/utility/ECLPropTable.hpp
+++ b/opm/utility/ECLPropTable.hpp
@@ -105,6 +105,17 @@ namespace Opm {
         /// Retrieve maximum saturation in all tables.
         std::vector<double> maximumSat() const;
 
+        /// Retrieve raw data for specific table.
+        ///
+        /// \param[in] t ID of sub-table of interpolant.
+        ///
+        /// \param[in] c ID of result column/dependent variable.
+        ///
+        /// \return Abcissa and ordinate data vectors for requested table.
+        std::pair<std::vector<double>, std::vector<double>>
+        rawTableData(const InTable& t,
+                     const ResultColumn& c) const;
+
     private:
         /// Single tabulated 1D interpolant.
         class SingleTable
@@ -155,6 +166,13 @@ namespace Opm {
 
             /// Retrieve maximum saturation in table.
             double maximumSat() const;
+
+            /// Retrieve abcissa values.
+            std::vector<double> abcissa() const;
+
+            /// Retrieve ordinate values for specific column of data.
+            std::vector<double> ordinate(const ECLPropTableRawData::SizeType nCols,
+                                         const ResultColumn& c) const;
 
         private:
             /// Independent variable.

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -109,8 +109,18 @@ public:
         return { b, e };
     }
 
+    int regionID(const int cell) const
+    {
+        if (regIdx_.empty()) {
+            return 0;
+        } else {
+            return regIdx_[cell];
+        }
+    }
+
 private:
     Opm::AssembledConnections map_;
+    std::vector<int> regIdx_;
 };
 
 RegionMapping::RegionMapping(const std::size_t       numCells,
@@ -128,6 +138,9 @@ RegionMapping::RegionMapping(const std::size_t       numCells,
         }
 
         this->map_.compress(1);
+
+        // Region index array is left empty in this case.
+        // See implementation of regionID() for handling.
     }
     else if (regIdx.size() != numCells) {
         throw std::invalid_argument {
@@ -152,6 +165,13 @@ RegionMapping::RegionMapping(const std::size_t       numCells,
         }
 
         this->map_.compress(maxReg + 1);
+
+        // Copy region index array, but again remember to adjust one-based
+        // SATNUM indices.
+        this->regIdx_ = regIdx;
+        for (int& r : this->regIdx_) {
+            --r;
+        }
     }
 }
 

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -492,6 +492,12 @@ namespace Relperm {
                 return this->func_.interpolate(t, c, sw);
             }
 
+            std::pair<std::vector<double>, std::vector<double>>
+            rawKrTable(const std::size_t regID) const
+            {
+                return func_.rawTableData(table(regID), krcol());
+            }
+
         private:
             ::Opm::SatFuncInterpolant func_;
 
@@ -592,6 +598,10 @@ public:
     relperm(const ECLGraph&             G,
             const ECLRestartData&       rstrt,
             const ECLPhaseIndex         p) const;
+
+    using SatFuncTable = std::pair<std::vector<double>, std::vector<double>>;
+
+    SatFuncTable waterSatFunc(const int cell) const;
 
 private:
     class EPSEvaluator
@@ -1244,6 +1254,20 @@ extractRawTableEndPoints(const EPSEvaluator::ActPh& active) const
     return ep;
 }
 
+auto
+Opm::ECLSaturationFunc::Impl::
+waterSatFunc(const int cell) const -> SatFuncTable
+{
+    const int regionID = rmap_.regionID(cell);
+    auto table = wat_->rawKrTable(regionID);
+    if (this->eps_) {
+        // TODO: handle end-point scaling.
+        // Should both s and kr be scaled?
+    }
+    return table;
+}
+
+
 // =====================================================================
 
 Opm::ECLSaturationFunc::
@@ -1289,4 +1313,11 @@ relperm(const ECLGraph&       G,
         const ECLPhaseIndex   p) const
 {
     return this->pImpl_->relperm(G, rstrt, p);
+}
+
+auto
+Opm::ECLSaturationFunc::
+waterSatFunc(const int cell) const -> SatFuncTable
+{
+    return this->pImpl_->waterSatFunc(cell);
 }

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -126,6 +126,10 @@ namespace Opm {
                 const ECLRestartData& rstrt,
                 const ECLPhaseIndex   p) const;
 
+        using SatFuncTable = std::pair<std::vector<double>, std::vector<double>>;
+
+        SatFuncTable waterSatFunc(const int cell) const;
+
     private:
         /// Implementation backend.
         class Impl;


### PR DESCRIPTION
This adds the method `ECLSaturationFunc::waterSatFunc(const int cell)` allowing a client to retrieve the relative permeability table used for a given cell.

The work is preliminary in the following sense:
 - There are no corresponding methods for gas or oil tables.
 - End-point scaling is *not* taken into account.

This is intended as a starting point for discussing both what is needed (and how it should be interfaced), and how to implement it. That said, I do think that the extension is done carefully enough to warrant merging.