### PR TITLE
Generalise Region Mapping Support

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -25,6 +25,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLFluxCalc.cpp
         opm/utility/ECLGraph.cpp
         opm/utility/ECLPropTable.cpp
+        opm/utility/ECLRegionMapping.cpp
         opm/utility/ECLResultData.cpp
         opm/utility/ECLSaturationFunc.cpp
         opm/utility/ECLUnitHandling.cpp
@@ -34,6 +35,7 @@ list (APPEND MAIN_SOURCE_FILES
 list (APPEND TEST_SOURCE_FILES
         tests/test_eclendpointscaling.cpp
         tests/test_eclproptable.cpp
+        tests/test_eclregionmapping.cpp
         tests/test_eclunithandling.cpp
         )
 
@@ -54,6 +56,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLGraph.hpp
         opm/utility/ECLPhaseIndex.hpp
         opm/utility/ECLPropTable.hpp
+        opm/utility/ECLRegionMapping.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLSaturationFunc.hpp
         opm/utility/ECLUnitHandling.hpp

--- a/opm/utility/ECLRegionMapping.cpp
+++ b/opm/utility/ECLRegionMapping.cpp
@@ -1,0 +1,143 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLRegionMapping.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <iterator>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+
+    std::vector<int>
+    makeRegionSubset(const std::vector<int>::size_type n,
+                     std::vector<int>                  regSubset)
+    {
+        auto ret = std::move(regSubset);
+
+        if (ret.empty()) {
+            ret.resize(n);
+
+            std::iota(std::begin(ret), std::end(ret), 0);
+        }
+
+        return ret;
+    }
+
+} // Anonymous
+
+Opm::ECLRegionMapping::
+ECLRegionMapping(const std::vector<int>& region,
+                 const std::vector<int>& regSubset)
+    : regSubset_(makeRegionSubset(region.size(), regSubset))
+{
+    {
+        auto i = 0;
+        for (const auto& ix : this->regSubset_) {
+            this->regionSubsetIndex_
+                .addConnection(this->activeID(region[ix]), i++);
+        }
+    }
+
+    if (this->next_ == this->start_) {
+        // No active region IDs.  Typically empty 'region' or 'regSubset'.
+        // Invalid nonetheless so we can't continue here.
+        throw std::invalid_argument {
+            "Requested Region/Index Vector Pair "
+            "Does not Form Valid Subset"
+        };
+    }
+
+    // Recall: next_ represents the dense, linear ID that would be assigned
+    // to the "next" unseen region ID in a "start_"-based index sequence.
+    //
+    // Therefore next_ - start_ is the number of linear IDs assigned during
+    // this construction process which is also the number of rows in the
+    // sparse mapping matrix.
+    this->regionSubsetIndex_.compress(this->next_ - this->start_);
+}
+
+const std::vector<int>&
+Opm::ECLRegionMapping::regionSubset() const
+{
+    return this->regSubset_;
+}
+
+std::vector<int>
+Opm::ECLRegionMapping::activeRegions() const
+{
+    auto areg = std::vector<int>{};
+    areg.reserve(activeID_.size());
+
+    for (const auto& reg : this->activeID_) {
+        areg.push_back(reg.first);
+    }
+
+    std::sort(std::begin(areg), std::end(areg));
+
+    return areg;
+}
+
+Opm::ECLRegionMapping::IndexView
+Opm::ECLRegionMapping::getRegionIndices(const int region) const
+{
+    const auto areg = this->activeID(region);
+
+    if (areg < 0) {
+        throw std::logic_error {
+            "Region ID not in configured subset"
+        };
+    }
+
+    const auto& start = this->regionSubsetIndex_.startPointers();
+    const auto& ix    = this->regionSubsetIndex_.neighbourhood();
+
+    auto begin = std::begin(ix) + start[areg + 0];
+    auto end   = std::begin(ix) + start[areg + 1];
+
+    return { begin, end };
+}
+
+int Opm::ECLRegionMapping::activeID(const int regID)
+{
+    auto& areg = this->activeID_[regID];
+
+    if (areg == 0) {
+        // Region ID 'regID' not previously seen.  Assign new active ID.
+        areg = this->next_++;
+    }
+
+    return areg - this->start_;
+}
+
+int Opm::ECLRegionMapping::activeID(const int regID) const
+{
+    auto i = this->activeID_.find(regID);
+
+    if (i == std::end(this->activeID_)) {
+        // Region ID 'regID' not in configured subset of ID set defined on
+        // active cells.
+        return -1;
+    }
+
+    return i->second - this->start_;
+}

