### PR TITLE
computeLocalSolutions: Compute Local ToF and Tracers for All Wells

### DIFF
--- a/examples/computeLocalSolutions.cpp
+++ b/examples/computeLocalSolutions.cpp
@@ -25,49 +25,156 @@
 #include "exampleSetup.hpp"
 #include <opm/flowdiagnostics/CellSet.hpp>
 
+#include <fstream>
+#include <ios>
+#include <type_traits>
+
+namespace {
+    using StartSets = std::vector< ::Opm::FlowDiagnostics::CellSet>;
+
+    template <class WellData>
+    std::vector<int>
+    activeCompletions(const ::Opm::ECLGraph& G,
+                      const WellData&        well)
+    {
+        auto completion_cells = std::vector<int>{};
+
+        completion_cells.reserve(well.completions.size());
+
+        for (const auto& completion : well.completions) {
+            const auto cell_index =
+                G.activeCell(completion.ijk, completion.gridName);
+
+            if (cell_index >= 0) {
+                completion_cells.push_back(cell_index);
+            }
+        }
+
+        return completion_cells;
+    }
+
+    template <class Select>
+    StartSets
+    getStartPointsFromWells(const example::Setup& setup,
+                            Select&&              pick)
+    {
+        auto start = StartSets{};
+
+        for (const auto& well : setup.well_fluxes) {
+            if (pick(well)) {
+                start.emplace_back(Opm::FlowDiagnostics::CellSetID(well.name),
+                                   activeCompletions(setup.graph, well));
+            }
+        }
+
+        return start;
+    }
+
+    StartSets injectors(const example::Setup& setup)
+    {
+        using WData =
+            std::decay<decltype(setup.well_fluxes[0])>::type;
+
+        return getStartPointsFromWells(setup, [](const WData& well)
+                                       { return well.is_injector_well; });
+    }
+
+    StartSets producers(const example::Setup& setup)
+    {
+        using WData =
+            std::decay<decltype(setup.well_fluxes[0])>::type;
+
+        return getStartPointsFromWells(setup, [](const WData& well)
+                                       { return ! well.is_injector_well; });
+    }
+
+    void printSolution(const ::Opm::FlowDiagnostics::CellSetValues& x,
+                       const ::Opm::FlowDiagnostics::CellSetID&     id,
+                       const std::string&                           varname)
+    {
+        const auto filename =
+            varname + '-' + id.to_string() + ".out";
+
+        std::ofstream os(filename);
+
+        if (os) {
+            os.precision(16);
+            os.setf(std::ios_base::scientific);
+
+            for (const auto& item : x) {
+                os << item.first << ' ' << item.second << '\n';
+            }
+        }
+    }
+
+    std::vector<int>
+    extractCellIDs(const ::Opm::FlowDiagnostics::CellSetValues& x)
+    {
+        auto i = std::vector<int>{};
+        i.reserve(x.size());
+
+        for (const auto& xi : x) { i.push_back(xi.first); }
+
+        std::sort(std::begin(i), std::end(i));
+
+        return i;
+    }
+
+    bool
+    sameReachability(const ::Opm::FlowDiagnostics::CellSetValues& tof,
+                     const ::Opm::FlowDiagnostics::CellSetValues& conc)
+    {
+        if (tof.size() != conc.size()) {
+            return false;
+        }
+
+        const auto tof_id  = extractCellIDs(tof);
+        const auto conc_id = extractCellIDs(conc);
+
+        return tof_id == conc_id;
+    }
+
+    void runAnalysis(const StartSets&                        start,
+                     const ::Opm::FlowDiagnostics::Solution& sol)
+    {
+        auto ok = std::vector<bool>{};
+        ok.reserve(start.size());
+
+        for (const auto& pt : start) {
+            const auto& id = pt.id();
+
+            const auto& tof  = sol.timeOfFlight (id);
+            const auto& conc = sol.concentration(id);
+
+            printSolution(tof , id, "tof" );
+            printSolution(conc, id, "conc");
+
+            if (! sameReachability(tof, conc)) {
+                std::cout << id.to_string() << ": FAIL\n";
+            }
+        }
+    }
+}
+
 // Syntax (typical):
-//   computeToFandTracers case=<ecl_case_prefix> step=<report_number>
+//   computeLocalSolutions case=<ecl_case_prefix> step=<report_number>
 int main(int argc, char* argv[])
 try {
     example::Setup setup(argc, argv);
     auto& fdTool = setup.toolbox;
 
-    // Create start sets from injector wells.
-    using ID = Opm::FlowDiagnostics::CellSetID;
-    std::vector<Opm::FlowDiagnostics::CellSet> start;
-    for (const auto& well : setup.well_fluxes) {
-        if (!well.is_injector_well) {
-            continue;
-        }
-        std::vector<int> completion_cells;
-        completion_cells.reserve(well.completions.size());
-        for (const auto& completion : well.completions) {
-            const auto& gridName = completion.gridName;
-            const auto& ijk = completion.ijk;
-            const int cell_index = setup.graph.activeCell(ijk, gridName);
-            if (cell_index >= 0) {
-                completion_cells.push_back(cell_index);
-            }
-        }
-        start.emplace_back(ID(well.name), completion_cells);
+    {
+        const auto inj = injectors(setup);
+        const auto fwd = fdTool.computeInjectionDiagnostics(inj);
+
+        runAnalysis(inj, fwd.fd);
     }
 
+    {
+        const auto prod = producers(setup);
+        const auto rev  = fdTool.computeProductionDiagnostics(prod);
 
-    // Solve for injection time of flight and tracers.
-    auto sol = fdTool.computeInjectionDiagnostics(start);
-
-    // Choose injector id, default to first injector.
-    const std::string id_string = setup.param.getDefault("id", start.front().id().to_string());
-    const ID id(id_string);
-
-    // Get local data for injector.
-    const bool tracer = setup.param.getDefault("tracer", false);
-    const auto& data = tracer ? sol.fd.concentration(id) : sol.fd.timeOfFlight(id);
-
-    // Write it to standard out.
-    std::cout.precision(16);
-    for (auto item : data) {
-        std::cout << item.first << "   " << item.second << '\n';
+        runAnalysis(prod, rev.fd);
     }
 }
 catch (const std::exception& e) {


### PR DESCRIPTION
This commit extends the 'computeLocalSolutions' utility to compute both time-of-flight and tracer concentrations for all wells in a model that are active at a particular report step.  Time-of-flight values are printed to files named
```
tof-<wellname>.out
```
while tracer concentration values are printed to files named
```
conc-<wellname>.out
```

While here, also add a bit of consistency checking to the ToF and tracer solution result sets.  In particular, check that these solutions have the same reachability in terms of cell IDs and print a failure diagnostic (for this well) if not.

Note: We may wish to re-add a way of computing the local solutions for a subset of the wells, but I think we should always compute both time-of-flight and tracer concentration values and verify reachability.