--- a/opm/utility/ECLRegionMapping.hpp
+++ b/opm/utility/ECLRegionMapping.hpp
@@ -1,0 +1,130 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLREGIONMAPPING_HEADER_INCLUDED
+#define OPM_ECLREGIONMAPPING_HEADER_INCLUDED
+
+#include <opm/utility/graph/AssembledConnections.hpp>
+#include <opm/utility/graph/AssembledConnectionsIteration.hpp>
+
+#include <unordered_map>
+#include <vector>
+
+namespace Opm {
+    /// Mapping of region IDs to subsets of explicit cell ID collection.
+    ///
+    /// The typical client code is
+    /// \code
+    ///    const auto map = ECLRegionMapping(/* ... */);
+    ///
+    ///    /// ...
+    ///
+    ///    const auto& subset = map.regionSubset();
+    ///
+    ///    for (const auto& regID : map.activeRegions()) {
+    ///        for (const auto& ix : map.getRegionIndices(regID)) {
+    ///            use(regID, subset[ix]);
+    ///        }
+    ///    }
+    /// \endcode
+    class ECLRegionMapping
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] region Container of region IDs.  Typically one of the
+        ///    explicit region ID vectors in an ECL result set such as
+        ///    SATNUM or PVTNUM.  Assumed to be defined on all active cells
+        ///    of an ECL result set.
+        ///
+        /// \param[in] regSubset Index subset of region IDs.  This object
+        ///    instance partitions the linear indices in
+        ///    \code
+        ///      [ 0 .. regSubset.size()-1 ]
+        ///    \endcode
+        ///    according to the corresponding unique region ID in the set
+        ///    \code
+        ///      { region[ i ] }_{i \in regSubset}
+        ///    \endcode
+        ///
+        ///    If empty or defaulted, \p regSubset is treated as if it were
+        ///    specified as \code [ 0 .. region.size() - 1] \endcode.  The
+        ///    common use case for this is working on the entire set of
+        ///    active cells implied by the region ID vector.
+        ///
+        ///    The typical use case of an explicit region subset is when
+        ///    sampling PVT or saturation function curves for graphical
+        ///    representation.
+        ECLRegionMapping(const std::vector<int>& region,
+                         const std::vector<int>& regSubset
+                             = std::vector<int>());
+
+        /// Retrieve index subset.
+        ///
+        /// Identical to constructor argument \c regSubset if supplied,
+        /// otherwise the vector \code [ 0 .. region.size()-1 ] \endcode.
+        const std::vector<int>& regionSubset() const;
+
+        /// Retrieve sorted list of unique region IDs in the subset defined
+        /// by \code { region[i] }_{i \in regionSubset()} \endcode.
+        std::vector<int> activeRegions() const;
+
+        /// Convenience alias to simplify declaring return type of member
+        /// function \code getRegionIndices() \endcode.
+        using IndexView = SimpleIteratorRange<
+            AssembledConnections::Neighbours::const_iterator>;
+
+        /// Retrive linear indices into \code regionSubset() \endcode that
+        /// correspond to particular region ID.
+        ///
+        /// \param[in] region Numeric region ID.  Must be one of the unique
+        ///    region IDs implied by \code activeRegions() \endcode.  If it
+        ///    is not one of those IDs, function \code getRegionIndices()
+        ///    \endcode throws an instance of \code std::logic_error
+        ///    \endcode.
+        ///
+        /// \return Linear index view into \code regionSubset() \endcode.
+        IndexView getRegionIndices(const int region) const;
+
+    private:
+        /// Offset from which to start assigning linear, dense active IDs.
+        int start_{1};
+
+        /// Next, unassigned linear ID.
+        int next_{1};
+
+        /// Subset of full region ID mapping.
+        std::vector<int> regSubset_;
+
+        /// Sparse mapping of region IDs to dense active IDs.
+        std::unordered_map<int, int> activeID_;
+
+        /// Map active IDs to subsets of the initial index subset.
+        AssembledConnections regionSubsetIndex_;
+
+        /// Translate region ID to dense linear active ID.  Mutable version.
+        int activeID(const int regID);
+
+        /// Translate region ID to dense linear active ID.  Immutable
+        /// version.
+        int activeID(const int regID) const;
+    };
+} // Opm
+
+#endif // OPM_ECLREGIONMAPPING_HEADER_INCLUDED

--- a/tests/test_eclregionmapping.cpp
+++ b/tests/test_eclregionmapping.cpp
@@ -1,0 +1,302 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_REGION_MAPPING
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/utility/ECLRegionMapping.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <initializer_list>
+#include <numeric>
+#include <stdexcept>
+
+namespace {
+    std::vector<int> pvtnum(const std::size_t n = 10)
+    {
+        return std::vector<int>(n, 1);
+    }
+
+    std::vector<int> satnum()
+    {
+        return std::vector<int> {
+            1, 1, 1, 2, 2,
+            3, 3, 3, 2, 2,
+        };
+    }
+
+    std::vector<int> linear(const std::vector<int>::size_type n)
+    {
+        auto i = std::vector<int>(n);
+
+        std::iota(std::begin(i), std::end(i), 0);
+
+        return i;
+    }
+
+    template <class Coll1, class Coll2>
+    void equal_collection(const Coll1& c1, const Coll2& c2)
+    {
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(c1), std::end(c1),
+                                      std::begin(c2), std::end(c2));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE (Full_Region_Mapping)
+
+BOOST_AUTO_TEST_CASE (Constructor_Failure)
+{
+    using RM = ::Opm::ECLRegionMapping;
+
+    BOOST_CHECK_THROW(RM{ std::vector<int>{} },
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (Single_Region)
+{
+    const auto rm = ::Opm::ECLRegionMapping{ pvtnum(5) };
+
+    // All cells in single region => active regions == single ID.
+    {
+        const auto expect_actreg = std::vector<int>{1};
+        equal_collection(rm.activeRegions(), expect_actreg);
+    }
+
+    // Defaulted index subset => Index vector [0 .. reg.size()-1]
+    {
+        const auto expect_ix = std::vector<int>{ 0, 1, 2, 3, 4, };
+        equal_collection(rm.regionSubset(), expect_ix);
+    }
+
+    // All cells in single region => region's subset of index vector is
+    // [0 .. regionSubset().size()-1]
+    {
+        const auto expect_regix = std::vector<int>{ 0, 1, 2, 3, 4, };
+        equal_collection(rm.getRegionIndices(1), expect_regix);
+    }
+
+    // Invalid region ID (outside configured subset) => logic_error.
+    BOOST_CHECK_THROW(rm.getRegionIndices(1729),
+                      std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE (Multiple_Regions)
+{
+    const auto rm = ::Opm::ECLRegionMapping{ satnum() };
+
+    // Active regions returned in sorted order
+    {
+        const auto expect_actreg = std::vector<int>{1, 2, 3};
+        equal_collection(rm.activeRegions(), expect_actreg);
+    }
+
+    // Defaulted index subset => Index vector [0 .. reg.size()-1]
+    {
+        const auto expect_ix = std::vector<int>{
+            0, 1, 2, 3, 4,
+            5, 6, 7, 8, 9,
+        };
+        equal_collection(rm.regionSubset(), expect_ix);
+    }
+
+    // Cells in multiple regions => Must verify correct subset mappings.
+    {
+        const auto expect_regix_1 = std::vector<int>{ 0, 1, 2, };
+        const auto expect_regix_2 = std::vector<int>{ 3, 4,
+                                                      8, 9 };
+        const auto expect_regix_3 = std::vector<int>{ 5, 6, 7, };
+
+        equal_collection(rm.getRegionIndices(1), expect_regix_1);
+        equal_collection(rm.getRegionIndices(2), expect_regix_2);
+        equal_collection(rm.getRegionIndices(3), expect_regix_3);
+    }
+
+    // Invalid region ID (outside configured subset) => logic_error.
+    BOOST_CHECK_THROW(rm.getRegionIndices(1701),
+                      std::logic_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (Subset_Region_Mapping)
+
+BOOST_AUTO_TEST_CASE (Single_Region_Subset)
+{
+    const auto rm = ::Opm::ECLRegionMapping{
+        pvtnum(5), std::vector<int>{ 1, 3, 4 }
+    };
+
+    // All cells in single region => active regions == single ID.
+    {
+        const auto expect_actreg = std::vector<int>{1};
+        equal_collection(rm.activeRegions(), expect_actreg);
+    }
+
+    // Explicit index subset => Index vector equal to this subset.
+    {
+        const auto expect_ix = std::vector<int>{ 1, 3, 4, };
+        equal_collection(rm.regionSubset(), expect_ix);
+    }
+
+    // All cells in single region => region's subset of index vector is
+    // [0 .. regionSubset().size()-1]
+    {
+        const auto expect_regix = std::vector<int>{ 0, 1, 2, };
+        equal_collection(rm.getRegionIndices(1), expect_regix);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Single_Region_MultiSampledSubset)
+{
+    const auto cellIDs =
+        std::vector<int>{ 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+    const auto rm = ::Opm::ECLRegionMapping{
+        pvtnum(5), cellIDs
+    };
+
+    // All cells in single region => active regions == single ID.
+    {
+        const auto expect_actreg = std::vector<int>{1};
+        equal_collection(rm.activeRegions(), expect_actreg);
+    }
+
+    // Explicit index subset => Index vector equal to this subset.
+    {
+        equal_collection(rm.regionSubset(), cellIDs);
+    }
+
+    // All cells in single region => region's subset of index vector is
+    // [0 .. regionSubset().size()-1]
+    {
+        const auto expect_regix = linear(cellIDs.size());
+        equal_collection(rm.getRegionIndices(1), expect_regix);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Multi_Region_Subset)
+{
+    const auto cellIDs = std::vector<int> {
+        0, 1, /* 2, */ /* 3, */ 4,
+        5, 6, /* 7, */ /* 8, */ 9,
+    };
+
+    const auto rm = ::Opm::ECLRegionMapping{
+        satnum(), cellIDs
+    };
+
+    // Active regions returned in sorted order (cell subset covers all
+    // regions).
+    {
+        const auto expect_actreg = std::vector<int>{1, 2, 3};
+        equal_collection(rm.activeRegions(), expect_actreg);
+    }
+
+    // Explicit index subset => Index vector must match this subset.
+    {
+        equal_collection(rm.regionSubset(), cellIDs);
+    }
+
+    // Cells in multiple regions => Must verify correct subset mappings.
+    {
+        const auto expect_regix_1 = std::vector<int>{ 0, 1, };
+        const auto expect_regix_2 = std::vector<int>{ 2,
+                                                      5, };
+        const auto expect_regix_3 = std::vector<int>{ 3, 4, };
+
+        equal_collection(rm.getRegionIndices(1), expect_regix_1);
+        equal_collection(rm.getRegionIndices(2), expect_regix_2);
+        equal_collection(rm.getRegionIndices(3), expect_regix_3);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Multi_Region_MultiSampledSubset)
+{
+    const auto cellIDs = std::vector<int> {
+        0, 0, 0, 0, 0, 0,       //  0 ..  5
+        9, 9, 8, 8, 3, 4,       //  6 .. 11
+        5, 5, 2, 2, 7, 7,       // 12 .. 17
+        0, 0, 0, 0, 0, 0,       // 18 .. 23
+    };
+
+    const auto rm = ::Opm::ECLRegionMapping{
+        satnum(), cellIDs
+    };
+
+    // Active regions returned in sorted order (cell subset covers all
+    // regions).
+    {
+        const auto expect_actreg = std::vector<int>{1, 2, 3};
+        equal_collection(rm.activeRegions(), expect_actreg);
+    }
+
+    // Explicit index subset => Index vector must match this subset.
+    {
+        equal_collection(rm.regionSubset(), cellIDs);
+    }
+
+    // Cells in multiple regions => Must verify correct subset mappings.
+    {
+        // Note: Index subsets appear in sorted order by construction.
+
+        const auto expect_regix_1 = std::vector<int>{
+             0,  1,  2,  3,  4,  5, //  0 ..  5
+         //                             6 .. 11
+                    14, 15,         // 12 .. 17
+            18, 19, 20, 21, 22, 23, // 18 .. 23
+        };
+
+        const auto expect_regix_2 = std::vector<int>{
+            //                          0 ..  5
+             6,  7,  8,  9, 10, 11, //  6 .. 11
+            //                         12 .. 17
+            //                         18 .. 23
+        };
+
+        const auto expect_regix_3 = std::vector<int>{
+            //                              0 ..  5
+            //                              6 .. 11
+            12, 13, /* 14, 15 */ 16, 17 // 12 .. 17
+            //                             18 .. 23
+        };
+
+        equal_collection(rm.getRegionIndices(1), expect_regix_1);
+        equal_collection(rm.getRegionIndices(2), expect_regix_2);
+        equal_collection(rm.getRegionIndices(3), expect_regix_3);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
This change-set introduces a new utility class, `ECLRegionMapping`, that simplifies working with integer region mappings as implied by ECL result set vectors such as SATNUM or PVTNUM.  We reimplement the `ECLSaturationFunc`'s region loop in terms of this new facility.

This will, in turn, enable future extensions that sample the effective saturation function curves in a single cell or a small subset of the cells in an ECL result set.  It is therefore the start of an alternative approach to solving the problem identified in PR #51.