### PR TITLE
Flux Calculator: Add Support for Variable Density and Viscosity

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -28,6 +28,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLRegionMapping.cpp
         opm/utility/ECLResultData.cpp
         opm/utility/ECLSaturationFunc.cpp
+        opm/utility/ECLTableInterpolation1D.cpp
         opm/utility/ECLUnitHandling.cpp
         opm/utility/ECLWellSolution.cpp
         )
@@ -36,6 +37,7 @@ list (APPEND TEST_SOURCE_FILES
         tests/test_eclendpointscaling.cpp
         tests/test_eclproptable.cpp
         tests/test_eclregionmapping.cpp
+        tests/test_eclsimple1dinterpolant.cpp
         tests/test_eclunithandling.cpp
         )
 
@@ -55,10 +57,12 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLFluxCalc.hpp
         opm/utility/ECLGraph.hpp
         opm/utility/ECLPhaseIndex.hpp
+        opm/utility/ECLPiecewiseLinearInterpolant.hpp
         opm/utility/ECLPropTable.hpp
         opm/utility/ECLRegionMapping.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLSaturationFunc.hpp
+        opm/utility/ECLTableInterpolation1D.hpp
         opm/utility/ECLUnitHandling.hpp
         opm/utility/ECLWellSolution.hpp
         )

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -25,6 +25,8 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLFluxCalc.cpp
         opm/utility/ECLGraph.cpp
         opm/utility/ECLPropTable.cpp
+        opm/utility/ECLPvtCommon.cpp
+        opm/utility/ECLPvtGas.cpp
         opm/utility/ECLRegionMapping.cpp
         opm/utility/ECLResultData.cpp
         opm/utility/ECLSaturationFunc.cpp
@@ -36,6 +38,7 @@ list (APPEND MAIN_SOURCE_FILES
 list (APPEND TEST_SOURCE_FILES
         tests/test_eclendpointscaling.cpp
         tests/test_eclproptable.cpp
+        tests/test_eclpvtcommon.cpp
         tests/test_eclregionmapping.cpp
         tests/test_eclsimple1dinterpolant.cpp
         tests/test_eclunithandling.cpp
@@ -59,6 +62,8 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLPhaseIndex.hpp
         opm/utility/ECLPiecewiseLinearInterpolant.hpp
         opm/utility/ECLPropTable.hpp
+        opm/utility/ECLPvtCommon.hpp
+        opm/utility/ECLPvtGas.hpp
         opm/utility/ECLRegionMapping.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLSaturationFunc.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -28,6 +28,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLPvtCommon.cpp
         opm/utility/ECLPvtGas.cpp
         opm/utility/ECLPvtOil.cpp
+        opm/utility/ECLPvtWater.cpp
         opm/utility/ECLRegionMapping.cpp
         opm/utility/ECLResultData.cpp
         opm/utility/ECLSaturationFunc.cpp
@@ -66,6 +67,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLPvtCommon.hpp
         opm/utility/ECLPvtGas.hpp
         opm/utility/ECLPvtOil.hpp
+        opm/utility/ECLPvtWater.hpp
         opm/utility/ECLRegionMapping.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLSaturationFunc.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -27,6 +27,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLPropTable.cpp
         opm/utility/ECLPvtCommon.cpp
         opm/utility/ECLPvtGas.cpp
+        opm/utility/ECLPvtOil.cpp
         opm/utility/ECLRegionMapping.cpp
         opm/utility/ECLResultData.cpp
         opm/utility/ECLSaturationFunc.cpp
@@ -64,6 +65,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLPropTable.hpp
         opm/utility/ECLPvtCommon.hpp
         opm/utility/ECLPvtGas.hpp
+        opm/utility/ECLPvtOil.hpp
         opm/utility/ECLRegionMapping.hpp
         opm/utility/ECLResultData.hpp
         opm/utility/ECLSaturationFunc.hpp

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -123,26 +123,22 @@ namespace example {
                      const bool                  useEPS)
     {
         if (compute_fluxes) {
-            auto satfunc = ::Opm::ECLSaturationFunc(G, init, useEPS);
+            const auto grav = 0.0;
 
-            Opm::ECLFluxCalc calc(G, std::move(satfunc));
+            Opm::ECLFluxCalc calc(G, init, grav, useEPS);
 
-            auto getFlux = [&calc, &rstrt]
-                (const Opm::ECLPhaseIndex         p)
+            return extractFluxField(G, [&calc, &rstrt]
+                (const Opm::ECLPhaseIndex p)
             {
                 return calc.flux(rstrt, p);
-            };
-
-            return extractFluxField(G, getFlux);
+            });
         }
 
-        auto getFlux = [&G, &rstrt]
-            (const Opm::ECLPhaseIndex         p)
+        return extractFluxField(G, [&G, &rstrt]
+            (const Opm::ECLPhaseIndex p)
         {
             return G.flux(rstrt, p);
-        };
-
-        return extractFluxField(G, getFlux);
+        });
     }
 
     template <class WellFluxes>

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -18,22 +18,186 @@
 */
 
 #include <opm/utility/ECLFluxCalc.hpp>
-#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 
+#include <algorithm>
+#include <exception>
+#include <functional>
+#include <iterator>
+#include <stdexcept>
 #include <utility>
+
+#include <ert/ecl/ecl_kw_magic.h>
+
+namespace {
+
+    std::vector<double>
+    computeGravDZ(const std::vector<int>&    neigh,
+                  const double               grav,
+                  const std::vector<double>& depth)
+    {
+        const auto nf = neigh.size() / 2;
+
+        auto gdz = std::vector<double>{};
+        gdz.reserve(nf);
+
+        for (auto f = 0*nf; f < nf; ++f) {
+            const auto c1 = neigh[2*f + 0];
+            const auto c2 = neigh[2*f + 1];
+
+            gdz.push_back(grav * (depth[c2] - depth[c1]));
+        }
+
+        return gdz;
+    }
+
+    std::vector<int>
+    pvtnumVector(const ::Opm::ECLGraph&        G,
+                 const ::Opm::ECLInitFileData& init)
+    {
+        auto pvtnum = G.rawLinearisedCellData<int>(init, "PVTNUM");
+
+        if (pvtnum.empty()) {
+            // PVTNUM missing in one or more of the grids managed by 'G'.
+            // Put all cells in PVTNUM region 1.
+            pvtnum.assign(G.numCells(), 1);
+        }
+
+        return pvtnum;
+    }
+
+    std::vector<double>
+    depthVector(const ::Opm::ECLGraph&        G,
+                const ::Opm::ECLInitFileData& init)
+    {
+        // Note: ECLGraph does not support unit conversion of INIT data so
+        // we need to perform the requisite conversions ourselves.
+        auto depth = G.rawLinearisedCellData<double>(init, "DEPTH");
+
+        if (depth.empty()) {
+            // DEPTH missing in one or more of the grids managed by 'G'.
+            // Put all cells at zero depth, which turns off gravity.
+            depth.assign(G.numCells(), 0.0);
+        }
+
+        const auto& ih = init.keywordData<int>(INTEHEAD_KW);
+        const auto usys = ::Opm::ECLUnits::
+            createUnitSystem(ih[ INTEHEAD_UNIT_INDEX ]);
+
+        const auto depthscale = usys->depth();
+
+        for (auto& zi : depth) {
+            zi = ::Opm::unit::convert::from(zi, depthscale);
+        }
+
+        return depth;
+    }
+
+    std::vector<double>
+    disgasVector(const ::Opm::ECLGraph&       G,
+                 const bool                   is_liveoil,
+                 const ::Opm::ECLRestartData& rstrt)
+    {
+        auto disgas = std::vector<double>{};
+
+        if (! is_liveoil) {
+            // Oil model does not use dissolved gas.  We don't need to
+            // provide Rs data, so return zero (simplifies calling code).
+
+            disgas.assign(G.numCells(), 0.0);
+
+            return disgas;
+        }
+
+        // Gas model does use vaporised oil.  Extract Rs data or throw if
+        // unavailable.
+        disgas = G.linearisedCellData(rstrt, "RS",
+                                      &::Opm::ECLUnits::UnitSystem::
+                                      dissolvedGasOilRat);
+
+        if (disgas.empty()) {
+            throw std::invalid_argument {
+                "Restart Data Does Not Provide "
+                "Dissolved Gas/Oil Ratio Data "
+                "for Live Oil PVT Model"
+            };
+        }
+
+        return disgas;
+    }
+
+    std::vector<double>
+    vapoilVector(const ::Opm::ECLGraph&       G,
+                 const bool                   is_wetgas,
+                 const ::Opm::ECLRestartData& rstrt)
+    {
+        auto vapoil = std::vector<double>{};
+
+        if (! is_wetgas) {
+            // Gas model does not use vaporised oil.  We don't need to
+            // provide Rv data, so return zero (simplifies calling code).
+
+            vapoil.assign(G.numCells(), 0.0);
+
+            return vapoil;
+        }
+
+        // Gas model does use vaporised oil.  Extract Rv data or throw if
+        // unavailable.
+        vapoil = G.linearisedCellData(rstrt, "RV",
+                                      &::Opm::ECLUnits::UnitSystem::
+                                      vaporisedOilGasRat);
+
+        if (vapoil.empty()) {
+            throw std::invalid_argument {
+                "Restart Data Does Not Provide "
+                "Vaporised Oil/Gas Ratio Data "
+                "for Wet Gas PVT Model"
+            };
+        }
+
+        return vapoil;
+    }
+
+    template <class PVTPtr>
+    void verify_active_phase(const PVTPtr&      pvt,
+                             const std::string& phase)
+    {
+        if (! pvt) {
+            throw std::logic_error {
+                "Cannot Compute " + phase +
+                " PVT Unless "    + phase +
+                " is an Active Phase"
+            };
+        }
+    }
+
+} // Anonymous
 
 namespace Opm
 {
 
-    ECLFluxCalc::ECLFluxCalc(const ECLGraph&     graph,
-                             ECLSaturationFunc&& satfunc)
+    ECLFluxCalc::ECLFluxCalc(const ECLGraph&        graph,
+                             const ECLInitFileData& init,
+                             const double           grav,
+                             const bool             useEPS)
         : graph_(graph)
-        , satfunc_(std::move(satfunc))
+        , satfunc_(graph, init, useEPS)
+        , rmap_(pvtnumVector(graph, init))
         , neighbours_(graph.neighbours())
         , transmissibility_(graph.transmissibility())
+        , gravDz_(computeGravDZ(neighbours_, grav, depthVector(graph, init)))
+        , pvtGas_(ECLPVT::CreateGasPVTInterpolant::fromECLOutput(init))
+        , pvtOil_(ECLPVT::CreateOilPVTInterpolant::fromECLOutput(init))
+        , pvtWat_(ECLPVT::CreateWaterPVTInterpolant::fromECLOutput(init))
     {
+        const auto& lh = init.keywordData<bool>(LOGIHEAD_KW);
+
+        this->disgas_ = lh[ LOGIHEAD_RS_INDEX ]; // Live Oil?
+        this->vapoil_ = lh[ LOGIHEAD_RV_INDEX ]; // Wet Gas?
     }
 
 
@@ -42,16 +206,10 @@ namespace Opm
 
     std::vector<double>
     ECLFluxCalc::flux(const ECLRestartData& rstrt,
-                      const ECLPhaseIndex         phase) const
+                      const ECLPhaseIndex   phase) const
     {
         // Obtain dynamic data.
-        DynamicData dyn_data;
-        dyn_data.pressure = graph_
-            .linearisedCellData(rstrt, "PRESSURE",
-                                &ECLUnits::UnitSystem::pressure);
-
-        dyn_data.relperm = this->satfunc_
-            .relperm(this->graph_, rstrt, phase);
+        const auto dyn_data = this->phaseProperties(rstrt, phase);
 
         // Compute fluxes per connection.
         const int num_conn = transmissibility_.size();
@@ -71,16 +229,282 @@ namespace Opm
     {
         const int c1 = neighbours_[2*connection];
         const int c2 = neighbours_[2*connection + 1];
-        const double transmissibility = transmissibility_[connection];
-        const double viscosity = 1.0 * prefix::centi * unit::Poise;
-        const auto& pressure = dyn_data.pressure;
 
-        const int upwind_cell = (pressure[c2] > pressure[c1]) ? c2 : c1;
-        const double kr = dyn_data.relperm[upwind_cell];
+        // Phase pressure in connecting cells.
+        const auto p1 = dyn_data.pressure[c1];
+        const auto p2 = dyn_data.pressure[c2];
 
-        const double mobility = kr / viscosity;
-        return mobility * transmissibility * (pressure[c1] - pressure[c2]);
+        // Phase density at interface: Arith. avg. of cell values.
+        const auto rho =
+            (dyn_data.density[c1] + dyn_data.density[c2]) / 2.0;
+
+        // Phase potential drop across interface.
+        const auto dh = p1 - p2 + rho*this->gravDz_[connection];
+
+        // Phase mobility at interface: Upstream weighting (phase pot).
+        const auto ucell = (dh < 0.0) ? c2 : c1;
+        const auto mob   = dyn_data.mobility[ucell];
+
+        // Background (static) transmissibility.
+        const auto T = this->transmissibility_[connection];
+
+        return mob * T * dh;
     }
 
+
+
+
+
+    ECLFluxCalc::DynamicData
+    ECLFluxCalc::phaseProperties(const ECLRestartData& rstrt,
+                                 const ECLPhaseIndex   phase) const
+    {
+        auto dyn_data = DynamicData{};
+
+        // Step 1 of Phase Pressure Calculation.
+        // Retrieve oil pressure directly from result set.
+        dyn_data.pressure = this->graph_
+            .linearisedCellData(rstrt, "PRESSURE",
+                                &ECLUnits::UnitSystem::pressure);
+
+        // Step 1 of Mobility Calculation.
+        // Store phase's relative permeability values.
+        dyn_data.mobility =
+            this->satfunc_.relperm(this->graph_, rstrt, phase);
+
+        // Step 1 of Mass Density (Reservoir Conditions) Calculation.
+        // Allocate space for storing the cell values.
+        dyn_data.density.assign(this->graph_.numCells(), 0.0);
+
+        switch (phase) {
+        case ECLPhaseIndex::Aqua:
+            return this->watPVT(std::move(dyn_data));
+
+        case ECLPhaseIndex::Liquid:
+            return this->oilPVT(rstrt, std::move(dyn_data));
+
+        case ECLPhaseIndex::Vapour:
+            return this->gasPVT(rstrt, std::move(dyn_data));
+        }
+
+        throw std::invalid_argument {
+            "phaseProperties(): Invalid Phase Identifier"
+        };
+    }
+
+
+
+
+
+    ECLFluxCalc::DynamicData
+    ECLFluxCalc::gasPVT(const ECLRestartData& rstrt,
+                        DynamicData&&         dyn_data) const
+    {
+        verify_active_phase(this->pvtGas_, "Gas");
+
+        const auto rv = vapoilVector(this->graph_, this->vapoil_, rstrt);
+
+        this->regionLoop([this, &rv, &dyn_data]
+            (const int regID)
+        {
+            // Note: This function assumes that 'regID' is a traditional
+            // ECL-style one-based region ID such as PVTNUM.  Subtract one,
+            // where approriate, to generate zero-based region indices.
+
+            const auto Rv = ECLPVT::Gas::VaporizedOil {
+                this->gatherRegionSubset(regID, rv)
+            };
+
+            const auto Pg = ECLPVT::Gas::GasPressure {
+                // Cheating.  This is Po.
+                this->gatherRegionSubset(regID, dyn_data.pressure)
+            };
+
+            // Mass Density at Reservoir Conditions.  Relies on setup code
+            // having allocated sufficient space.
+            {
+                const auto rhoOS = this->vapoil_
+                    ? this->pvtOil_->surfaceMassDensity(regID - 1)
+                    : 0.0;
+
+                const auto rhoGS =
+                    this->pvtGas_->surfaceMassDensity(regID - 1);
+
+                const auto Bg = this->pvtGas_
+                    ->formationVolumeFactor(regID - 1, Rv, Pg);
+
+                auto rhoGr = std::vector<double>{};
+                rhoGr.reserve(Bg.size());
+
+                std::transform(std::begin(Bg),
+                               std::end  (Bg),
+                               std::begin(Rv.data),
+                               std::back_inserter(rhoGr),
+                    [rhoOS, rhoGS]
+                    (const double Bg_i, const double Rv_i)
+                {
+                    return (rhoOS*Rv_i + rhoGS) / Bg_i;
+                });
+
+                this->scatterRegionResults(regID, rhoGr, dyn_data.density);
+            }
+
+            // Convert relative permeability values into mobility values
+            // (divide by phase viscosity).  Relies on setup code having
+            // computed relative permeability for the phase.
+            {
+                const auto mu = this->pvtGas_->viscosity(regID - 1, Rv, Pg);
+
+                this->computePhaseMobility(regID, mu, dyn_data);
+            }
+        });
+
+        return std::move(dyn_data);
+    }
+
+
+
+
+
+    ECLFluxCalc::DynamicData
+    ECLFluxCalc::oilPVT(const ECLRestartData& rstrt,
+                        DynamicData&&         dyn_data) const
+    {
+        verify_active_phase(this->pvtOil_, "Oil");
+
+        const auto rs = disgasVector(this->graph_, this->disgas_, rstrt);
+
+        this->regionLoop([this, &rs, &dyn_data]
+            (const int regID)
+        {
+            // Note: This section assumes that 'regID' is a traditional
+            // ECL-style one-based region ID such as PVTNUM.  Subtract one,
+            // where approriate, to generate zero-based region indices.
+
+            const auto Rs = ECLPVT::Oil::DissolvedGas {
+                this->gatherRegionSubset(regID, rs)
+            };
+
+            const auto Po = ECLPVT::Oil::OilPressure {
+                // Recall: dyn_data.pressure is Po directly from 'rstrt'.
+                this->gatherRegionSubset(regID, dyn_data.pressure)
+            };
+
+            // Mass Density at Reservoir Conditions.  Relies on setup code
+            // having allocated sufficient space.
+            {
+                const auto rhoOS =
+                    this->pvtOil_->surfaceMassDensity(regID - 1);
+
+                const auto rhoGS = this->disgas_
+                    ? this->pvtGas_->surfaceMassDensity(regID - 1)
+                    : 0.0;
+
+                const auto Bo = this->pvtOil_
+                    ->formationVolumeFactor(regID - 1, Rs, Po);
+
+                auto rhoOr = std::vector<double>{};
+                rhoOr.reserve(Bo.size());
+
+                std::transform(std::begin(Bo),
+                               std::end  (Bo),
+                               std::begin(Rs.data),
+                               std::back_inserter(rhoOr),
+                    [rhoOS, rhoGS]
+                    (const double Bo_i, const double Rs_i)
+                {
+                    return (rhoOS + rhoGS*Rs_i) / Bo_i;
+                });
+
+                this->scatterRegionResults(regID, rhoOr, dyn_data.density);
+            }
+
+            // Convert relative permeability values into mobility values
+            // (divide by phase viscosity).  Relies on setup code having
+            // computed relative permeability for the phase.
+            {
+                const auto mu = this->pvtOil_->viscosity(regID - 1, Rs, Po);
+
+                this->computePhaseMobility(regID, mu, dyn_data);
+            }
+        });
+
+        return std::move(dyn_data);
+    }
+
+
+
+
+
+    ECLFluxCalc::DynamicData
+    ECLFluxCalc::watPVT(DynamicData&& dyn_data) const
+    {
+        verify_active_phase(this->pvtWat_, "Water");
+
+        this->regionLoop([this, &dyn_data]
+            (const int regID)
+        {
+            // Note: This section assumes that 'regID' is a traditional
+            // ECL-style one-based region ID such as PVTNUM.  Subtract one,
+            // where approriate, to generate zero-based region indices.
+
+            const auto Pw = ECLPVT::Water::WaterPressure {
+                // Cheating.  This is Po.
+                this->gatherRegionSubset(regID, dyn_data.pressure)
+            };
+
+            // Mass Density at Reservoir Conditions.  Relies on setup code
+            // having allocated sufficient space.
+            {
+                const auto rhoWS =
+                    this->pvtWat_->surfaceMassDensity(regID - 1);
+
+                const auto Bw = this->pvtWat_
+                    ->formationVolumeFactor(regID - 1, Pw);
+
+                auto rhoWr = std::vector<double>{};
+                rhoWr.reserve(Bw.size());
+
+                std::transform(std::begin(Bw),
+                               std::end  (Bw),
+                               std::back_inserter(rhoWr),
+                    [rhoWS](const double Bw_i)
+                {
+                    return rhoWS / Bw_i;
+                });
+
+                this->scatterRegionResults(regID, rhoWr, dyn_data.density);
+            }
+
+            // Convert relative permeability values into mobility values
+            // (divide by phase viscosity).  Relies on setup code having
+            // computed relative permeability for the phase.
+            {
+                const auto mu = this->pvtWat_->viscosity(regID - 1, Pw);
+
+                this->computePhaseMobility(regID, mu, dyn_data);
+            }
+        });
+
+        return std::move(dyn_data);
+    }
+
+
+
+
+
+    void
+    ECLFluxCalc::computePhaseMobility(const int                  regID,
+                                      const std::vector<double>& mu,
+                                      DynamicData&               dyn_data) const
+    {
+        auto kr = this->gatherRegionSubset(regID, dyn_data.mobility);
+
+        std::transform(std::begin(kr), std::end  (kr),
+                       std::begin(mu), std::begin(kr),
+                       std::divides<double>());
+
+        this->scatterRegionResults(regID, kr, dyn_data.mobility);
+    }
 
 } // namespace Opm

--- a/opm/utility/ECLPiecewiseLinearInterpolant.hpp
+++ b/opm/utility/ECLPiecewiseLinearInterpolant.hpp
@@ -1,0 +1,349 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLSIMPLE1DINTERPOLANT_HEADER_INCLUDED
+#define OPM_ECLSIMPLE1DINTERPOLANT_HEADER_INCLUDED
+
+#include <opm/utility/ECLTableInterpolation1D.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace Opm { namespace Interp1D { namespace PiecewisePolynomial {
+
+    /// Piecewise linear interpolation in set of result columns.
+    ///
+    /// \tparam Extrapolation Policy class for determining how to
+    ///    extrapolate results outside the range covered by the independent
+    ///    variate.  Must support member functions \c left and \c right that
+    ///    extrapolate a tabulated function to the left and right of the
+    ///    input range, respectively.  Typically a policy class from
+    ///    namespace ExtrapolationPolicy.
+    ///
+    /// \tparam IsAscendingRange Flag for whether or not the input range is
+    ///    sorted ascendingly or descendingly.  Class \c Linear assumes that
+    ///    the input range is sorted, so if \code IsAscendingRange = false
+    ///    \endcode, this implies that the input range is treated as being
+    ///    sorted descendingly (i.e., as if by \code std::sort(begin, end,
+    ///    std::greater<>{}) \endcode.
+    template <class Extrapolation, bool IsAscendingRange = true>
+    class Linear
+    {
+    public:
+        /// Constructor.
+        ///
+        /// Essentially a hack.  This creates an invalid interpolant and
+        /// exists only to support creating an object backed by an empty
+        /// range that will be subsequently discarded and not actually used.
+        /// This, in turn, is useful in the construction of live oil/wet gas
+        /// property interpolants that have padded tables.
+        ///
+        /// \param[in] extrap Instance of the configured extrapolation
+        ///    policy class.
+        explicit Linear(Extrapolation&& extrap)
+            : extrap_(std::forward<Extrapolation>(extrap))
+            , nCols_ (0)
+        {}
+
+        /// Constructor.
+        ///
+        /// \tparam ElmIterator Iterator over the elements of an input range
+        ///    or a result column.  Typically \code
+        ///    std::vector<double>::const_iterator \endcode.
+        ///
+        /// \tparam ValueTransform Representation of a value transformation
+        ///    that, often, effects unit conversion of input tables.
+        ///    Assumed to implement a function call operator that supports
+        ///    the syntax
+        ///    \code
+        ///       w = ValueTransform(v)
+        ///    \endcode
+        ///
+        /// \param[in] extrap Instance of the configured extrapolation
+        ///    policy class.
+        ///
+        /// \param[in] xBegin Start of range of independent variate.
+        ///
+        /// \param[in] xEnd One past the end of the range of indpendent
+        ///    variate.
+        ///
+        /// \param[in,out] colIt Sequence of ranges of dependent variates.
+        ///    On input, points to beginning of ranges.  On output, each
+        ///    range pointer is advanced across \code std::distance(xBegin,
+        ///    xEnd) \endcode entries.  This assumes that the underlying
+        ///    ranges are formatted according to ECL result set conventions
+        ///    (TAB vector from the INIT file).
+        ///
+        /// \param[in] xTransform Value transformation for the independent
+        ///    variate.  Called for each "valid" element of the input range.
+        ///
+        /// \param[in] colTransform Sequence of value transformations for
+        ///    the dependent variates.  In particular, \code
+        ///    colTransform[i]() \endcode is invoked on the \c i-th
+        ///    dependent variate if and only if the corresponding element of
+        ///    the input range is "valid".
+        template <class ElmIterator, class ValueTransform>
+        Linear(Extrapolation&&                    extrap,
+               ElmIterator                        xBegin,
+               ElmIterator                        xEnd,
+               std::vector<ElmIterator>&          colIt,
+               const ValueTransform&              xTransform,
+               const std::vector<ValueTransform>& colTransform);
+
+        /// Classify an input point according to the range of the
+        /// interpolant's configured independent variate.
+        ///
+        /// Classification is performed according to the configured policy
+        /// for treating the sort order of the input range.
+        ///
+        /// \param[in] x Input point.
+        ///
+        /// \return Classification of the input point \p x.
+        LocalInterpPoint classifyPoint(const double x) const
+        {
+            return LocalInterpPoint::identify(this->x_, x, Ascending_P{});
+        }
+
+        /// Evaluate interpolant of particular dependent variable at
+        /// particular input point.
+        ///
+        /// \param[in] col Column ID of particular dependent variable.
+        ///
+        /// \param[in] pt Input point.  Result of previous call to member
+        ///    function \code classifyPoint() \endcode.
+        ///
+        /// \return Value of dependent variable \p col at interpolation
+        ///    point \p pt.
+        double evaluate(const std::size_t       col,
+                        const LocalInterpPoint& pt) const
+        {
+            if (pt.cat == PointCategory::InRange) {
+                // Common case.  Input point is within range of x_.  Placed
+                // first to enable early return.
+                return this->interpolate(pt, col);
+            }
+
+            auto yval = [this](const std::size_t i,
+                               const std::size_t j) -> double
+            {
+                return this->y(i, j);
+            };
+
+            if (pt.cat == PointCategory::LeftOfRange) {
+                // Extrapolate function ot the left of input range.
+                const auto xmin = this->x_.front();
+
+                return this->extrap_.left(xmin, xmin + pt.t, col, yval);
+            }
+
+            assert (pt.cat == PointCategory::RightOfRange);
+
+            // Extrapolate function ot the right of input range.
+            const auto xmax = this->x_.back();
+            return this->extrap_.right(xmax, xmax + pt.t, col,
+                                       this->x_.size(), yval);
+        }
+
+        /// Retrieve abscissas of interpolant's independent variate.
+        const std::vector<double>& independentVariable() const
+        {
+            return this->x_;
+        }
+
+        /// Retrieve ordinates of one of the interpolant's dependent
+        /// variates.
+        ///
+        /// \param[in] col Column ID of particular dependent variable.
+        ///
+        /// \return Ordinates corresponding to particular dependent variate,
+        ///    with the \c i-th element matching the \c i-th element of the
+        ///    independent variate.
+        std::vector<double> resultVariable(const std::size_t col) const
+        {
+            auto result = std::vector<double>{};
+
+            if (col >= this->nCols_) {
+                throw std::domain_error {
+                    "Result Column Identifier Ouf of Bounds"
+                };
+            }
+
+            result.reserve(this->x_.size());
+            for (auto n = this->x_.size(), i = 0*n; i < n; ++i) {
+                result.push_back(this->y(i, col));
+            }
+
+            return result;
+        }
+
+    private:
+        /// Predicate for ascendingly sorted input ranges.  True_type for
+        /// ascending ranges, false_type for descendingly sorted ranges.
+        using Ascending_P =
+            std::integral_constant<bool, IsAscendingRange>;
+
+        /// Instance of extrapolation policy object.  Invoked when input
+        /// points are outside the range of the table's independent variate.
+        Extrapolation extrap_;
+
+        /// Number of result columns.
+        std::size_t nCols_;
+
+        /// Abscissas (independent variate), compressed to valid points
+        /// only.
+        std::vector<double> x_;
+
+        /// Ordinates of dependent variates, compressed to valid points of
+        /// input range.  Stored with column index (dependent variate ID)
+        /// cycling the most rapidly.
+        std::vector<double> y_;
+
+        /// Evaluate interpolant of particular dependent variable at
+        /// particular input point.
+        ///
+        /// Implements case of input point being within range of table's
+        /// independent variate.
+        ///
+        /// \param[in] col Column ID of particular dependent variable.
+        ///
+        /// \param[in] pt Input point.  Result of previous call to member
+        ///    function \code classifyPoint() \endcode.
+        ///
+        /// \return Value of dependent variable \p col at interpolation
+        ///    point \p pt.
+        double interpolate(const LocalInterpPoint& pt,
+                           const std::size_t       col) const
+        {
+            assert (pt.cat == PointCategory::InRange);
+            assert (pt.interval + 1 < this->x_.size());
+
+            const auto left = pt.interval + 0;
+            const auto xl   = this->x_[left];
+            const auto yl   = this->y (left, col);
+
+            const auto right = pt.interval + 1;
+            const auto xr    = this->x_[right];
+            const auto yr    = this->y (right, col);
+
+            const auto t = pt.t / (xr - xl);
+
+            return t*yr + (1.0 - t)*yl;
+        }
+
+        /// Retrieve value of ordinate at specified row and column pair.
+        ///
+        /// \param[in] row Row index.
+        ///
+        /// \param[in] col Column index.
+        ///
+        /// \return Ordinate at index \code (row, col) \endcode.
+        double y(const std::size_t row,
+                 const std::size_t col) const
+        {
+            // Recall: this->y_ stored with column index cycling the most
+            // rapidly.
+
+            assert (col < this->nCols_);
+            assert (row*this->nCols_ + col < this->y_.size());
+
+            return this->y_[row*this->nCols_ + col];
+        }
+    };
+
+    template <class Extrapolation, bool IsAscendingRange>
+    template <class ElmIterator, class ValueTransform>
+    Linear<Extrapolation, IsAscendingRange>::
+    Linear(Extrapolation&&                    extrap,
+           ElmIterator                        xBegin,
+           ElmIterator                        xEnd,
+           std::vector<ElmIterator>&          colIt,
+           const ValueTransform&              xTransform,
+           const std::vector<ValueTransform>& colTransform)
+        : extrap_(std::forward<Extrapolation>(extrap))
+        , nCols_ (colIt.size())
+    {
+        // There must be at least one dependent variable/result variable.
+        assert (colIt.size() >= 1);
+
+        const auto nRows = std::distance(xBegin, xEnd);
+
+        this->x_.reserve(nRows);
+        this->y_.reserve(nRows * colIt.size());
+
+        auto keyValid = [](const double xi)
+        {
+            // Indep. variable values <= -1.0e20 or >= 1.0e20 signal
+            // "unused" table nodes (rows).  These nodes are in the table to
+            // fill out the allocated size if one particular sub-table does
+            // not use all nodes.  The magic value 1.0e20 is documented in
+            // the Fileformats Reference Manual.
+            return std::abs(xi) < 1.0e20;
+        };
+
+        while (xBegin != xEnd) {
+            // Extract relevant portion of the table.  Preallocated rows
+            // that are not actually part of the result set (i.e., those
+            // that are set to a sentinel value) are discarded.
+            if (keyValid(*xBegin)) {
+                this->x_.push_back(xTransform(*xBegin));
+
+                auto colID = 0*colTransform.size();
+                for (auto ci : colIt) {
+                    // Store 'y_' with column index cycling most rapidly.
+                    this->y_.push_back(colTransform[colID++](*ci));
+                }
+            }
+
+            // -------------------------------------------------------------
+            // Advance iterators.
+
+            // 1) Independent variable.
+            ++xBegin;
+
+            // 2) Dependent/result/columns.
+            for (auto& ci : colIt) {
+                ++ci;
+            }
+        }
+
+        // Dispose of any excess capacity.
+        if (this->x_.size() < static_cast<decltype(this->x_.size())>(nRows)) {
+            this->x_.shrink_to_fit();
+            this->y_.shrink_to_fit();
+        }
+
+        if (this->x_.size() < 2) {
+            // Table has no interval that supports interpolation.  Either
+            // just a single node or no nodes at all.  We can't do anything
+            // useful here, so don't pretend that this is okay.
+
+            throw std::invalid_argument {
+                "No Interpolation Intervals of Non-Zero Size"
+            };
+        }
+    }
+
+}}} // Opm::Interp1D::PiecewisePolynomial
+
+#endif // OPM_ECLSIMPLE1DINTERPOLANT_HEADER_INCLUDED

--- a/opm/utility/ECLPiecewiseLinearInterpolant.hpp
+++ b/opm/utility/ECLPiecewiseLinearInterpolant.hpp
@@ -154,15 +154,14 @@ namespace Opm { namespace Interp1D { namespace PiecewisePolynomial {
                 // Extrapolate function ot the left of input range.
                 const auto xmin = this->x_.front();
 
-                return this->extrap_.left(xmin, xmin + pt.t, col, yval);
+                return this->extrap_.left(this->x_, xmin + pt.t, col, yval);
             }
 
             assert (pt.cat == PointCategory::RightOfRange);
 
             // Extrapolate function ot the right of input range.
             const auto xmax = this->x_.back();
-            return this->extrap_.right(xmax, xmax + pt.t, col,
-                                       this->x_.size(), yval);
+            return this->extrap_.right(this->x_, xmax + pt.t, col, yval);
         }
 
         /// Retrieve abscissas of interpolant's independent variate.

--- a/opm/utility/ECLPropTable.cpp
+++ b/opm/utility/ECLPropTable.cpp
@@ -30,136 +30,24 @@
 Opm::SatFuncInterpolant::SingleTable::
 SingleTable(ElmIt               xBegin,
             ElmIt               xEnd,
+            const ConvertUnits& convert,
             std::vector<ElmIt>& colIt)
+    : interp_(Extrap{}, xBegin, xEnd, colIt,
+              convert.indep, convert.column)
 {
-    // There must be at least one dependent variable/result variable.
-    assert (colIt.size() >= 1);
-
-    const auto nRows = std::distance(xBegin, xEnd);
-
-    this->x_.reserve(nRows);
-    this->y_.reserve(nRows * colIt.size());
-
-    auto keyValid = [](const double xi)
-    {
-        // Indep. variable values <= -1.0e20 or >= 1.0e20 signal "unused"
-        // table nodes (rows).  These nodes are in the table to fill out the
-        // allocated size if one particular sub-table does not use all
-        // nodes.  The magic value 1.0e20 is documented in the Fileformats
-        // Reference Manual.
-        return std::abs(xi) < 1.0e20;
-    };
-
-    while (xBegin != xEnd) {
-        // Extract relevant portion of the table.  Preallocated rows that
-        // are not actually part of the result set (i.e., those that are set
-        // to a sentinel value) are discarded.
-        if (keyValid(*xBegin)) {
-            this->x_.push_back(*xBegin);
-
-            for (auto ci : colIt) {
-                // Store 'y_' with column index cycling most rapidly.
-                this->y_.push_back(*ci);
-            }
-        }
-
-        // -------------------------------------------------------------
-        // Advance iterators.
-
-        // 1) Independent variable.
-        ++xBegin;
-
-        // 2) Dependent/result/columns.
-        for (auto& ci : colIt) {
-            ++ci;
-        }
-    }
-
-    // Dispose of any excess capacity.
-    if (this->x_.size() < static_cast<decltype(this->x_.size())>(nRows)) {
-        this->x_.shrink_to_fit();
-        this->y_.shrink_to_fit();
-    }
-
-    if (this->x_.size() < 2) {
-        // Table has no interval that supports interpolation.  Either just a
-        // single node or no nodes at all.  We can't do anything useful
-        // here, so don't pretend that this is okay.
-
-        throw std::invalid_argument {
-            "No Interpolation Intervals of Non-Zero Size"
-        };
-    }
-}
-
-double
-Opm::SatFuncInterpolant::SingleTable::
-y(const ECLPropTableRawData::SizeType nCols,
-  const ECLPropTableRawData::SizeType row,
-  const ResultColumn&                 c) const
-{
-    assert (row * nCols < this->y_.size());
-    assert (c.i < nCols);
-
-    // Recall: 'y_' stored with column index cycling the most rapidly (row
-    // major ordering).
-    return this->y_[row*nCols + c.i];
 }
 
 std::vector<double>
 Opm::SatFuncInterpolant::SingleTable::
-interpolate(const ECLPropTableRawData::SizeType nCols,
-            const ResultColumn&                 c,
-            const std::vector<double>&          x) const
+interpolate(const ResultColumn&        c,
+            const std::vector<double>& x) const
 {
     auto y = std::vector<double>{};  y.reserve(x.size());
 
-    auto yval = [nCols, c, this]
-        (const ECLPropTableRawData::SizeType i)
-    {
-        return this->y(nCols, i, c);
-    };
-
-    const auto yfirst =
-        yval(ECLPropTableRawData::SizeType{ 0 });
-
-    const auto ylast =
-        yval(ECLPropTableRawData::SizeType{ this->x_.size() - 1 });
-
     for (const auto& xi : x) {
-        y.push_back(0.0);
-        auto& yi = y.back();
+        const auto pt = this->interp_.classifyPoint(xi);
 
-        if (! (xi > this->x_.front())) {
-            // Constant extrapolation to the left of range.
-            yi = yfirst;
-        }
-        else if (! (xi < this->x_.back())) {
-            // Constant extrapolation to the right of range.
-            yi = ylast;
-        }
-        else {
-            // Somewhere in [min(x_), max(x_)].  Primary key (indep. var) is
-            // sorted range.  Recall: lower_bound() returns insertion point,
-            // which translates to the *upper* (right-hand) end-point of the
-            // interval in this context.
-            auto b = std::begin(this->x_);
-            auto p = std::lower_bound(b, std::end(this->x_), xi);
-
-            assert ((p != b) && "Logic Error Left End-Point");
-            assert ((p != std::end(this->x_)) &&
-                    "Logic Error Right End-Point");
-
-            // p = lower_bound() => left == i-1, right == i-0.
-            const auto i     = p - b;
-            const auto left  = i - 1;
-            const auto right = i - 0;
-
-            const auto xl = this->x_[left];
-            const auto t  = (xi - xl) / (this->x_[right] - xl);
-
-            yi = (1.0 - t)*yval(left) + t*yval(right);
-        }
+        y.push_back(this->interp_.evaluate(c.i, pt));
     }
 
     return y;
@@ -168,13 +56,12 @@ interpolate(const ECLPropTableRawData::SizeType nCols,
 double
 Opm::SatFuncInterpolant::SingleTable::connateSat() const
 {
-    return this->x_.front();
+    return this->interp_.independentVariable().front();
 }
 
 double
 Opm::SatFuncInterpolant::SingleTable::
-criticalSat(const ECLPropTableRawData::SizeType nCols,
-            const ResultColumn&                 c) const
+criticalSat(const ResultColumn& c) const
 {
     // Note: Relative permeability functions are presented as non-decreasing
     // functions of the corresponding phase saturation.  The internal table
@@ -184,11 +71,13 @@ criticalSat(const ECLPropTableRawData::SizeType nCols,
     // linear scan from row=0 to row=n-1 irrespective of the input format of
     // the current saturation function.
 
-    const auto nRows = this->x_.size();
+    const auto y = this->interp_.resultVariable(c.i);
+
+    const auto nRows = y.size();
 
     auto row = 0 * nRows;
     for (; row < nRows; ++row) {
-        if (this->y(nCols, row, c) > 0.0) { break; }
+        if (y[row] > 0.0) { break; }
     }
 
     if (row == 0) {
@@ -197,18 +86,19 @@ criticalSat(const ECLPropTableRawData::SizeType nCols,
         };
     }
 
-    return this->x_[row - 1];
+    return this->interp_.independentVariable()[row - 1];
 }
 
 double
 Opm::SatFuncInterpolant::SingleTable::maximumSat() const
 {
-    return this->x_.back();
+    return this->interp_.independentVariable().back();
 }
 
 // =====================================================================
 
-Opm::SatFuncInterpolant::SatFuncInterpolant(const ECLPropTableRawData& raw)
+Opm::SatFuncInterpolant::SatFuncInterpolant(const ECLPropTableRawData& raw,
+                                            const ConvertUnits&        convert)
     : nResCols_(raw.numCols - 1)
 {
     if (raw.numCols < 2) {
@@ -241,7 +131,7 @@ Opm::SatFuncInterpolant::SatFuncInterpolant(const ECLPropTableRawData& raw)
         // Note: The SingleTable ctor advances each 'colIt' across numRows
         // entries.  That is a bit of a layering violation, but helps in the
         // implementation of this loop.
-        this->table_.push_back(SingleTable(xBegin, xEnd, colIt));
+        this->table_.push_back(SingleTable(xBegin, xEnd, convert, colIt));
     }
 }
 
@@ -262,7 +152,7 @@ Opm::SatFuncInterpolant::interpolate(const InTable&             t,
         };
     }
 
-    return this->table_[t.i].interpolate(this->nResCols_, c, x);
+    return this->table_[t.i].interpolate(c, x);
 }
 
 std::vector<double>
@@ -285,7 +175,7 @@ Opm::SatFuncInterpolant::criticalSat(const ResultColumn& c) const
     scrit.reserve(this->table_.size());
 
     for (const auto& t : this->table_) {
-        scrit.push_back(t.criticalSat(this->nResCols_, c));
+        scrit.push_back(t.criticalSat(c));
     }
 
     return scrit;

--- a/opm/utility/ECLPropTable.hpp
+++ b/opm/utility/ECLPropTable.hpp
@@ -47,19 +47,32 @@ namespace Opm {
 
         /// Raw table data.  Column major (Fortran) order.  Typically
         /// copied/extracted directly from TAB vector of INIT result-set.
-        DataVector data;
+        /// Array of size \code numRows * numCols * numPrimary \endcode for
+        /// each table, stored consecutively.
+        DataVector data{};
+
+        /// Primary lookup key for 2D interpolation.  Only relevant for PVT
+        /// tables of wet gas and/or live oil (Pg or Rs, respectively).
+        /// Array of size \c numPrimary elements for each table, stored
+        /// consecutively.
+        DataVector primaryKey{};
+
+        /// Number of primary key elements for each individual table.  Only
+        /// relevant (i.e., != 1) for PVT tables of wet gas and/or live oil.
+        SizeType numPrimary{0};
 
         /// Number of rows allocated in the result set for each individual
-        /// table.  Typically corresponds to setting in one of the *DIMS
-        /// keywords.  Should normally be at least two.
-        SizeType numRows;
+        /// primary key.  Typically corresponds to setting in one of the
+        /// *DIMS keywords.  Should normally be at least two for saturation
+        /// functions.
+        SizeType numRows{0};
 
         /// Number of columns in this table.  Varies by keyword/table.
-        SizeType numCols;
+        SizeType numCols{0};
 
         /// Number of tables of this type.  Must match the corresponding
         /// region keyword.
-        SizeType numTables;
+        SizeType numTables{0};
     };
 
     /// Collection of 1D interpolants from tabulated functions (e.g., the

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -1,0 +1,246 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLPvtCommon.hpp>
+
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <functional>
+
+namespace {
+    double fvfScale(const ::Opm::ECLUnits::UnitSystem& usys)
+    {
+        // B = [rVolume / sVolume(Liquid)]
+        return usys.reservoirVolume()
+            /  usys.surfaceVolumeLiquid();
+    }
+
+    double fvfGasScale(const ::Opm::ECLUnits::UnitSystem& usys)
+    {
+        // B = [rVolume / sVolume(Gas)]
+        return usys.reservoirVolume()
+            /  usys.surfaceVolumeGas();
+    }
+
+    double rsScale(const ::Opm::ECLUnits::UnitSystem& usys)
+    {
+        // Rs = [sVolume(Gas) / sVolume(Liquid)]
+        return usys.surfaceVolumeGas()
+            /  usys.surfaceVolumeLiquid();
+    }
+
+    double rvScale(const ::Opm::ECLUnits::UnitSystem& usys)
+    {
+        // Rv = [sVolume(Liq) / sVolume(Gas)]
+        return usys.surfaceVolumeLiquid()
+            /  usys.surfaceVolumeGas();
+    }
+
+    ::Opm::ECLPVT::ConvertUnits::Converter
+    createConverterToSI(const double uscale)
+    {
+        return ::Opm::ECLPVT::ConvertUnits::Converter {
+            [uscale](const double q) -> double
+            {
+                return ::Opm::unit::convert::from(q, uscale);
+            }
+        };
+    }
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+pressure(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    return createConverterToSI(usys.pressure());
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+disGas(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    return createConverterToSI(rsScale(usys));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+vapOil(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    return createConverterToSI(rvScale(usys));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvf(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    return createConverterToSI(1.0 / fvfScale(usys));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfDerivPress(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/B)/dp
+    const auto B_scale = fvfScale(usys);
+    const auto P_scale = usys.pressure();
+
+    return createConverterToSI(1.0 / (B_scale * P_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/B)/dRv
+    const auto B_scale  = fvfScale(usys);
+    const auto Rv_scale = rvScale(usys);
+
+    return createConverterToSI(1.0 / (B_scale * Rv_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfVisc(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    const auto Bscale     = fvfScale(usys);
+    const auto visc_scale = usys.viscosity();
+
+    return createConverterToSI(1.0 / (Bscale * visc_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfViscDerivPress(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/(B*mu))/dp
+    const auto B_scale  = fvfScale(usys);
+    const auto P_scale  = usys.pressure();
+    const auto mu_scale = usys.viscosity();
+
+    return createConverterToSI(1.0 / (B_scale * mu_scale * P_scale));
+}
+
+::Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfViscDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/(B*mu))/dRv
+    const auto B_scale  = fvfScale(usys);
+    const auto mu_scale = usys.viscosity();
+    const auto Rv_scale = rvScale(usys);
+
+    return createConverterToSI(1.0 / (B_scale * mu_scale * Rv_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfGas(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    return createConverterToSI(1.0 / fvfGasScale(usys));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfGasDerivPress(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/B)/dp
+    const auto B_scale = fvfGasScale(usys);
+    const auto P_scale = usys.pressure();
+
+    return createConverterToSI(1.0 / (B_scale * P_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfGasDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/B)/dRv
+    const auto B_scale  = fvfGasScale(usys);
+    const auto Rv_scale = rvScale(usys);
+
+    return createConverterToSI(1.0 / (B_scale * Rv_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfGasVisc(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    const auto Bscale     = fvfGasScale(usys);
+    const auto visc_scale = usys.viscosity();
+
+    return createConverterToSI(1.0 / (Bscale * visc_scale));
+}
+
+Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfGasViscDerivPress(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/(B*mu))/dp
+    const auto B_scale  = fvfGasScale(usys);
+    const auto P_scale  = usys.pressure();
+    const auto mu_scale = usys.viscosity();
+
+    return createConverterToSI(1.0 / (B_scale * mu_scale * P_scale));
+}
+
+::Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+recipFvfGasViscDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    // d(1/(B*mu))/dRv
+    const auto B_scale  = fvfGasScale(usys);
+    const auto mu_scale = usys.viscosity();
+    const auto Rv_scale = rvScale(usys);
+
+    return createConverterToSI(1.0 / (B_scale * mu_scale * Rv_scale));
+}
+
+// =====================================================================
+
+Opm::ECLPVT::PVDx::PVDx(ElemIt               xBegin,
+                        ElemIt               xEnd,
+                        const ConvertUnits&  convert,
+                        std::vector<ElemIt>& colIt)
+    : interp_(Extrap{2}, xBegin, xEnd, colIt,
+              convert.indep, convert.column)
+{}
+
+std::vector<double>
+Opm::ECLPVT::PVDx::formationVolumeFactor(const std::vector<double>& p) const
+{
+    return this->computeQuantity(p,
+        [this](const EvalPt& pt) -> double
+    {
+        // 1 / (1 / B)
+        return 1.0 / this->fvf_recip(pt);
+    });
+}
+
+std::vector<double>
+Opm::ECLPVT::PVDx::viscosity(const std::vector<double>& p) const
+{
+    return this->computeQuantity(p,
+        [this](const EvalPt& pt) -> double
+    {
+        // (1 / B) / (1 / (B * mu)
+        return this->fvf_recip(pt) / this->fvf_mu_recip(pt);
+    });
+}

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -73,6 +73,13 @@ pressure(const ::Opm::ECLUnits::UnitSystem& usys)
     return createConverterToSI(usys.pressure());
 }
 
+::Opm::ECLPVT::ConvertUnits::Converter
+Opm::ECLPVT::CreateUnitConverter::ToSI::
+compressibility(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    return createConverterToSI(1.0 / usys.pressure());
+}
+
 Opm::ECLPVT::ConvertUnits::Converter
 Opm::ECLPVT::CreateUnitConverter::ToSI::
 disGas(const ::Opm::ECLUnits::UnitSystem& usys)

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -226,7 +226,7 @@ Opm::ECLPVT::PVDx::PVDx(ElemIt               xBegin,
                         ElemIt               xEnd,
                         const ConvertUnits&  convert,
                         std::vector<ElemIt>& colIt)
-    : interp_(Extrap{2}, xBegin, xEnd, colIt,
+    : interp_(Extrap{}, xBegin, xEnd, colIt,
               convert.indep, convert.column)
 {}
 

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_ECLPVTCOMMON_HEADER_INCLUDED
 #define OPM_ECLPVTCOMMON_HEADER_INCLUDED
 
+#include <opm/utility/ECLPhaseIndex.hpp>
 #include <opm/utility/ECLPiecewiseLinearInterpolant.hpp>
 #include <opm/utility/ECLPropTable.hpp>
 #include <opm/utility/ECLTableInterpolation1D.hpp>
@@ -40,6 +41,10 @@
 /// volume factor, viscosities &c) for oil or gas based on tabulated
 /// descriptions as represented in an ECL result set (INIT file 'TAB'
 /// vector).
+
+namespace Opm {
+    class ECLInitFileData;
+} // Opm
 
 namespace Opm { namespace ECLPVT {
 
@@ -63,6 +68,17 @@ namespace Opm { namespace ECLPVT {
         /// Convert quantities from native representations to strict SI
         /// units of measure.
         struct ToSI {
+            /// Convert quantities of type mass density (\rho) to
+            /// strict SI units of measure (i.e., to kg/m^3).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            density(const ::Opm::ECLUnits::UnitSystem& usys);
+
             /// Convert quantities of type pressure to strict SI units of
             /// measure (i.e., to Pascal units).
             ///
@@ -715,6 +731,14 @@ namespace Opm { namespace ECLPVT {
         }
     };
 
+    /// Extract component mass density at surface conditions.
+    ///
+    /// \param[in] init ECL result set INIT file representation.
+    ///
+    /// \param[in] phase
+    std::vector<double>
+    surfaceMassDensity(const ECLInitFileData& init,
+                       const ECLPhaseIndex    phase);
 }} // Opm::ECLPVT
 
 #endif // OPM_ECLPVTCOMMON_HEADER_INCLUDED

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -1,0 +1,586 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPVTCOMMON_HEADER_INCLUDED
+#define OPM_ECLPVTCOMMON_HEADER_INCLUDED
+
+#include <opm/utility/ECLPiecewiseLinearInterpolant.hpp>
+#include <opm/utility/ECLPropTable.hpp>
+#include <opm/utility/ECLTableInterpolation1D.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <functional>
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+/// \file
+///
+/// Facility for evaluating pressure-dependent fluid properties (formation
+/// volume factor, viscosities &c) for oil or gas based on tabulated
+/// descriptions as represented in an ECL result set (INIT file 'TAB'
+/// vector).
+
+namespace Opm { namespace ECLPVT {
+
+    /// Protocol for converting raw table input data to strict SI unit
+    /// conventions.
+    struct ConvertUnits
+    {
+        /// Convenience type alias for a value transformation.
+        using Converter = std::function<double(const double)>;
+
+        /// How to convert the independent variate (1st column)
+        Converter indep;
+
+        /// How to convert the dependent variates (2nd... columns).
+        std::vector<Converter> column;
+    };
+
+    /// Collection of unit converters for PVT quantities tabulated in a
+    /// result set's INIT file.
+    struct CreateUnitConverter {
+        /// Convert quantities from native representations to strict SI
+        /// units of measure.
+        struct ToSI {
+            /// Convert quantities of type pressure to strict SI units of
+            /// measure (i.e., to Pascal units).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            pressure(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert quantities of type dissolved gas-oil ratio (Rs) to
+            /// strict SI units of measure (i.e., to Sm^3/Sm^3).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            disGas(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert quantities of type vaporised oil-gas ratio (Rv) to
+            /// strict SI units of measure (i.e., to Sm^3/Sm^3).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            vapOil(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert quantities of type reciprocal formation volume
+            /// factor (1/B) to strict SI units of measure (i.e., to
+            /// Sm^3/Rm^3).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvf(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal
+            /// formation volume factor (1/B) with respect to fluid pressure
+            /// to strict SI units of measure (i.e., to Sm^3/(Rm^3 * Pa)).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfDerivPress(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal
+            /// formation volume factor (1/B) with respect to vaporised
+            /// oil-gas ratio to strict SI units of measure (i.e., to
+            /// Sm^3/(Rm^3 * (Sm^3 / Sm^3))).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert quantities of type reciprocal product of formation
+            /// volume factor and phase viscosity (1/(B * mu)) to strict SI
+            /// units of measure (i.e., to Sm^3/(Rm^3 * Pa*s)).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfVisc(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal product
+            /// of formation volume factor and phase viscosity (1/(B * mu))
+            /// with respect to fluid pressure to strict SI units of measure
+            /// (i.e., to Sm^3/(Rm^3 * Pa*s * Pa)).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfViscDerivPress(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal product
+            /// of formation volume factor and phase viscosity (1/(B * mu))
+            /// with respect to vaporised oil-gas ratio to strict SI units
+            /// of measure (i.e., to Sm^3/(Rm^3 * Pa*s * (Sm^3/Sm^3))).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfViscDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert quantities of type reciprocal formation volume
+            /// factor (1/B) to strict SI units of measure (i.e., to
+            /// Sm^3/Rm^3).
+            ///
+            /// Specialisation for Gas.
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfGas(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal
+            /// formation volume factor (1/B) with respect to fluid pressure
+            /// to strict SI units of measure (i.e., to Sm^3/(Rm^3 * Pa)).
+            ///
+            /// Specialisation for Gas.
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfGasDerivPress(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal
+            /// formation volume factor (1/B) with respect to vaporised
+            /// oil-gas ratio to strict SI units of measure (i.e., to
+            /// Sm^3/(Rm^3 * (Sm^3 / Sm^3))).
+            ///
+            /// Specialisation for Gas.
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfGasDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert quantities of type reciprocal product of formation
+            /// volume factor and phase viscosity (1/(B * mu)) to strict SI
+            /// units of measure (i.e., to Sm^3/(Rm^3 * Pa*s)).
+            ///
+            /// Specialisation for Gas.
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfGasVisc(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal product
+            /// of formation volume factor and phase viscosity (1/(B * mu))
+            /// with respect to fluid pressure to strict SI units of measure
+            /// (i.e., to Sm^3/(Rm^3 * Pa*s * Pa)).
+            ///
+            /// Specialisation for Gas.
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfGasViscDerivPress(const ::Opm::ECLUnits::UnitSystem& usys);
+
+            /// Convert derivatives of quantities of type reciprocal product
+            /// of formation volume factor and phase viscosity (1/(B * mu))
+            /// with respect to vaporised oil-gas ratio to strict SI units
+            /// of measure (i.e., to Sm^3/(Rm^3 * Pa*s * (Sm^3/Sm^3))).
+            ///
+            /// Specialisation for Gas.
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            recipFvfGasViscDerivVapOil(const ::Opm::ECLUnits::UnitSystem& usys);
+        };
+    };
+
+    /// Evaluate pressure-dependent properties (formation volume factor,
+    /// viscosity &c) for dead oil (PVDO) or dry gas (PVDG) from tabulated
+    /// functions as represented in an ECL result set (ECLInitData).
+    class PVDx
+    {
+    public:
+        /// Convenience type alias.
+        using ElemIt = ECLPropTableRawData::ElementIterator;
+
+        /// Constructor.
+        ///
+        /// \param[in] xBegin Starting position of range of independent
+        ///    variable (phase pressure).
+        ///
+        /// \param[in] xEnd One past the end of range of independent
+        ///    variable.  Must be reachable from \p xBegin.
+        ///
+        /// \param[in,out] colIt Column iterators that reference the
+        ///    dependent variables (reciprocal FVF &c).  Should be size 4 to
+        ///    represent the FVF, the viscosity and the derivatives with
+        ///    respect to phase pressure.  On input, positioned at the
+        ///    beginning of a single table's dependent variables columns.
+        ///    On output, advanced across \code std::distance(xBegin, xEnd)
+        ///    \endcode rows/entries.
+        PVDx(ElemIt               xBegin,
+             ElemIt               xEnd,
+             const ConvertUnits&  convert,
+             std::vector<ElemIt>& colIt);
+
+        /// Evaluate the phase FVF in selection of pressure points.
+        ///
+        /// \param[in] p Set of phase pressure points.
+        ///
+        /// \return Phase Formation volume factors for each pressure point.
+        std::vector<double>
+        formationVolumeFactor(const std::vector<double>& p) const;
+
+        /// Evaluate the phase viscosity in selection of pressure points.
+        ///
+        /// \param[in] p Set of phase pressure points.
+        ///
+        /// \return Phase viscosity for each pressure point.
+        std::vector<double>
+        viscosity(const std::vector<double>& p) const;
+
+    private:
+        /// Extrapolation policy for property evaluator/interpolant.
+        using Extrap = ::Opm::Interp1D::PiecewisePolynomial::
+            ExtrapolationPolicy::LinearlyWithDerivatives;
+
+        /// Type of fundamental table interpolant.
+        using Backend = ::Opm::Interp1D::PiecewisePolynomial::Linear<Extrap>;
+
+        /// Convenience type alias representing the interpolant's evaluation
+        /// point conventions.
+        using EvalPt = std::decay<
+            decltype(std::declval<Backend>().classifyPoint(0.0))
+        >::type;
+
+        /// Interpolant for table of
+        ///
+        ///    [1/B, 1/(B*mu), d(1/B)/dp, d(1/(B*mu))/dp]
+        ///
+        /// versus "pressure" p--typically phase pressure for oil (Po) or
+        /// gas (Pg).
+        Backend interp_;
+
+        /// Translate pressure value to evaluation point and identify
+        /// relevant extrapolation case if needed.
+        EvalPt getInterpPoint(const double p) const
+        {
+            return this->interp_.classifyPoint(p);
+        }
+
+        /// Interpolate reciprocal FVF at evaluation point.
+        double fvf_recip(const EvalPt& pt) const
+        {
+            const auto col = std::size_t{0};
+
+            return this->interp_.evaluate(col, pt);
+        }
+
+        /// Interpolate reciprocal product of FVF and viscosity at
+        /// evaluation point.
+        double fvf_mu_recip(const EvalPt& pt) const
+        {
+            const auto col = std::size_t{1};
+
+            return this->interp_.evaluate(col, pt);
+        }
+
+        /// Compute a dynamic quantity such as the FVF or viscosity for a
+        /// selection of pressure values.
+        template <class EvalDynamicQuant>
+        std::vector<double>
+        computeQuantity(const std::vector<double>& p,
+                        EvalDynamicQuant&&         eval) const
+        {
+            auto result = std::vector<double>{};
+            result.reserve(p.size());
+
+            for (const auto& pi : p) {
+                result.push_back(eval(this->getInterpPoint(pi)));
+            }
+
+            return result;
+        }
+    };
+
+    /// Evaluate pressure-dependent properties (formation volume factor,
+    /// viscosity &c) for live oil (PVTO) or wet gas (PVTG) from tabulated
+    /// functions as represented in an ECL result set (ECLInitData).
+    template <class SubtableInterpolant>
+    class PVTx
+    {
+    public:
+        PVTx(std::vector<double>              key,
+             std::vector<SubtableInterpolant> propInterp)
+            : key_       (std::move(key))
+            , propInterp_(std::move(propInterp))
+        {
+            if (this->key_.size() != this->propInterp_.size()) {
+                throw std::invalid_argument {
+                    "Size of Key Table Does Not Match "
+                    "Number of Sub-Table Interpolants"
+                };
+            }
+
+            if (this->key_.size() < 2) {
+                throw std::invalid_argument {
+                    "Mixing-Dependent Property Evaluator "
+                    "Must Have At Least Two Inner Tables"
+                };
+            }
+        }
+
+        struct PrimaryKey
+        {
+            const std::vector<double>& data;
+        };
+
+        struct InnerVariate
+        {
+            const std::vector<double>& data;
+        };
+
+        std::vector<double>
+        formationVolumeFactor(const PrimaryKey&   key,
+                              const InnerVariate& x) const
+        {
+            const auto col = std::size_t{0};
+
+            return this->computeQuantity(key, x,
+                [this, col](const std::size_t     curve,
+                            const InnerEvalPoint& pt) -> double
+            {
+                // 1 / (1 / B).
+                return 1 / this->propInterp_[curve].evaluate(col, pt);
+            });
+        }
+
+        std::vector<double>
+        viscosity(const PrimaryKey& key,
+                  const InnerVariate& x) const
+        {
+            return this->computeQuantity(key, x,
+                [this](const std::size_t     curve,
+                       const InnerEvalPoint& pt) -> double
+            {
+                const auto& I = this->propInterp_[curve];
+
+                const auto fvf_recip    = I.evaluate(0, pt);
+                const auto fvf_mu_recip = I.evaluate(1, pt);
+
+                // (1 / B) / (1 / (B*mu))
+                return fvf_recip / fvf_mu_recip;
+            });
+        }
+
+    private:
+        using InnerEvalPoint = typename std::decay<
+            decltype(std::declval<SubtableInterpolant>().classifyPoint(0.0))
+        >::type;
+
+        using OuterInterpPoint =
+            ::Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint;
+
+        struct InnerInterpPoint {
+            InnerEvalPoint left;
+            InnerEvalPoint right;
+        };
+
+        std::vector<double> key_;
+        std::vector<SubtableInterpolant> propInterp_;
+
+        InnerInterpPoint getInterpPoint(const std::size_t i,
+                                        const double      x) const
+        {
+            assert ((i + 1) < this->propInterp_.size());
+
+            return {
+                this->propInterp_[i + 0].classifyPoint(x),
+                this->propInterp_[i + 1].classifyPoint(x)
+            };
+        }
+
+        template <class Function>
+        double interpolate(Function&&              func,
+                           const OuterInterpPoint& outer,
+                           const double            x) const
+        {
+            assert (outer.cat == ::Opm::Interp1D::PointCategory::InRange);
+
+            const auto pt =
+                this->getInterpPoint(outer.interval, x);
+
+            const auto yLeft  = func(outer.interval + 0, pt.left);
+            const auto yRight = func(outer.interval + 1, pt.right);
+
+            const auto t = outer.t / (this->key_[outer.interval + 1] -
+                                      this->key_[outer.interval + 0]);
+
+            // t == 0 => yLeft, t == 1 => yRight
+            return t*yRight + (1.0 - t)*yLeft;
+        }
+
+        template <class Function>
+        double extrapLeft(Function&&              func,
+                          const OuterInterpPoint& outer,
+                          const double            x) const
+        {
+            assert (outer.cat == ::Opm::Interp1D::PointCategory::LeftOfRange);
+            assert (outer.interval == 0*this->key_.size());
+
+            const auto pt =
+                this->getInterpPoint(outer.interval, x);
+
+            const auto yLeft  = func(0, pt.left);
+            const auto yRight = func(1, pt.right);
+
+            const auto dydk =
+                (yRight - yLeft) / (this->key_[1] - this->key_[0]);
+
+            return yLeft + outer.t*dydk;
+        }
+
+        template <class Function>
+        double extrapRight(Function&&              func,
+                           const OuterInterpPoint& outer,
+                           const double            x) const
+        {
+            const auto nIntervals = this->key_.size() - 1;
+
+            assert (outer.cat == ::Opm::Interp1D::PointCategory::RightOfRange);
+            assert (outer.interval == nIntervals);
+
+            const auto pt = this->getInterpPoint(nIntervals - 1, x);
+
+            const auto yLeft  = func(nIntervals - 1, pt.left);
+            const auto yRight = func(nIntervals - 0, pt.right);
+
+            const auto dydk =
+                (yRight - yLeft) / (this->key_[nIntervals - 0] -
+                                    this->key_[nIntervals - 1]);
+
+            return yRight + outer.t*dydk;
+        }
+
+        template <class Function>
+        double evaluate(const double key,
+                        const double x,
+                        Function&&   func) const
+        {
+            const auto outer = ::Opm::Interp1D::PiecewisePolynomial::
+                LocalInterpPoint::identify(this->key_, key);
+
+            switch (outer.cat) {
+            case ::Opm::Interp1D::PointCategory::InRange:
+                return this->interpolate(std::forward<Function>(func),
+                                         outer, x);
+
+            case ::Opm::Interp1D::PointCategory::LeftOfRange:
+                return this->extrapLeft(std::forward<Function>(func),
+                                        outer, x);
+
+            case ::Opm::Interp1D::PointCategory::RightOfRange:
+                return this->extrapRight(std::forward<Function>(func),
+                                         outer, x);
+            }
+
+            throw std::logic_error {
+                "Outer/Primary Key Cannot Be Classified"
+            };
+        }
+
+        template <class Function>
+        std::vector<double>
+        computeQuantity(const PrimaryKey&   key,
+                        const InnerVariate& x,
+                        Function            func) const
+        {
+            auto result = std::vector<double>{};
+
+            const auto nVals = key.data.size();
+
+            if (x.data.size() != nVals) {
+                throw std::invalid_argument {
+                    "Number of Inner Sampling Points Does Not Match "
+                    "Number of Outer Sampling Points"
+                };
+            }
+
+            result.reserve(nVals);
+
+            for (auto i = 0*nVals; i < nVals; ++i) {
+                const auto q =
+                    this->evaluate(key.data[i], x.data[i], func);
+
+                result.push_back(q);
+            }
+
+            return result;
+        }
+    };
+
+}} // Opm::ECLPVT
+
+#endif // OPM_ECLPVTCOMMON_HEADER_INCLUDED

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -70,6 +70,17 @@ namespace Opm { namespace ECLPVT {
             static ConvertUnits::Converter
             pressure(const ::Opm::ECLUnits::UnitSystem& usys);
 
+            /// Convert quantities of type compressibility to strict SI
+            /// units of measure (i.e., to Pascal^-1 units).
+            ///
+            /// \param[in] usys Native unit system for particular result
+            ///    set.
+            ///
+            /// \return Value transformation function affecting requisite
+            ///    unit conversion.
+            static ConvertUnits::Converter
+            compressibility(const ::Opm::ECLUnits::UnitSystem& usys);
+
             /// Convert quantities of type dissolved gas-oil ratio (Rs) to
             /// strict SI units of measure (i.e., to Sm^3/Sm^3).
             ///

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -1,0 +1,540 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLPvtGas.hpp>
+
+#include <opm/utility/ECLPropTable.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ert/ecl/ecl_kw_magic.h>
+
+namespace {
+    ::Opm::ECLPVT::ConvertUnits
+    createDryGasUnitConverter(const int usys)
+    {
+        using ToSI = ::Opm::ECLPVT::CreateUnitConverter::ToSI;
+
+        const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+        // [ Pg, 1/B, 1/(B*mu), d(1/B)/dP, d(1/(B*mu))/dP ]
+        return ::Opm::ECLPVT::ConvertUnits {
+            ToSI::pressure(*u),
+            {
+                ToSI::recipFvfGas(*u),
+                ToSI::recipFvfGasVisc(*u),
+                ToSI::recipFvfGasDerivPress(*u),
+                ToSI::recipFvfGasViscDerivPress(*u)
+            }
+        };
+    }
+
+    std::pair< ::Opm::ECLPVT::ConvertUnits::Converter,
+               ::Opm::ECLPVT::ConvertUnits>
+    wetGasUnitConverter(const int usys)
+    {
+        using ToSI = ::Opm::ECLPVT::CreateUnitConverter::ToSI;
+
+        const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+        // Key   = Pg
+        // Table = [ Rv, 1/B, 1/(B*mu), d(1/B)/dRv, d(1/(B*mu))/dRv ]
+
+        auto cvrtTable = ::Opm::ECLPVT::ConvertUnits {
+            ToSI::vapOil(*u),
+            {
+                ToSI::recipFvfGas(*u),
+                ToSI::recipFvfGasVisc(*u),
+                ToSI::recipFvfGasDerivVapOil(*u),
+                ToSI::recipFvfGasViscDerivVapOil(*u)
+            }
+        };
+
+        return std::make_pair(ToSI::pressure(*u),
+                              std::move(cvrtTable));
+    }
+}
+
+// Enable runtime selection of dry or wet gas functions.
+class PVxGBase
+{
+public:
+    virtual std::vector<double>
+    formationVolumeFactor(const std::vector<double>& rv,
+                          const std::vector<double>& pg) const = 0;
+
+    virtual std::vector<double>
+    viscosity(const std::vector<double>& rv,
+              const std::vector<double>& pg) const = 0;
+
+    virtual std::unique_ptr<PVxGBase> clone() const = 0;
+};
+
+// =====================================================================
+
+class DryGas : public PVxGBase
+{
+public:
+    using ElemIt = ::Opm::ECLPVT::PVDx::ElemIt;
+    using ConvertUnits = ::Opm::ECLPVT::ConvertUnits;
+
+    DryGas(ElemIt               xBegin,
+           ElemIt               xEnd,
+           const ConvertUnits&  convert,
+           std::vector<ElemIt>& colIt)
+        : interpolant_(xBegin, xEnd, convert, colIt)
+    {}
+
+    virtual std::vector<double>
+    formationVolumeFactor(const std::vector<double>& /* rv */,
+                          const std::vector<double>& pg) const override
+    {
+        return this->interpolant_.formationVolumeFactor(pg);
+    }
+
+    virtual std::vector<double>
+    viscosity(const std::vector<double>& /* rv */,
+              const std::vector<double>& pg) const override
+    {
+        return this->interpolant_.viscosity(pg);
+    }
+
+    virtual std::unique_ptr<PVxGBase> clone() const override
+    {
+        return std::unique_ptr<PVxGBase>(new DryGas(*this));
+    }
+
+private:
+    ::Opm::ECLPVT::PVDx interpolant_;
+};
+
+// =====================================================================
+
+class WetGas : public PVxGBase
+{
+public:
+    using Extrap = ::Opm::Interp1D::PiecewisePolynomial::
+        ExtrapolationPolicy::LinearlyWithDerivatives;
+
+    using SubtableInterpolant = ::Opm::Interp1D::PiecewisePolynomial::
+        Linear<Extrap, /* IsAscendingRange = */ false>;
+
+    WetGas(std::vector<double>              key,
+           std::vector<SubtableInterpolant> propInterp)
+        : interp_(std::move(key), std::move(propInterp))
+    {}
+
+    virtual std::vector<double>
+    formationVolumeFactor(const std::vector<double>& rv,
+                          const std::vector<double>& pg) const override
+    {
+        // PKey   Inner   C0     C1         C2           C3
+        // Pg     Rv      1/B    1/(B*mu)   d(1/B)/dRv   d(1/(B*mu))/dRv
+        //        :       :      :          :            :
+        const auto key = TableInterpolant::PrimaryKey { pg };
+        const auto x   = TableInterpolant::InnerVariate { rv };
+
+        return this->interp_.formationVolumeFactor(key, x);
+    }
+
+    virtual std::vector<double>
+    viscosity(const std::vector<double>& rv,
+              const std::vector<double>& pg) const override
+    {
+        // PKey   Inner   C0     C1         C2           C3
+        // Pg     Rv      1/B    1/(B*mu)   d(1/B)/dRv   d(1/(B*mu))/dRv
+        //        :       :      :          :            :
+        const auto key = TableInterpolant::PrimaryKey { pg };
+        const auto x   = TableInterpolant::InnerVariate { rv };
+
+        return this->interp_.viscosity(key, x);
+    }
+
+    virtual std::unique_ptr<PVxGBase> clone() const override
+    {
+        return std::unique_ptr<PVxGBase>(new WetGas(*this));
+    }
+
+private:
+    using TableInterpolant = ::Opm::ECLPVT::PVTx<SubtableInterpolant>;
+
+    TableInterpolant interp_;
+};
+
+// #####################################################################
+
+namespace {
+    std::vector<std::unique_ptr<PVxGBase>>
+    createDryGas(const ::Opm::ECLPropTableRawData& raw,
+                 const int                         usys)
+    {
+        using PVTInterp = std::unique_ptr<PVxGBase>;
+        using ElmIt     = ::Opm::ECLPropTableRawData::ElementIterator;
+
+        assert ((raw.numPrimary == 1) &&
+                "Can't Create Dry Gas Function From Wet Gas Table");
+
+        const auto cvrt = createDryGasUnitConverter(usys);
+
+        return ::Opm::MakeInterpolants<PVTInterp>::fromRawData(raw,
+            [&cvrt](ElmIt xBegin, ElmIt xEnd, std::vector<ElmIt>& colIt)
+        {
+            return PVTInterp{ new DryGas(xBegin, xEnd, cvrt, colIt) };
+        });
+    }
+
+    std::vector<double>
+    extractPrimaryKey(const ::Opm::ECLPropTableRawData&             raw,
+                      const ::Opm::ECLPropTableRawData::SizeType    t,
+                      const ::Opm::ECLPVT::ConvertUnits::Converter& cvrtKey)
+    {
+        auto key = std::vector<double>{};
+        key.reserve(raw.numPrimary);
+
+        for (auto begin = std::begin(raw.primaryKey) + (t + 0)*raw.numPrimary,
+                  end   = begin + raw.numPrimary;
+             begin != end; ++begin)
+        {
+            if (std::abs(*begin) < 1.0e20) {
+                key.push_back(cvrtKey(*begin));
+            }
+        }
+
+        return key;
+    }
+
+    std::vector<std::unique_ptr<PVxGBase>>
+    createWetGas(const ::Opm::ECLPropTableRawData& raw,
+                 const int                         usys)
+    {
+        auto ret = std::vector<std::unique_ptr<PVxGBase>>{};
+        ret.reserve(raw.numTables);
+
+        using Extrap = WetGas::Extrap;
+        using StI    = WetGas::SubtableInterpolant;
+        using ElemIt = ::Opm::ECLPropTableRawData::ElementIterator;
+
+        const auto cvrt = wetGasUnitConverter(usys);
+
+        auto sti = ::Opm::MakeInterpolants<StI>::fromRawData(raw,
+            [&cvrt](ElemIt               xBegin,
+                    ElemIt               xEnd,
+                    std::vector<ElemIt>& colIt) -> StI
+        {
+            try {
+                return StI(Extrap{2}, xBegin, xEnd, colIt,
+                           cvrt.second.indep,
+                           cvrt.second.column);
+            }
+            catch (const std::invalid_argument&) {
+                // No valid nodes.  Return invalid.
+                return StI(Extrap{2});
+            }
+        });
+
+        for (auto t = 0*raw.numTables;
+                  t <   raw.numTables; ++t)
+        {
+            auto key = extractPrimaryKey(raw, t, cvrt.first);
+
+            const auto begin = (t + 0)*raw.numPrimary;
+            const auto end   = begin + key.size();
+
+            ret.emplace_back(new WetGas(std::move(key),
+                {
+                    std::make_move_iterator(std::begin(sti) + begin),
+                    std::make_move_iterator(std::begin(sti) + end)
+                }));
+        }
+
+        return ret;
+    }
+
+    std::vector<std::unique_ptr<PVxGBase>>
+    createPVTFunction(const ::Opm::ECLPropTableRawData& raw,
+                      const int                         usys)
+    {
+        if (raw.numPrimary == 0) {
+            // Malformed Gas PVT table.
+            throw std::invalid_argument {
+                "Gas PVT Table Without Primary Lookup Key"
+            };
+        }
+
+        if (raw.numCols != 5) {
+            throw std::invalid_argument {
+                "PVT Table for Gas Must Have Five Columns"
+            };
+        }
+
+        if (raw.primaryKey.size() != (raw.numPrimary * raw.numTables)) {
+            throw std::invalid_argument {
+                "Size Mismatch in Pressure Nodes of PVT Table for Gas"
+            };
+        }
+
+        if (raw.data.size() !=
+            (raw.numPrimary * raw.numRows * raw.numCols * raw.numTables))
+        {
+            throw std::invalid_argument {
+                "Size Mismatch in Condensed Table Data "
+                "of PVT Table for Gas"
+            };
+        }
+
+        if (raw.numPrimary == 1) {
+            return createDryGas(raw, usys);
+        }
+
+        return createWetGas(raw, usys);
+    }
+
+    std::vector<std::unique_ptr<PVxGBase>>
+    clone(const std::vector<std::unique_ptr<PVxGBase>>& src)
+    {
+        auto dest = std::vector<std::unique_ptr<PVxGBase>>{};
+        dest.reserve(src.size());
+
+        for (const auto& p : src) {
+            dest.push_back(p->clone());
+        }
+
+        return dest;
+    }
+}
+
+// #####################################################################
+// #####################################################################
+
+// =====================================================================
+// Class ECLPVT::Gas::Impl
+// ---------------------------------------------------------------------
+
+class Opm::ECLPVT::Gas::Impl
+{
+private:
+    using EvalPtr = std::unique_ptr<PVxGBase>;
+
+public:
+    Impl(const ECLPropTableRawData& raw, const int usys);
+
+    Impl(const Impl& rhs);
+    Impl(Impl&& rhs);
+
+    Impl& operator=(const Impl& rhs);
+    Impl& operator=(Impl&& rhs);
+
+    using RegIdx = std::vector<EvalPtr>::size_type;
+
+    std::vector<double>
+    formationVolumeFactor(const RegIdx               region,
+                          const std::vector<double>& rv,
+                          const std::vector<double>& pg) const;
+
+    std::vector<double>
+    viscosity(const RegIdx               region,
+              const std::vector<double>& rv,
+              const std::vector<double>& pg) const;
+
+private:
+    std::vector<EvalPtr> eval_;
+
+    void validateRegIdx(const RegIdx region) const;
+};
+
+Opm::ECLPVT::Gas::Impl::
+Impl(const ECLPropTableRawData& raw,
+     const int                  usys)
+    : eval_(createPVTFunction(raw, usys))
+{}
+
+Opm::ECLPVT::Gas::Impl::Impl(const Impl& rhs)
+    : eval_(clone(rhs.eval_))
+{}
+
+Opm::ECLPVT::Gas::Impl::Impl(Impl&& rhs)
+    : eval_(std::move(rhs.eval_))
+{}
+
+Opm::ECLPVT::Gas::Impl&
+Opm::ECLPVT::Gas::Impl::operator=(const Impl& rhs)
+{
+    this->eval_ = clone(rhs.eval_);
+
+    return *this;
+}
+
+Opm::ECLPVT::Gas::Impl&
+Opm::ECLPVT::Gas::Impl::operator=(Impl&& rhs)
+{
+    this->eval_ = std::move(rhs.eval_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::ECLPVT::Gas::Impl::
+formationVolumeFactor(const RegIdx               region,
+                      const std::vector<double>& rv,
+                      const std::vector<double>& pg) const
+{
+    this->validateRegIdx(region);
+
+    return this->eval_[region]->formationVolumeFactor(rv, pg);
+}
+
+std::vector<double>
+Opm::ECLPVT::Gas::Impl::
+viscosity(const RegIdx               region,
+          const std::vector<double>& rv,
+          const std::vector<double>& pg) const
+{
+    this->validateRegIdx(region);
+
+    return this->eval_[region]->viscosity(rv, pg);
+}
+
+void
+Opm::ECLPVT::Gas::Impl::validateRegIdx(const RegIdx region) const
+{
+    if (region >= this->eval_.size()) {
+        throw std::invalid_argument {
+            "Region Index " +
+            std::to_string(region) +
+            " Outside Valid Range (0 .. " +
+            std::to_string(this->eval_.size() - 1) + ')'
+        };
+    }
+}
+
+// ======================================================================
+// Class ECLPVT::Gas
+// ----------------------------------------------------------------------
+
+Opm::ECLPVT::Gas::Gas(const ECLPropTableRawData& raw,
+                      const int                  usys)
+    : pImpl_(new Impl(raw, usys))
+{}
+
+Opm::ECLPVT::Gas::~Gas()
+{}
+
+Opm::ECLPVT::Gas::Gas(const Gas& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::ECLPVT::Gas::Gas(Gas&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::ECLPVT::Gas&
+Opm::ECLPVT::Gas::operator=(const Gas& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+Opm::ECLPVT::Gas&
+Opm::ECLPVT::Gas::operator=(Gas&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::ECLPVT::Gas::
+formationVolumeFactor(const int           region,
+                      const VaporizedOil& rv,
+                      const GasPressure&  pg) const
+{
+    return this->pImpl_->formationVolumeFactor(region, rv.data, pg.data);
+}
+
+std::vector<double>
+Opm::ECLPVT::Gas::
+viscosity(const int           region,
+          const VaporizedOil& rv,
+          const GasPressure&  pg) const
+{
+    return this->pImpl_->viscosity(region, rv.data, pg.data);
+}
+
+// =====================================================================
+
+std::unique_ptr<Opm::ECLPVT::Gas>
+Opm::ECLPVT::CreateGasPVTInterpolant::
+fromECLOutput(const ECLInitFileData& init)
+{
+    using GPtr = ::std::unique_ptr<Opm::ECLPVT::Gas>;
+
+    const auto& ih   = init.keywordData<int>(INTEHEAD_KW);
+    const auto  iphs = static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
+
+    if ((iphs & (1u << 2)) == 0) {
+        // Gas is not an active phase.
+        // Return sentinel (null) pointer.
+        return GPtr{};
+    }
+
+    auto raw = ::Opm::ECLPropTableRawData{};
+
+    const auto& tabdims = init.keywordData<int>("TABDIMS");
+    const auto& tab     = init.keywordData<double>("TAB");
+
+    raw.numPrimary = tabdims[ TABDIMS_NRPVTG_ITEM ]; // #Composition nodes
+    raw.numRows    = tabdims[ TABDIMS_NPPVTG_ITEM ]; // #Rv (or Pg) nodes
+    raw.numCols    = 5; // [ Rv, 1/B, 1/(B*mu), d(1/B)/dRv, d(1/(B*mu))/dRv ]
+    raw.numTables  = tabdims[ TABDIMS_NTPVTG_ITEM ]; // # PVTG tables
+
+    // Extract Primary Key (Pg)
+    {
+        const auto nTabElem = raw.numPrimary * raw.numTables;
+
+        // Subtract one to account for 1-based indices.
+        const auto start = tabdims[ TABDIMS_JBPVTG_OFFSET_ITEM ] - 1;
+
+        raw.primaryKey.assign(&tab[start], &tab[start] + nTabElem);
+    }
+
+    // Extract Full Table
+    {
+        const auto nTabElem =
+            raw.numPrimary * raw.numRows * raw.numCols * raw.numTables;
+
+        // Subtract one to account for 1-based indices.
+        const auto start = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
+
+        raw.data.assign(&tab[start], &tab[start] + nTabElem);
+    }
+
+    return GPtr{ new Gas(raw, ih[ INTEHEAD_UNIT_INDEX ]) };
+}

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -141,7 +141,7 @@ class WetGas : public PVxGBase
 {
 public:
     using Extrap = ::Opm::Interp1D::PiecewisePolynomial::
-        ExtrapolationPolicy::LinearlyWithDerivatives;
+        ExtrapolationPolicy::Linearly;
 
     using SubtableInterpolant = ::Opm::Interp1D::PiecewisePolynomial::
         Linear<Extrap, /* IsAscendingRange = */ false>;
@@ -249,13 +249,13 @@ namespace {
                     std::vector<ElemIt>& colIt) -> StI
         {
             try {
-                return StI(Extrap{2}, xBegin, xEnd, colIt,
+                return StI(Extrap{}, xBegin, xEnd, colIt,
                            cvrt.second.indep,
                            cvrt.second.column);
             }
             catch (const std::invalid_argument&) {
                 // No valid nodes.  Return invalid.
-                return StI(Extrap{2});
+                return StI(Extrap{});
             }
         });
 

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -1,0 +1,161 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPVTGAS_HEADER_INCLUDED
+#define OPM_ECLPVTGAS_HEADER_INCLUDED
+
+#include <memory>
+#include <vector>
+
+// Forward declarations
+namespace Opm {
+    struct ECLPropTableRawData;
+    class ECLInitFileData;
+} // Opm
+
+namespace Opm { namespace ECLPVT {
+
+    /// Interpolant for Basic Gas PVT Relations.
+    class Gas
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] raw Raw tabulated data.  Must correspond to the PVTG
+        ///    vector of an ECL INIT file..
+        ///
+        /// \param[in] usys Unit system convention of the result set from
+        ///    which \p raw was extracted.  Must correspond to item 3 of the
+        ///    INTEHEAD keyword in the INIT file.
+        Gas(const ECLPropTableRawData& raw, const int usys);
+
+        /// Destructor.
+        ~Gas();
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Existing interpolant for Gas PVT relations.
+        Gas(const Gas& rhs);
+
+        /// Move constructor.
+        ///
+        /// Subsumes the implementation of an existing Gas PVT relation
+        /// interpolant.
+        ///
+        /// \param[in] rhs Existing Gas PVT relation interpolant.  Does not
+        ///    have a valid implementation when the constructor completes.
+        Gas(Gas&& rhs);
+
+        /// Assignment operator
+        ///
+        /// \param[in] rhs Existing Gas PVT relation interpolant.
+        ///
+        /// \return \code *this \endcode.
+        Gas& operator=(const Gas& rhs);
+
+        /// Move assignment operator.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing Gas PVT relation interpolant.  Does not
+        ///    have a valid implementation when the constructor completes.
+        ///
+        /// \return \code *this \endcode.
+        Gas& operator=(Gas&& rhs);
+
+        /// Representation of the Vaporised Oil-Gas Ratio (Rv).
+        ///
+        /// Mostly as a convenience to disambiguate the client interface.
+        struct VaporizedOil
+        {
+            /// Vaporised oil-gas ratio data for all sampling points.
+            std::vector<double> data;
+        };
+
+        /// Representation of Gas Phase Pressure (Pg).
+        ///
+        /// Mostly as a convenience to disambiguate the client interface.
+        struct GasPressure
+        {
+            /// Gas phase pressure for all sampling points.
+            std::vector<double> data;
+        };
+
+        /// Compute the gas phase formation volume factor in a single region.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \param[in] rv Vaporised oil-gas ratio.  Unused in the case of a
+        ///    dry gas model.  Size must match number of elements in \code
+        ///    pg.data \endcode in the case of wet gas model.  Strict SI
+        ///    units of measurement.
+        ///
+        /// \param[in] pg Gas phase pressure.  Strict SI units of measurement.
+        ///
+        /// \return Gas phase formation volume factor.  Size equal to number
+        ///    of elements in \code po.data \endcode.
+        std::vector<double>
+        formationVolumeFactor(const int           region,
+                              const VaporizedOil& rv,
+                              const GasPressure&  pg) const;
+
+        /// Compute the gas phase fluid viscosity in a single region.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \param[in] rv Vaporised oil-gas ratio.  Unused in the case of a
+        ///    dry gas model.  Size must match number of elements in \code
+        ///    pg.data \endcode in the case of wet gas model.  Strict SI
+        ///    units of measurement.
+        ///
+        /// \param[in] pg Gas phase pressure.  Strict SI units of measurement.
+        ///
+        /// \return Gas phase fluid viscosity.  Size equal to number
+        ///    of elements in \code pg.data \endcode.
+        std::vector<double>
+        viscosity(const int           region,
+                  const VaporizedOil& rv,
+                  const GasPressure&  pg) const;
+
+    private:
+        /// Implementation class.
+        class Impl;
+
+        /// Pointer to implementation.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Basic Gas PVT Relation Interpolant Factory Functions.
+    struct CreateGasPVTInterpolant
+    {
+        /// Create Gas PVT interpolant directly from an ECL result set
+        /// (i.e., from the tabulated functions in the 'TAB' vector.
+        ///
+        /// \param[in] init ECL result set INIT file representation.
+        ///
+        /// \return Gas PVT interpolant.  Nullpointer if gas is not an
+        ///    active phase in the result set.
+        static std::unique_ptr<Gas>
+        fromECLOutput(const ECLInitFileData& init);
+    };
+}} // Opm::ECLPVT
+
+#endif // OPM_ECLPVTGAS_HEADER_INCLUDED

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -43,7 +43,13 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] usys Unit system convention of the result set from
         ///    which \p raw was extracted.  Must correspond to item 3 of the
         ///    INTEHEAD keyword in the INIT file.
-        Gas(const ECLPropTableRawData& raw, const int usys);
+        ///
+        /// \param[in] rhoS Mass density of gas at surface conditions.
+        ///    Typically computed by \code ECLPVT::surfaceMassDensity()
+        ///    \endcode.
+        Gas(const ECLPropTableRawData& raw,
+            const int                  usys,
+            std::vector<double>        rhoS);
 
         /// Destructor.
         ~Gas();
@@ -134,6 +140,15 @@ namespace Opm { namespace ECLPVT {
         viscosity(const int           region,
                   const VaporizedOil& rv,
                   const GasPressure&  pg) const;
+
+        /// Retrieve constant mass density of gas at surface conditions.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \return Mass density of gas at surface in particular model
+        ///    region.
+        double surfaceMassDensity(const int region) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -139,7 +139,7 @@ class LiveOil : public PVxOBase
 {
 public:
     using Extrap = ::Opm::Interp1D::PiecewisePolynomial::
-        ExtrapolationPolicy::LinearlyWithDerivatives;
+        ExtrapolationPolicy::Linearly;
 
     using SubtableInterpolant = ::Opm::Interp1D::PiecewisePolynomial::
         Linear<Extrap, /* IsAscendingRange = */ true>;
@@ -247,13 +247,13 @@ namespace {
                     std::vector<ElemIt>& colIt) -> StI
         {
             try {
-                return StI(Extrap{2}, xBegin, xEnd, colIt,
+                return StI(Extrap{}, xBegin, xEnd, colIt,
                            cvrt.second.indep,
                            cvrt.second.column);
             }
             catch (const std::invalid_argument&) {
                 // No valid nodes.  Return invalid.
-                return StI(Extrap{2});
+                return StI(Extrap{});
             }
         });
 

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -1,0 +1,538 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLPvtOil.hpp>
+
+#include <opm/utility/ECLPropTable.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ert/ecl/ecl_kw_magic.h>
+
+namespace {
+    ::Opm::ECLPVT::ConvertUnits
+    deadOilUnitConverter(const ::Opm::ECLUnits::UnitSystem& usys)
+    {
+        using ToSI = ::Opm::ECLPVT::CreateUnitConverter::ToSI;
+
+        // [ Po, 1/B, 1/(B*mu), d(1/B)/dPo, d(1/(B*mu))/dPo ]
+        return ::Opm::ECLPVT::ConvertUnits {
+            ToSI::pressure(usys),
+            {
+                ToSI::recipFvf(usys),
+                ToSI::recipFvfVisc(usys),
+                ToSI::recipFvfDerivPress(usys),
+                ToSI::recipFvfViscDerivPress(usys)
+            }
+        };
+    }
+
+    ::Opm::ECLPVT::ConvertUnits deadOilUnitConverter(const int usys)
+    {
+        const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+        return deadOilUnitConverter(*u);
+    }
+
+    std::pair< ::Opm::ECLPVT::ConvertUnits::Converter,
+               ::Opm::ECLPVT::ConvertUnits>
+    liveOilUnitConverter(const int usys)
+    {
+        using ToSI = ::Opm::ECLPVT::CreateUnitConverter::ToSI;
+
+        const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+        // Key   = Rs
+        // Table = [ Po, 1/B, 1/(B*mu), d(1/B)/dPo, d(1/(B*mu))/dPo ]
+        //       = dead oil table format.
+
+        return std::make_pair(ToSI::disGas(*u),
+                              deadOilUnitConverter(*u));
+    }
+}
+
+// ---------------------------------------------------------------------
+
+// Enable runtime selection of dead or live oil functions.
+class PVxOBase
+{
+public:
+    virtual std::vector<double>
+    formationVolumeFactor(const std::vector<double>& rs,
+                          const std::vector<double>& po) const = 0;
+
+    virtual std::vector<double>
+    viscosity(const std::vector<double>& rs,
+              const std::vector<double>& po) const = 0;
+
+    virtual std::unique_ptr<PVxOBase> clone() const = 0;
+};
+
+// =====================================================================
+
+class DeadOil : public PVxOBase
+{
+public:
+    using ElemIt = ::Opm::ECLPVT::PVDx::ElemIt;
+    using ConvertUnits = ::Opm::ECLPVT::ConvertUnits;
+
+    DeadOil(ElemIt               xBegin,
+            ElemIt               xEnd,
+            const ConvertUnits&  convert,
+            std::vector<ElemIt>& colIt)
+        : interpolant_(xBegin, xEnd, convert, colIt)
+    {}
+
+    virtual std::vector<double>
+    formationVolumeFactor(const std::vector<double>& /* rs */,
+                          const std::vector<double>& po) const override
+    {
+        return this->interpolant_.formationVolumeFactor(po);
+    }
+
+    virtual std::vector<double>
+    viscosity(const std::vector<double>& /* rs */,
+              const std::vector<double>& po) const override
+    {
+        return this->interpolant_.viscosity(po);
+    }
+
+    virtual std::unique_ptr<PVxOBase> clone() const override
+    {
+        return std::unique_ptr<PVxOBase>(new DeadOil(*this));
+    }
+
+private:
+    ::Opm::ECLPVT::PVDx interpolant_;
+};
+
+// =====================================================================
+
+class LiveOil : public PVxOBase
+{
+public:
+    using Extrap = ::Opm::Interp1D::PiecewisePolynomial::
+        ExtrapolationPolicy::LinearlyWithDerivatives;
+
+    using SubtableInterpolant = ::Opm::Interp1D::PiecewisePolynomial::
+        Linear<Extrap, /* IsAscendingRange = */ true>;
+
+    LiveOil(std::vector<double>              key,
+            std::vector<SubtableInterpolant> propInterp)
+        : interp_(std::move(key), std::move(propInterp))
+    {}
+
+    virtual std::vector<double>
+    formationVolumeFactor(const std::vector<double>& rs,
+                          const std::vector<double>& po) const override
+    {
+        // PKey   Inner   C0     C1         C2           C3
+        // Rs     Po      1/B    1/(B*mu)   d(1/B)/dPo   d(1/(B*mu))/dPo
+        //        :       :      :          :            :
+        const auto key = TableInterpolant::PrimaryKey { rs };
+        const auto x   = TableInterpolant::InnerVariate { po };
+
+        return this->interp_.formationVolumeFactor(key, x);
+    }
+
+    virtual std::vector<double>
+    viscosity(const std::vector<double>& rs,
+              const std::vector<double>& po) const override
+    {
+        // PKey   Inner   C0     C1         C2           C3
+        // Rs     Po      1/B    1/(B*mu)   d(1/B)/dPo   d(1/(B*mu))/dPo
+        //        :       :      :          :            :
+        const auto key = TableInterpolant::PrimaryKey { rs };
+        const auto x   = TableInterpolant::InnerVariate { po };
+
+        return this->interp_.viscosity(key, x);
+    }
+
+    virtual std::unique_ptr<PVxOBase> clone() const override
+    {
+        return std::unique_ptr<PVxOBase>(new LiveOil(*this));
+    }
+
+private:
+    using TableInterpolant = ::Opm::ECLPVT::PVTx<SubtableInterpolant>;
+
+    TableInterpolant interp_;
+};
+
+// #####################################################################
+
+namespace {
+    std::vector<std::unique_ptr<PVxOBase>>
+    createDeadOil(const ::Opm::ECLPropTableRawData& raw,
+                  const int                         usys)
+    {
+        using PVTInterp = std::unique_ptr<PVxOBase>;
+        using ElmIt     = ::Opm::ECLPropTableRawData::ElementIterator;
+
+        assert ((raw.numPrimary == 1) &&
+                "Can't Create Dead Oil Function From Live Oil Table");
+
+        const auto cvrt = deadOilUnitConverter(usys);
+
+        return ::Opm::MakeInterpolants<PVTInterp>::fromRawData(raw,
+            [&cvrt](ElmIt xBegin, ElmIt xEnd, std::vector<ElmIt>& colIt)
+        {
+            return PVTInterp{ new DeadOil(xBegin, xEnd, cvrt, colIt) };
+        });
+    }
+
+    std::vector<double>
+    extractPrimaryKey(const ::Opm::ECLPropTableRawData&             raw,
+                      const ::Opm::ECLPropTableRawData::SizeType    t,
+                      const ::Opm::ECLPVT::ConvertUnits::Converter& cvrtKey)
+    {
+        auto key = std::vector<double>{};
+        key.reserve(raw.numPrimary);
+
+        for (auto begin = std::begin(raw.primaryKey) + (t + 0)*raw.numPrimary,
+                  end   = begin + raw.numPrimary;
+             begin != end; ++begin)
+        {
+            if (std::abs(*begin) < 1.0e20) {
+                key.push_back(cvrtKey(*begin));
+            }
+        }
+
+        return key;
+    }
+
+    std::vector<std::unique_ptr<PVxOBase>>
+    createLiveOil(const ::Opm::ECLPropTableRawData& raw,
+                  const int                         usys)
+    {
+        auto ret = std::vector<std::unique_ptr<PVxOBase>>{};
+        ret.reserve(raw.numTables);
+
+        using Extrap = LiveOil::Extrap;
+        using StI    = LiveOil::SubtableInterpolant;
+        using ElemIt = ::Opm::ECLPropTableRawData::ElementIterator;
+
+        const auto cvrt = liveOilUnitConverter(usys);
+
+        auto sti = ::Opm::MakeInterpolants<StI>::fromRawData(raw,
+            [&cvrt](ElemIt               xBegin,
+                    ElemIt               xEnd,
+                    std::vector<ElemIt>& colIt) -> StI
+        {
+            try {
+                return StI(Extrap{2}, xBegin, xEnd, colIt,
+                           cvrt.second.indep,
+                           cvrt.second.column);
+            }
+            catch (const std::invalid_argument&) {
+                // No valid nodes.  Return invalid.
+                return StI(Extrap{2});
+            }
+        });
+
+        for (auto t = 0*raw.numTables;
+                  t <   raw.numTables; ++t)
+        {
+            auto key = extractPrimaryKey(raw, t, cvrt.first);
+
+            const auto begin = (t + 0)*raw.numPrimary;
+            const auto end   = begin + key.size();
+
+            ret.emplace_back(new LiveOil(std::move(key),
+                {
+                    std::make_move_iterator(std::begin(sti) + begin),
+                    std::make_move_iterator(std::begin(sti) + end)
+                }));
+        }
+
+        return ret;
+    }
+
+    std::vector<std::unique_ptr<PVxOBase>>
+    createPVTFunction(const ::Opm::ECLPropTableRawData& raw,
+                      const int                         usys)
+    {
+        if (raw.numPrimary == 0) {
+            // Malformed Gas PVT table.
+            throw std::invalid_argument {
+                "Oil PVT Table Without Primary Lookup Key"
+            };
+        }
+
+        if (raw.numCols != 5) {
+            throw std::invalid_argument {
+                "PVT Table for Oil Must Have Five Columns"
+            };
+        }
+
+        if (raw.primaryKey.size() != (raw.numPrimary * raw.numTables)) {
+            throw std::invalid_argument {
+                "Size Mismatch in RS Nodes of PVT Table for Oil"
+            };
+        }
+
+        if (raw.data.size() !=
+            (raw.numPrimary * raw.numRows * raw.numCols * raw.numTables))
+        {
+            throw std::invalid_argument {
+                "Size Mismatch in Condensed Table Data "
+                "of PVT Table for Oil"
+            };
+        }
+
+        if (raw.numPrimary == 1) {
+            return createDeadOil(raw, usys);
+        }
+
+        return createLiveOil(raw, usys);
+    }
+
+    std::vector<std::unique_ptr<PVxOBase>>
+    clone(const std::vector<std::unique_ptr<PVxOBase>>& src)
+    {
+        auto dest = std::vector<std::unique_ptr<PVxOBase>>{};
+        dest.reserve(src.size());
+
+        for (const auto& p : src) {
+            dest.push_back(p->clone());
+        }
+
+        return dest;
+    }
+}
+
+// #####################################################################
+// #####################################################################
+
+// =====================================================================
+// Class ECLPVT::Oil::Impl
+// ---------------------------------------------------------------------
+
+class Opm::ECLPVT::Oil::Impl
+{
+private:
+    using EvalPtr = std::unique_ptr<PVxOBase>;
+
+public:
+    Impl(const ECLPropTableRawData& raw, const int usys);
+
+    Impl(const Impl& rhs);
+    Impl(Impl&& rhs);
+
+    Impl& operator=(const Impl& rhs);
+    Impl& operator=(Impl&& rhs);
+
+    using RegIdx = std::vector<EvalPtr>::size_type;
+
+    std::vector<double>
+    formationVolumeFactor(const RegIdx               region,
+                          const std::vector<double>& rs,
+                          const std::vector<double>& po) const;
+
+    std::vector<double>
+    viscosity(const RegIdx               region,
+              const std::vector<double>& rs,
+              const std::vector<double>& po) const;
+
+private:
+    std::vector<EvalPtr> eval_;
+
+    void validateRegIdx(const RegIdx region) const;
+};
+
+Opm::ECLPVT::Oil::Impl::
+Impl(const ECLPropTableRawData& raw,
+     const int                  usys)
+    : eval_(createPVTFunction(raw, usys))
+{}
+
+Opm::ECLPVT::Oil::Impl::Impl(const Impl& rhs)
+    : eval_(clone(rhs.eval_))
+{}
+
+Opm::ECLPVT::Oil::Impl::Impl(Impl&& rhs)
+    : eval_(std::move(rhs.eval_))
+{}
+
+Opm::ECLPVT::Oil::Impl&
+Opm::ECLPVT::Oil::Impl::operator=(const Impl& rhs)
+{
+    this->eval_ = clone(rhs.eval_);
+
+    return *this;
+}
+
+Opm::ECLPVT::Oil::Impl&
+Opm::ECLPVT::Oil::Impl::operator=(Impl&& rhs)
+{
+    this->eval_ = std::move(rhs.eval_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::ECLPVT::Oil::Impl::
+formationVolumeFactor(const RegIdx               region,
+                      const std::vector<double>& rs,
+                      const std::vector<double>& po) const
+{
+    this->validateRegIdx(region);
+
+    return this->eval_[region]->formationVolumeFactor(rs, po);
+}
+
+std::vector<double>
+Opm::ECLPVT::Oil::Impl::
+viscosity(const RegIdx               region,
+          const std::vector<double>& rs,
+          const std::vector<double>& po) const
+{
+    this->validateRegIdx(region);
+
+    return this->eval_[region]->viscosity(rs, po);
+}
+
+void
+Opm::ECLPVT::Oil::Impl::validateRegIdx(const RegIdx region) const
+{
+    if (region >= this->eval_.size()) {
+        throw std::invalid_argument {
+            "Region Index " +
+            std::to_string(region) +
+            " Outside Valid Range (0 .. " +
+            std::to_string(this->eval_.size() - 1) + ')'
+        };
+    }
+}
+
+// ======================================================================
+// Class ECLPVT::Oil
+// ----------------------------------------------------------------------
+
+Opm::ECLPVT::Oil::Oil(const ECLPropTableRawData& raw,
+                      const int                  usys)
+    : pImpl_(new Impl(raw, usys))
+{}
+
+Opm::ECLPVT::Oil::~Oil()
+{}
+
+Opm::ECLPVT::Oil::Oil(const Oil& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::ECLPVT::Oil::Oil(Oil&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::ECLPVT::Oil&
+Opm::ECLPVT::Oil::operator=(const Oil& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+Opm::ECLPVT::Oil&
+Opm::ECLPVT::Oil::operator=(Oil&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::ECLPVT::Oil::
+formationVolumeFactor(const int           region,
+                      const DissolvedGas& rs,
+                      const OilPressure&  po) const
+{
+    return this->pImpl_->formationVolumeFactor(region, rs.data, po.data);
+}
+
+std::vector<double>
+Opm::ECLPVT::Oil::
+viscosity(const int           region,
+          const DissolvedGas& rs,
+          const OilPressure&  po) const
+{
+    return this->pImpl_->viscosity(region, rs.data, po.data);
+}
+
+// =====================================================================
+
+std::unique_ptr<Opm::ECLPVT::Oil>
+Opm::ECLPVT::CreateOilPVTInterpolant::
+fromECLOutput(const ECLInitFileData& init)
+{
+    using OPtr = std::unique_ptr<Opm::ECLPVT::Oil>;
+
+    const auto& ih   = init.keywordData<int>(INTEHEAD_KW);
+    const auto  iphs = static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
+
+    if ((iphs & (1u << 0)) == 0) {
+        // Oil is not an active phase (unexpected).
+        // Return sentinel (null) pointer.
+        return OPtr{};
+    }
+
+    auto raw = ::Opm::ECLPropTableRawData{};
+
+    const auto& tabdims = init.keywordData<int>("TABDIMS");
+    const auto& tab     = init.keywordData<double>("TAB");
+
+    raw.numPrimary = tabdims[ TABDIMS_NRPVTO_ITEM ]; // #Rs nodes/full table
+    raw.numRows    = tabdims[ TABDIMS_NPPVTO_ITEM ]; // #Po nodes/sub-table
+    raw.numCols    = 5; // [ Po, 1/B, 1/(B*mu), d(1/B)/dPo, d(1/(B*mu))/dPo ]
+    raw.numTables  = tabdims[ TABDIMS_NTPVTO_ITEM ]; // # PVTO tables
+
+    // Extract Primary Key (Rs)
+    {
+        const auto nTabElem = raw.numPrimary * raw.numTables;
+
+        // Subtract one to account for 1-based indices.
+        const auto start = tabdims[ TABDIMS_JBPVTO_OFFSET_ITEM ] - 1;
+
+        raw.primaryKey.assign(&tab[start], &tab[start] + nTabElem);
+    }
+
+    // Extract Full Table
+    {
+        const auto nTabElem =
+            raw.numPrimary * raw.numRows * raw.numCols * raw.numTables;
+
+        // Subtract one to account for 1-based indices.
+        const auto start = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
+
+        raw.data.assign(&tab[start], &tab[start] + nTabElem);
+    }
+
+    return OPtr{ new Oil(raw, ih[ INTEHEAD_UNIT_INDEX ]) };
+}

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -1,0 +1,159 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPVTOIL_HEADER_INCLUDED
+#define OPM_ECLPVTOIL_HEADER_INCLUDED
+
+#include <memory>
+#include <vector>
+
+// Forward declarations
+namespace Opm {
+    struct ECLPropTableRawData;
+    class ECLInitFileData;
+} // Opm
+
+namespace Opm { namespace ECLPVT {
+
+    /// Interpolant for Basic Oil PVT Relations.
+    class Oil
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] raw Raw tabulated data.  Must correspond to the PVTO
+        ///    vector of an ECL INIT file..
+        ///
+        /// \param[in] usys Unit system convention of the result set from
+        ///    which \p raw was extracted.  Must correspond to item 3 of the
+        ///    INTEHEAD keyword in the INIT file.
+        Oil(const ECLPropTableRawData& raw, const int usys);
+
+        /// Destructor.
+        ~Oil();
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Existing interpolant for Oil PVT relations.
+        Oil(const Oil& rhs);
+
+        /// Move constructor.
+        ///
+        /// Subsumes the implementation of an existing Oil PVT relation
+        /// interpolant.
+        ///
+        /// \param[in] rhs Existing Oil PVT relation interpolant.  Does not
+        ///    have a valid implementation when the constructor completes.
+        Oil(Oil&& rhs);
+
+        /// Assignment operator
+        ///
+        /// \param[in] rhs Existing Oil PVT relation interpolant.
+        ///
+        /// \return \code *this \endcode.
+        Oil& operator=(const Oil& rhs);
+
+        /// Move assignment operator.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing Oil PVT relation interpolant.  Does not
+        ///    have a valid implementation when the constructor completes.
+        ///
+        /// \return \code *this \endcode.
+        Oil& operator=(Oil&& rhs);
+
+        /// Representation of the Dissolved Gas-Oil Ratio (Rs).
+        ///
+        /// Mostly as a convenience to disambiguate the client interface.
+        struct DissolvedGas {
+            /// Dissolved gas-oil ratio data for all sampling points.
+            std::vector<double> data;
+        };
+
+        /// Representation of Oil Phase Pressure (Po).
+        ///
+        /// Mostly as a convenience to disambiguate the client interface.
+        struct OilPressure {
+            /// Oil phase pressure for all sampling points.
+            std::vector<double> data;
+        };
+
+        /// Compute the oil phase formation volume factor in a single region.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \param[in] rs Dissolved gas-oil ratio.  Unused in the case of a
+        ///    dead oil model.  Size must match number of elements in \code
+        ///    po.data \endcode in the case of live oil model.  Strict SI
+        ///    units of measurement.
+        ///
+        /// \param[in] po Oil phase pressure.  Strict SI units of measurement.
+        ///
+        /// \return Oil phase formation volume factor.  Size equal to number
+        ///    of elements in \code po.data \endcode.
+        std::vector<double>
+        formationVolumeFactor(const int           region,
+                              const DissolvedGas& rs,
+                              const OilPressure&  po) const;
+
+        /// Compute the oil phase fluid viscosity in a single region.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \param[in] rs Dissolved gas-oil ratio.  Unused in the case of a
+        ///    dead oil model.  Size must match number of elements in \code
+        ///    po.data \endcode in the case of live oil model.  Strict SI
+        ///    units of measurement.
+        ///
+        /// \param[in] po Oil phase pressure.  Strict SI units of measurement.
+        ///
+        /// \return Oil phase fluid viscosity.  Size equal to number of
+        ///    elements in \code po.data \endcode.
+        std::vector<double>
+        viscosity(const int           region,
+                  const DissolvedGas& rs,
+                  const OilPressure&  po) const;
+
+    private:
+        /// Implementation class.
+        class Impl;
+
+        /// Pointer to implementation.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Basic Oil PVT Relation Interpolant Factory Functions.
+    struct CreateOilPVTInterpolant
+    {
+        /// Create Oil PVT interpolant directly from an ECL result set
+        /// (i.e., from the tabulated functions in the 'TAB' vector.
+        ///
+        /// \param[in] init ECL result set INIT file representation.
+        ///
+        /// \return Oil PVT interpolant.  Nullpointer if oil is not an
+        ///    active phase in the result set (unexpected).
+        static std::unique_ptr<Oil>
+        fromECLOutput(const ECLInitFileData& init);
+    };
+}} // Opm::ECLPVT
+
+#endif // OPM_ECLPVTOIL_HEADER_INCLUDED

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -43,7 +43,13 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] usys Unit system convention of the result set from
         ///    which \p raw was extracted.  Must correspond to item 3 of the
         ///    INTEHEAD keyword in the INIT file.
-        Oil(const ECLPropTableRawData& raw, const int usys);
+        ///
+        /// \param[in] rhoS Mass density of oil at surface conditions.
+        ///    Typically computed by \code ECLPVT::surfaceMassDensity()
+        ///    \endcode.
+        Oil(const ECLPropTableRawData& raw,
+            const int                  usys,
+            std::vector<double>        rhoS);
 
         /// Destructor.
         ~Oil();
@@ -132,6 +138,15 @@ namespace Opm { namespace ECLPVT {
         viscosity(const int           region,
                   const DissolvedGas& rs,
                   const OilPressure&  po) const;
+
+        /// Retrieve constant mass density of oil at surface conditions.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \return Mass density of oil at surface in particular model
+        ///    region.
+        double surfaceMassDensity(const int region) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLPvtWater.cpp
+++ b/opm/utility/ECLPvtWater.cpp
@@ -1,0 +1,325 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLPvtWater.hpp>
+
+#include <opm/utility/ECLPropTable.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ert/ecl/ecl_kw_magic.h>
+
+namespace {
+    ::Opm::ECLPVT::ConvertUnits waterUnitConverter(const int usys)
+    {
+        using ToSI = ::Opm::ECLPVT::CreateUnitConverter::ToSI;
+
+        const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+        // [ Pref, 1/Bw, Cw, 1/(Bw*mu_w), Cw - Cv ]
+
+        return ::Opm::ECLPVT::ConvertUnits {
+            ToSI::pressure(*u),
+            {
+                ToSI::recipFvf(*u),
+                ToSI::compressibility(*u),
+                ToSI::recipFvfVisc(*u),
+                ToSI::compressibility(*u)
+            }
+        };
+    }
+} // Anonymous
+
+class PVTCurves
+{
+public:
+    using ElemIt = std::vector<double>::const_iterator;
+    using ConvertUnits = ::Opm::ECLPVT::ConvertUnits;
+
+    PVTCurves(ElemIt               xBegin,
+              ElemIt               xEnd,
+              const ConvertUnits&  convert,
+              std::vector<ElemIt>& colIt);
+
+    std::vector<double>
+    formationVolumeFactor(const std::vector<double>& pw) const
+    {
+        return this->evaluate(pw, [this](const double p) -> double
+            {
+                // 1 / (1 / B)
+                return 1.0 / this->recipFvf(p);
+            });
+    }
+
+    std::vector<double>
+    viscosity(const std::vector<double>& pw) const
+    {
+        return this->evaluate(pw, [this](const double p) -> double
+            {
+                // (1 / B) / (1 / (B * mu))
+                return this->recipFvf(p) / this->recipFvfVisc(p);
+            });
+    }
+
+private:
+    double pw_ref_       { 1.0 };
+    double recipFvf_     { 1.0 }; // 1 / B
+    double recipFvfVisc_ { 1.0 }; // 1 / (B*mu)
+    double Cw_           { 1.0 };
+    double diffCwCv_     { 0.0 }; // Cw - Cv
+
+    double recipFvf(const double pw) const
+    {
+        const auto x = this->Cw_ * (pw - this->pw_ref_);
+
+        return this->recipFvf_ * this->exp(x);
+    }
+
+    double recipFvfVisc(const double pw) const
+    {
+        const auto y = this->diffCwCv_ * (pw - this->pw_ref_);
+
+        return this->recipFvfVisc_ * this->exp(y);
+    }
+
+    double exp(const double x) const
+    {
+        return 1.0 + x*(1.0 + x/2.0);
+    }
+
+    template <class CalcQuant>
+    std::vector<double>
+    evaluate(const std::vector<double>& pw,
+             CalcQuant&&                calculate) const
+    {
+        auto q = std::vector<double>{};
+        q.reserve(pw.size());
+
+        for (const auto& pwi : pw) {
+            q.push_back(calculate(pwi));
+        }
+
+        return q;
+    }
+};
+
+PVTCurves::PVTCurves(ElemIt               xBegin,
+                     ElemIt               xEnd,
+                     const ConvertUnits&  convert,
+                     std::vector<ElemIt>& colIt)
+{
+    assert ((std::distance(xBegin, xEnd) == 1) &&
+            "Logic Error in Defining PVTW Input Ranges");
+
+#ifdef NDEBUG
+    // Suppress "unusued variable" in release mode.
+    static_cast<void>(xEnd);
+#endif  // NDEBUG
+
+    // Recall: Table is
+    //
+    //    [ Pw, 1/Bw, Cw, 1/(Bw*mu_w), Cw - Cv ]
+    //
+    // xBegin is Pw, colIt is remaining four columns.
+
+    this->recipFvf_     = convert.column[0](*colIt[0]); // 1/Bw
+    this->Cw_           = convert.column[1](*colIt[1]); // Cw
+    this->recipFvfVisc_ = convert.column[2](*colIt[2]); // 1/(Bw*mu_w)
+    this->diffCwCv_     = convert.column[3](*colIt[3]); // Cw - Cv
+
+    // Honour requirement that constructor advances column iterators.
+    for (auto& it : colIt) { ++it; }
+
+    if (! (std::abs(*xBegin) < 1.0e20)) {
+          throw std::invalid_argument {
+            "Invalid Input PVTW Table"
+        };
+    }
+
+    this->pw_ref_ = convert.indep(*xBegin);
+}
+
+// #####################################################################
+// #####################################################################
+
+// =====================================================================
+// Class ECLPVT::Water::Impl
+// ---------------------------------------------------------------------
+
+class Opm::ECLPVT::Water::Impl
+{
+public:
+    Impl(const ECLPropTableRawData& raw, const int usys);
+
+    using RegIdx = std::vector<PVTCurves>::size_type;
+
+    std::vector<double>
+    formationVolumeFactor(const RegIdx               region,
+                          const std::vector<double>& pw) const
+    {
+        this->validateRegIdx(region);
+
+        return this->eval_[region].formationVolumeFactor(pw);
+    }
+
+    std::vector<double>
+    viscosity(const RegIdx               region,
+              const std::vector<double>& pw) const
+    {
+        this->validateRegIdx(region);
+
+        return this->eval_[region].viscosity(pw);
+    }
+
+private:
+    std::vector<PVTCurves> eval_;
+
+    void validateRegIdx(const RegIdx region) const;
+};
+
+Opm::ECLPVT::Water::Impl::Impl(const ECLPropTableRawData& raw,
+                               const int                  usys)
+{
+    using ElemIt = PVTCurves::ElemIt;
+
+    const auto cvrt = waterUnitConverter(usys);
+
+    this->eval_  = MakeInterpolants<PVTCurves>::fromRawData(raw,
+        [&cvrt](ElemIt               xBegin,
+                ElemIt               xEnd,
+                std::vector<ElemIt>& colIt) -> PVTCurves
+    {
+        return PVTCurves(xBegin, xEnd, cvrt, colIt);
+    });
+}
+
+void
+Opm::ECLPVT::Water::Impl::validateRegIdx(const RegIdx region) const
+{
+    if (region >= this->eval_.size()) {
+        throw std::invalid_argument {
+            "Region Index " +
+            std::to_string(region) +
+            " Outside Valid Range (0 .. " +
+            std::to_string(this->eval_.size() - 1) + ')'
+        };
+    }
+}
+
+// =====================================================================
+// Class ECLPVT::Water
+// ---------------------------------------------------------------------
+
+Opm::ECLPVT::Water::Water(const ECLPropTableRawData& raw,
+                          const int                  usys)
+    : pImpl_(new Impl(raw, usys))
+{}
+
+Opm::ECLPVT::Water::~Water()
+{}
+
+Opm::ECLPVT::Water::Water(const Water& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::ECLPVT::Water::Water(Water&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::ECLPVT::Water&
+Opm::ECLPVT::Water::operator=(const Water& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+Opm::ECLPVT::Water&
+Opm::ECLPVT::Water::operator=(Water&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+std::vector<double>
+Opm::ECLPVT::Water::formationVolumeFactor(const int            region,
+                                          const WaterPressure& pw) const
+{
+    return this->pImpl_->formationVolumeFactor(region, pw.data);
+}
+
+std::vector<double>
+Opm::ECLPVT::Water::viscosity(const int            region,
+                              const WaterPressure& pw) const
+{
+    return this->pImpl_->viscosity(region, pw.data);
+}
+
+// =====================================================================
+
+std::unique_ptr<Opm::ECLPVT::Water>
+Opm::ECLPVT::CreateWaterPVTInterpolant::
+fromECLOutput(const ECLInitFileData& init)
+{
+    using WPtr = ::std::unique_ptr<Opm::ECLPVT::Water>;
+
+    const auto& ih   = init.keywordData<int>(INTEHEAD_KW);
+    const auto  iphs = static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
+
+    if ((iphs & (1u << 1)) == 0) {
+        // Water is  not an active phase.
+        // Return sentinel (null) pointer.
+        return WPtr{};
+    }
+
+    auto raw = ::Opm::ECLPropTableRawData{};
+
+    const auto& tabdims = init.keywordData<int>("TABDIMS");
+    const auto& tab     = init.keywordData<double>("TAB");
+
+    raw.numPrimary = 1; // Single record per region
+    raw.numRows    = 1; // Single record per region
+    raw.numCols    = 5; // [ Pw, 1/B, Cw, 1/(B*mu), Cw - Cv ]
+    raw.numTables  = tabdims[ TABDIMS_NTPVTW_ITEM ]; // # PVTW tables
+
+    // Extract Full Table
+    {
+        const auto nTabElem =
+            raw.numPrimary * raw.numRows * raw.numCols * raw.numTables;
+
+        // Subtract one to account for 1-based indices.
+        const auto start = tabdims[ TABDIMS_IBPVTW_OFFSET_ITEM ] - 1;
+
+        raw.data.assign(&tab[start], &tab[start] + nTabElem);
+    }
+
+    return WPtr{ new Water(raw, ih[ INTEHEAD_UNIT_INDEX ]) };
+}

--- a/opm/utility/ECLPvtWater.hpp
+++ b/opm/utility/ECLPvtWater.hpp
@@ -1,0 +1,138 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPVTWATER_HEADER_INCLUDED
+#define OPM_ECLPVTWATER_HEADER_INCLUDED
+
+#include <memory>
+#include <vector>
+
+namespace Opm {
+    struct ECLPropTableRawData;
+    class  ECLInitFileData;
+} // Opm
+
+namespace Opm { namespace ECLPVT {
+
+    /// Interpolant for Basic Water PVT Relations.
+    class Water
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] raw Raw tabulated data.  Must correspond to the PVTW
+        ///    vector of an ECL INIT file..
+        ///
+        /// \param[in] usys Unit system convention of the result set from
+        ///    which \p raw was extracted.  Must correspond to item 3 of the
+        ///    INTEHEAD keyword in the INIT file.
+        Water(const ECLPropTableRawData& raw, const int usys);
+
+        /// Destructor.
+        ~Water();
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Existing interpolant for Water PVT relations.
+        Water(const Water& rhs);
+
+        /// Move constructor.
+        ///
+        /// Subsumes the implementation of an existing Water PVT relation
+        /// interpolant.
+        ///
+        /// \param[in] rhs Existing Water PVT relation interpolant.  Does not
+        ///    have a valid implementation when the constructor completes.
+        Water(Water&& rhs);
+
+        /// Assignment operator
+        ///
+        /// \param[in] rhs Existing Oil Water relation interpolant.
+        ///
+        /// \return \code *this \endcode.
+        Water& operator=(const Water& rhs);
+
+        /// Move assignment operator.
+        ///
+        /// Subsumes the implementation of an existing object.
+        ///
+        /// \param[in] rhs Existing Water PVT relation interpolant.  Does not
+        ///    have a valid implementation when the constructor completes.
+        ///
+        /// \return \code *this \endcode.
+        Water& operator=(Water&& rhs);
+
+        /// Representation of Water Phase Pressure (Pw).
+        ///
+        /// Mostly as a convenience to disambiguate the client interface.
+        struct WaterPressure {
+            /// Water phase pressure for all sampling points.
+            std::vector<double> data;
+        };
+
+        /// Compute the oil phase formation volume factor in a single region.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \param[in] pw Water phase pressure.  Strict SI units of measurement.
+        ///
+        /// \return Oil phase formation volume factor.  Size equal to number
+        ///    of elements in \code pw.data \endcode.
+        std::vector<double>
+        formationVolumeFactor(const int            region,
+                              const WaterPressure& pw) const;
+
+        /// Compute the water phase fluid viscosity in a single region.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \param[in] pw Water phase pressure.  Strict SI units of measurement.
+        ///
+        /// \return Oil phase fluid viscosity.  Size equal to number of
+        ///    elements in \code pw.data \endcode.
+        std::vector<double>
+        viscosity(const int            region,
+                  const WaterPressure& pw) const;
+
+    private:
+        /// Implementation class.
+        class Impl;
+
+        /// Pointer to implementation.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Basic Oil PVT Relation Interpolant Factory Functions.
+    struct CreateWaterPVTInterpolant
+    {
+        /// Create Oil PVT interpolant directly from an ECL result set
+        /// (i.e., from the tabulated functions in the 'TAB' vector.
+        ///
+        /// \param[in] init ECL result set INIT file representation.
+        ///
+        /// \return Oil PVT interpolant.  Nullpointer if water is not an
+        ///    active phase in the result set.
+        static std::unique_ptr<Water>
+        fromECLOutput(const ECLInitFileData& init);
+    };
+}} // Opm::ECLPVT
+
+#endif // OPM_ECLPVTWATER_HEADER_INCLUDED

--- a/opm/utility/ECLPvtWater.hpp
+++ b/opm/utility/ECLPvtWater.hpp
@@ -42,7 +42,13 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] usys Unit system convention of the result set from
         ///    which \p raw was extracted.  Must correspond to item 3 of the
         ///    INTEHEAD keyword in the INIT file.
-        Water(const ECLPropTableRawData& raw, const int usys);
+        ///
+        /// \param[in] rhoS Mass density of water at surface conditions.
+        ///    Typically computed by \code ECLPVT::surfaceMassDensity()
+        ///    \endcode.
+        Water(const ECLPropTableRawData& raw,
+              const int                  usys,
+              const std::vector<double>& rhoS);
 
         /// Destructor.
         ~Water();
@@ -111,6 +117,15 @@ namespace Opm { namespace ECLPVT {
         std::vector<double>
         viscosity(const int            region,
                   const WaterPressure& pw) const;
+
+        /// Retrieve constant mass density of water at surface conditions.
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \return Mass density of water at surface in particular model
+        ///    region.
+        double surfaceMassDensity(const int region) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -250,13 +250,8 @@ namespace {
                 ///    values of \p kw.
                 void operator()(const ecl_kw_type* kw, EType* x) const
                 {
-                    // 1) Extract raw 'int' values.
-                    ecl_kw_get_memcpy_int_data(kw, x);
-
-                    // 2) Convert to 'bool'-like values by comparing to
-                    //    magic constant ECL_BOOL_TRUE_INT (ecl_util.h).
                     for (auto n = ecl_kw_get_size(kw), i = 0*n; i < n; ++i) {
-                        x[i] = static_cast<EType>(x[i] == ECL_BOOL_TRUE_INT);
+                        x[i] = ecl_kw_iget_bool(kw, i);
                     }
                 }
             };

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -368,10 +368,13 @@ namespace Relperm {
                 kro.reserve(sw.data.size());
 
                 for (auto n = sw.data.size(), i = 0*n; i < n; ++i) {
-                    const auto den = sg.data[i] + sw.data[i] - swco;
+                    const auto Sw_corr =
+                        std::max(sw.data[i] - swco, 1.0e-6);
+
+                    const auto den = sg.data[i] + Sw_corr;
 
                     const auto xg = sg.data[i] / den;
-                    const auto xw = (sw.data[i] + swco) / den;
+                    const auto xw = Sw_corr    / den;
 
                     kro.push_back(xg*kr_og[i] + xw*kr_ow[i]);
                 }

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -449,9 +449,10 @@ Relperm::Gas::Details::tableData(const std::vector<int>&    tabdims,
 {
     auto t = Opm::ECLPropTableRawData{};
 
-    t.numCols   = 3;            // Sg, Krg, Pcgo
-    t.numRows   = tabdims[ TABDIMS_NSSGFN_ITEM ];
-    t.numTables = tabdims[ TABDIMS_NTSGFN_ITEM ];
+    t.numPrimary = 1;
+    t.numCols    = 3;           // Sg, Krg, Pcgo
+    t.numRows    = tabdims[ TABDIMS_NSSGFN_ITEM ];
+    t.numTables  = tabdims[ TABDIMS_NTSGFN_ITEM ];
 
     const auto nTabElems = t.numRows * t.numTables * t.numCols;
 
@@ -495,6 +496,8 @@ Relperm::Oil::Details::tableData(const std::vector<int>&    tabdims,
 {
     auto t = Opm::ECLPropTableRawData{};
 
+    t.numPrimary = 1;
+
     t.numCols = isTwoP
         ? 2                     // So, Kro
         : 3;                    // So, Krow, Krog
@@ -537,9 +540,10 @@ Relperm::Water::Details::tableData(const std::vector<int>&    tabdims,
 {
     auto t = Opm::ECLPropTableRawData{};
 
-    t.numCols   = 3;            // Sw, Krw, Pcow
-    t.numRows   = tabdims[ TABDIMS_NSSWFN_ITEM ];
-    t.numTables = tabdims[ TABDIMS_NTSWFN_ITEM ];
+    t.numPrimary = 1;
+    t.numCols    = 3;           // Sw, Krw, Pcow
+    t.numRows    = tabdims[ TABDIMS_NSSWFN_ITEM ];
+    t.numTables  = tabdims[ TABDIMS_NTSWFN_ITEM ];
 
     const auto nTabElems = t.numRows * t.numTables * t.numCols;
 

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -28,6 +28,9 @@
 #include <opm/utility/ECLPropTable.hpp>
 #include <opm/utility/ECLRegionMapping.hpp>
 #include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -100,14 +103,19 @@ namespace Relperm {
             Opm::ECLPropTableRawData
             tableData(const std::vector<int>&    tabdims,
                       const std::vector<double>& tab);
+
+            Opm::SatFuncInterpolant::ConvertUnits
+            unitConverter(const int usys);
         }
 
         class KrFunction
         {
         public:
             KrFunction(const std::vector<int>&    tabdims,
-                       const std::vector<double>& tab)
-                : func_(Details::tableData(tabdims, tab))
+                       const std::vector<double>& tab,
+                       const int                  usys)
+                : func_(Details::tableData(tabdims, tab),
+                        Details::unitConverter(usys))
             {}
 
             std::vector<double> sgco() const
@@ -157,6 +165,9 @@ namespace Relperm {
             tableData(const std::vector<int>&    tabdims,
                       const bool                 isTwoP,
                       const std::vector<double>& tab);
+
+            Opm::SatFuncInterpolant::ConvertUnits
+            unitConverter(const bool isTwoP);
         } // namespace Details
 
         class KrFunction
@@ -165,7 +176,8 @@ namespace Relperm {
             KrFunction(const std::vector<int>&    tabdims,
                        const bool                 isTwoP,
                        const std::vector<double>& tab)
-                : func_(Details::tableData(tabdims, isTwoP, tab))
+                : func_(Details::tableData(tabdims, isTwoP, tab),
+                        Details::unitConverter(isTwoP))
                 , twop_(isTwoP)
             {}
 
@@ -374,14 +386,19 @@ namespace Relperm {
             Opm::ECLPropTableRawData
             tableData(const std::vector<int>&    tabdims,
                       const std::vector<double>& tab);
+
+            Opm::SatFuncInterpolant::ConvertUnits
+            unitConverter(const int usys);
         } // namespace Details
 
         class KrFunction
         {
         public:
             KrFunction(const std::vector<int>&    tabdims,
-                       const std::vector<double>& tab)
-                : func_(Details::tableData(tabdims, tab))
+                       const std::vector<double>& tab,
+                       const int                  usys)
+                : func_(Details::tableData(tabdims, tab),
+                        Details::unitConverter(usys))
             {}
 
             std::vector<double> swco() const
@@ -446,6 +463,31 @@ Relperm::Gas::Details::tableData(const std::vector<int>&    tabdims,
     return t;
 }
 
+Opm::SatFuncInterpolant::ConvertUnits
+Relperm::Gas::Details::unitConverter(const int usys)
+{
+    using CU = Opm::SatFuncInterpolant::ConvertUnits;
+    using Cvrt = CU::Converter;
+
+    auto id = [](const double x) { return x; };
+
+    const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+    const auto pscale = u->pressure();
+
+    auto cvrt_press = [pscale](const double p) {
+        return ::Opm::unit::convert::from(p, pscale);
+    };
+
+    return CU {
+        Cvrt{ id },             // Sg
+        { Cvrt{ id },           // Krg
+          Cvrt{ cvrt_press } }  // Pcgo
+    };
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 Opm::ECLPropTableRawData
 Relperm::Oil::Details::tableData(const std::vector<int>&    tabdims,
                                  const bool                 isTwoP,
@@ -470,6 +512,25 @@ Relperm::Oil::Details::tableData(const std::vector<int>&    tabdims,
     return t;
 }
 
+Opm::SatFuncInterpolant::ConvertUnits
+Relperm::Oil::Details::unitConverter(const bool isTwoP)
+{
+    using CU = Opm::SatFuncInterpolant::ConvertUnits;
+    using Cvrt = CU::Converter;
+
+    auto id = [](const double x) { return x; };
+
+    //                          [Kro]            [Krow, Krog]
+    const auto ncvrt = isTwoP ? std::size_t{1} : std::size_t{2};
+
+    return CU {
+        Cvrt{ id },                          // So
+        std::vector<Cvrt>(ncvrt, Cvrt{ id }) // Kr
+    };
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 Opm::ECLPropTableRawData
 Relperm::Water::Details::tableData(const std::vector<int>&    tabdims,
                                    const std::vector<double>& tab)
@@ -488,6 +549,29 @@ Relperm::Water::Details::tableData(const std::vector<int>&    tabdims,
     t.data.assign(&tab[start], &tab[start] + nTabElems);
 
     return t;
+}
+
+Opm::SatFuncInterpolant::ConvertUnits
+Relperm::Water::Details::unitConverter(const int usys)
+{
+    using CU = Opm::SatFuncInterpolant::ConvertUnits;
+    using Cvrt = CU::Converter;
+
+    auto id = [](const double x) { return x; };
+
+    const auto u = ::Opm::ECLUnits::createUnitSystem(usys);
+
+    const auto pscale = u->pressure();
+
+    auto cvrt_press = [pscale](const double p) {
+        return ::Opm::unit::convert::from(p, pscale);
+    };
+
+    return CU {
+        Cvrt{ id },             // Sw
+        { Cvrt{ id },           // Krw
+          Cvrt{ cvrt_press } }  // Pcow
+    };
 }
 
 // =====================================================================
@@ -780,7 +864,8 @@ private:
     std::unique_ptr<EPSEvaluator> eps_;
 
     void initRelPermInterp(const EPSEvaluator::ActPh& active,
-                           const ECLInitFileData&     init);
+                           const ECLInitFileData&     init,
+                           const int                  usys);
 
     void initEPS(const EPSEvaluator::ActPh& active,
                  const bool                 use3PtScaling,
@@ -870,7 +955,7 @@ Opm::ECLSaturationFunc::Impl::init(const ECLGraph&        G,
 
     const auto active = EPSEvaluator::ActPh{iphs};
 
-    this->initRelPermInterp(active, init);
+    this->initRelPermInterp(active, init, ih[INTEHEAD_UNIT_INDEX]);
 
     if (useEPS) {
         const auto& lh = init.keywordData<bool>(LOGIHEAD_KW);
@@ -891,7 +976,8 @@ Opm::ECLSaturationFunc::Impl::init(const ECLGraph&        G,
 void
 Opm::ECLSaturationFunc::
 Impl::initRelPermInterp(const EPSEvaluator::ActPh& active,
-                        const ECLInitFileData&     init)
+                        const ECLInitFileData&     init,
+                        const int                  usys)
 {
     const auto isThreePh =
         active.oil && active.gas && active.wat;
@@ -901,11 +987,11 @@ Impl::initRelPermInterp(const EPSEvaluator::ActPh& active,
     const auto& tab     = init.keywordData<double>("TAB");
 
     if (active.gas) {
-        this->gas_.reset(new Relperm::Gas::KrFunction(tabdims, tab));
+        this->gas_.reset(new Relperm::Gas::KrFunction(tabdims, tab, usys));
     }
 
     if (active.wat) {
-        this->wat_.reset(new Relperm::Water::KrFunction(tabdims, tab));
+        this->wat_.reset(new Relperm::Water::KrFunction(tabdims, tab, usys));
     }
 
     if (active.oil) {

--- a/opm/utility/ECLTableInterpolation1D.cpp
+++ b/opm/utility/ECLTableInterpolation1D.cpp
@@ -1,0 +1,124 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLTableInterpolation1D.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <exception>
+#include <functional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace Details {
+    template <class Compare>
+    std::vector<double>::size_type
+    intervalInRange(const std::vector<double>& abscissas,
+                    const double               x,
+                    Compare&&                  compare)
+    {
+        // Verify that 'x' is within range.  Order of arguments matters.
+        assert (! compare(x, abscissas.front()));
+        assert (! compare(abscissas.back(), x));
+
+        const auto b = std::begin(abscissas);
+        const auto p =
+            std::lower_bound(b, std::end(abscissas), x,
+                             std::forward<Compare>(compare));
+
+        assert (p != std::end(abscissas));
+
+        // p = lower_bound() => p identifies *right-hand* (upper) end-point
+        // of interval (insertion point) => (p - b) is index of right-hand
+        // end-point.  Consequently (p - b) - 1 is index of *left-hand*
+        // end-point and the point with which we associate the pertinent
+        // interval.  Special case handling for p == b.
+
+        return (p == b) ? 0 : (p - b) - 1;
+    }
+
+    template <class Compare>
+    Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint
+    identifyPoint(const std::vector<double>& xi,
+                  const double               x,
+                  Compare&&                  compare)
+    {
+        namespace PP = ::Opm::Interp1D::PiecewisePolynomial;
+        using PCat   = ::Opm::Interp1D::PointCategory;
+
+        const auto left = xi.front();
+        if (compare(x, left)) {
+            // Left of min(xi) (== xi.front())
+            return PP::LocalInterpPoint {
+                PCat::LeftOfRange, 0, x - left,
+            };
+        }
+
+        const auto right = xi.back();
+        if (compare(right, x)) {
+            // Right of max(xi) (== xi.back())
+            return PP::LocalInterpPoint {
+                PCat::RightOfRange, xi.size() - 1, x - right,
+            };
+        }
+
+        // Common case: x \in [min(xi), max(xi)]
+        const auto interval = intervalInRange(xi, x, compare);
+
+        assert ((interval + 1 < xi.size()) || (xi.size() == 1));
+
+        return PP::LocalInterpPoint {
+            PCat::InRange, interval, x - xi[interval],
+        };
+    }
+
+    template <class Compare = std::less<double>>
+    Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint
+    identify(const std::vector<double>& xi,
+             const double               x,
+             Compare&&                  compare = Compare{})
+    {
+        if (xi.empty()) {
+            throw std::invalid_argument {
+                "Cannot Relate Point to Non-Existent Range of Variable"
+            };
+        }
+
+        return identifyPoint(xi, x, std::forward<Compare>(compare));
+    }
+} // Anonymous
+
+// =====================================================================
+
+Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint
+Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint::
+identify(const std::vector<double>& xi,
+         const double               x, std::true_type)
+{
+    return Details::identify(xi, x);
+}
+
+Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint
+Opm::Interp1D::PiecewisePolynomial::LocalInterpPoint::
+identify(const std::vector<double>& xi,
+         const double               x, std::false_type)
+{
+    return Details::identify(xi, x, std::greater<double>{});
+}

--- a/opm/utility/ECLTableInterpolation1D.hpp
+++ b/opm/utility/ECLTableInterpolation1D.hpp
@@ -1,0 +1,312 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLTABLEINTERPOLATION1D_HEADER_INCLUDED
+#define OPM_ECLTABLEINTERPOLATION1D_HEADER_INCLUDED
+
+#include <cassert>
+#include <type_traits>
+#include <vector>
+
+/// \file
+///
+/// Common types and policies for one-dimensional (single variate)
+/// interpolation of tabulated functions.  Mainly intended to support
+/// piecewise linear interpolation.
+
+namespace Opm { namespace Interp1D {
+
+    /// Categories of interpolation behaviour according to location of
+    /// interpolation point with respect to range of independent variable.
+    enum class PointCategory {
+        /// Point within range of independent variable.
+        InRange,
+
+        /// Point is to the left of range.
+        LeftOfRange,
+
+        /// Point is to the right of range.
+        RightOfRange,
+    };
+
+    /// Functionality for interpolating functions of a single variate using
+    /// piecewise polynomials.
+    namespace PiecewisePolynomial {
+
+        /// Policies that implement particular behaviours for extrapolating
+        /// a tabulated function, assuming ECL's table format, outside the
+        /// tabulated range of its independent variable.
+        namespace ExtrapolationPolicy {
+            /// Extrapolate function using constant values.
+            class Constant
+            {
+            public:
+                /// Extrapolate function to the left of range using first
+                /// tabulated function value.
+                ///
+                /// \tparam TabulatedFunction Representation of a tabulated
+                ///    function.  Must support function call operator such
+                ///    that the statement \code y = Func(i, col); \endcode
+                ///    returns the value of the \c col-th dependent variate
+                ///    at the \c i-th abscissa.
+                ///
+                /// \tparam Index Integer type representing an index into
+                ///    the abscissas of the tabulated function.
+                ///
+                /// \param[in] xmin Location of left-most abscissa.  Unused.
+                ///
+                /// \param[in] x Interpolation point (global coordinates).
+                ///    Unused.
+                ///
+                /// \param[in] col Column index identifying which dependent
+                ///    variate to extrapolate.
+                ///
+                /// \param[in] f Tabulated function instance.
+                ///
+                /// \return Value of \p col-th variate of tabulated function
+                ///    extrapolated to the left of the range of table's
+                ///    independent variate.
+                template <class TabulatedFunction, class Index>
+                double left(const double     /* xmin */,
+                            const double     /* x */,
+                            const Index         col ,
+                            TabulatedFunction&& f) const
+                {
+                    return f(0, col);
+                }
+
+                /// Extrapolate function to the rigth of range using "last"
+                /// tabulated function value.
+                ///
+                /// \tparam TabulatedFunction Representation of a tabulated
+                ///    function.  Must support function call operator such
+                ///    that the statement \code y = Func(i, col); \endcode
+                ///    returns the value of the \c col-th dependent variate
+                ///    at the \c i-th abscissa.
+                ///
+                /// \tparam Index Integer type representing an index into
+                ///    the abscissas of the tabulated function.
+                ///
+                /// \param[in] xmax Location of rigth-most abscissa.  Unused.
+                ///
+                /// \param[in] x Interpolation point (global coordinates).
+                ///    Unused.
+                ///
+                /// \param[in] col Column index identifying which dependent
+                ///    variate to extrapolate.
+                ///
+                /// \param[in] nRows Number of rows (abscissas) in
+                ///    function's underlying table representation.
+                ///
+                /// \param[in] f Tabulated function instance.
+                ///
+                /// \return Value of \p col-th variate of tabulated function
+                ///    extrapolated to the rigth of the range of table's
+                ///    independent variate.
+                template <class TabulatedFunction, class Index>
+                double right(const double     /* xmax */,
+                             const double     /* x */,
+                             const Index         col,
+                             const Index         nRows,
+                             TabulatedFunction&& f) const
+                {
+                    return f(nRows - 1, col);
+                }
+            };
+
+            /// Extrapolate function using tabulated constant derivatives in
+            /// range end-points.
+            class LinearlyWithDerivatives
+            {
+            public:
+                /// Constructor
+                ///
+                /// \param[in] nResCol Number of function value (result)
+                ///    columns in underlying tabulated function.  Equal to
+                ///    total number of dependent variable columns less the
+                ///    number of derivative columns.  Typically two as in
+                ///    the cases of the PV{D,T}{G,O} tables.
+                explicit LinearlyWithDerivatives(const std::size_t nResCol)
+                    : nResCol_(nResCol)
+                {}
+
+                /// Extrapolate function to the left of range using first
+                /// tabulated function value and corresponding derivative.
+                ///
+                /// \tparam TabulatedFunction Representation of a tabulated
+                ///    function.  Must support function call operator such
+                ///    that the statement \code y = Func(i, col); \endcode
+                ///    returns the value of the \c col-th dependent variate
+                ///    at the \c i-th abscissa.
+                ///
+                /// \tparam Index Integer type representing an index into
+                ///    the abscissas of the tabulated function.
+                ///
+                /// \param[in] xmin Location of left-most abscissa.
+                ///
+                /// \param[in] x Interpolation point (global coordinates).
+                ///
+                /// \param[in] col Column index identifying which dependent
+                ///    variate to extrapolate.
+                ///
+                /// \param[in] f Tabulated function instance.
+                ///
+                /// \return Value of \p col-th variate of tabulated function
+                ///    extrapolated to the left of the range of table's
+                ///    independent variate.
+                template <class TabulatedFunction, class Index>
+                double left(const double        xmin,
+                            const double        x,
+                            const Index         col,
+                            TabulatedFunction&& f) const
+                {
+                    // Derivative of f(i,col) in f(i, nResCol_ + col)
+                    const auto dfdx = f(0, this->nResCol_ + col);
+                    const auto dx   = x - xmin; // <= 0 if ascending range
+
+                    return f(0, col) + (dfdx * dx);
+                }
+
+                /// Extrapolate function to the rigth of range using "last"
+                /// tabulated function value and corresponding derivative.
+                ///
+                /// \tparam TabulatedFunction Representation of a tabulated
+                ///    function.  Must support function call operator such
+                ///    that the statement \code y = Func(i, col); \endcode
+                ///    returns the value of the \c col-th dependent variate
+                ///    at the \c i-th abscissa.
+                ///
+                /// \tparam Index Integer type representing an index into
+                ///    the abscissas of the tabulated function.
+                ///
+                /// \param[in] xmax Location of rigth-most abscissa.
+                ///
+                /// \param[in] x Interpolation point (global coordinates).
+                ///
+                /// \param[in] col Column index identifying which dependent
+                ///    variate to extrapolate.
+                ///
+                /// \param[in] nRows Number of rows (abscissas) in
+                ///    function's underlying table representation.
+                ///
+                /// \param[in] f Tabulated function instance.
+                ///
+                /// \return Value of \p col-th variate of tabulated function
+                ///    extrapolated to the rigth of the range of table's
+                ///    independent variate.
+                template <class TabulatedFunction, class Index>
+                double right(const double        xmax,
+                             const double        x,
+                             const Index         col,
+                             const Index         nRows,
+                             TabulatedFunction&& f) const
+                {
+                    // Derivative of f(i,col) in f(i, nResCol_ + col)
+                    const auto dfdx = f(nRows - 1, this->nResCol_ + col);
+                    const auto dx   = x - xmax; // >= 0 if ascending range
+
+                    return f(nRows - 1, col) + (dfdx * dx);
+                }
+
+            private:
+                /// Number of function value (result) columns in underlying
+                /// tabulated function.
+                std::size_t nResCol_;
+            };
+        } // ExtrapolationPolicy
+
+        /// Interpolation point localized with respect to sequence of
+        /// non-overlapping intervals with separating abscissas.
+        struct LocalInterpPoint {
+            /// Interpolation behaviour of point with respect to range.
+            PointCategory cat;
+
+            /// Interval index.  Meaningful only with respect to particular
+            /// sequence of abscissas.  Zero when
+            ///
+            /// \code
+            ///    cat == PointCategory::LeftOfRange
+            /// \endcode
+            ///
+            /// Equal to number of abscissas (i.e., one greater than number
+            /// of intervals) when
+            ///
+            /// \code
+            ///    cat == PointCategory::RightOfRange
+            /// \endcode.
+            std::vector<double>::size_type interval;
+
+            /// Local coordinate within interval.  Defined as
+            ///
+            /// \code
+            ///    x - abscissa[interval]
+            /// \endcode
+            ///
+            /// Non-positive for PointCategory::LeftOfRange.  Non-negative
+            /// otherwise.
+            double t;
+
+            /// Identify point category and, usually, particular interval in
+            /// which a specific point is localized.
+            ///
+            /// Overload for usual case of ascendingly sorted abscissas.
+            ///
+            /// \param[in] xi Sequence of separating abscissas representing
+            ///    non-overlapping intervals of an independent variable.
+            ///
+            /// \param[in] x Sample point.
+            ///
+            /// \param[in] is_ascending Tagged dispatch overload
+            ///    disambiguation object.  Unused.
+            ///
+            /// \return Sample point localized with respect to the abscissas
+            ///    \p xi.
+            static LocalInterpPoint
+            identify(const std::vector<double>& xi,
+                     const double               x,
+                     std::true_type is_ascending = std::true_type{});
+
+            /// Identify point category and, usually, particular interval in
+            /// which a specific point is localized.
+            ///
+            /// Overload for case of descendingly sorted abscissas (e.g.,
+            /// through \code std::sort(first, last, std::greater<>{})
+            /// \endcode).
+            ///
+            /// \param[in] xi Sequence of separating abscissas representing
+            ///    non-overlapping intervals of an independent variable.
+            ///
+            /// \param[in] x Sample point.
+            ///
+            /// \param[in] is_ascending Tagged dispatch overload
+            ///    disambiguation object.  Unused.
+            ///
+            /// \return Sample point localized with respect to the abscissas
+            ///    \p xi.
+            static LocalInterpPoint
+            identify(const std::vector<double>& xi,
+                     const double               x,
+                     std::false_type is_ascending);
+        };
+
+    } // PiecewisePolynomial
+
+}} // Opm::Interp1D
+
+#endif // OPM_ECLTABLEINTERPOLATION1D_HEADER_INCLUDED

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -66,6 +66,11 @@ namespace Opm { namespace ECLUnits {
             {
                 return Metric::Transmissibility;
             }
+
+            virtual double viscosity() const override
+            {
+                return Metric::Viscosity;
+            }
         };
 
         template <>
@@ -96,6 +101,11 @@ namespace Opm { namespace ECLUnits {
             {
                 return Field::Transmissibility;
             }
+
+            virtual double viscosity() const override
+            {
+                return Field::Viscosity;
+            }
         };
 
         template <>
@@ -125,6 +135,11 @@ namespace Opm { namespace ECLUnits {
             virtual double transmissibility() const override
             {
                 return Lab::Transmissibility;
+            }
+
+            virtual double viscosity() const override
+            {
+                return Lab::Viscosity;
             }
         };
 
@@ -164,6 +179,11 @@ namespace Opm { namespace ECLUnits {
                 using namespace unit;
 
                 return centi*Poise * cubic(meter) / (day * atm);
+            }
+
+            virtual double viscosity() const override
+            {
+                return prefix::centi*unit::Poise;
             }
         };
     } // namespace Impl

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -42,6 +42,16 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_METRIC_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual double density() const override
+            {
+                return Metric::Density;
+            }
+
+            virtual double depth() const override
+            {
+                return Metric::Length;
+            }
+
             virtual double pressure() const override
             {
                 return Metric::Pressure;
@@ -87,6 +97,16 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_FIELD_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual double density() const override
+            {
+                return Field::Density;
+            }
+
+            virtual double depth() const override
+            {
+                return Field::Length;
+            }
+
             virtual double pressure() const override
             {
                 return Field::Pressure;
@@ -132,6 +152,16 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_LAB_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual double density() const override
+            {
+                return Lab::Density;
+            }
+
+            virtual double depth() const override
+            {
+                return Lab::Length;
+            }
+
             virtual double pressure() const override
             {
                 return Lab::Pressure;
@@ -177,6 +207,19 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_PVT_M_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual double density() const override
+            {
+                using namespace prefix;
+                using namespace unit;
+
+                return kilogram / cubic(meter);
+            }
+
+            virtual double depth() const override
+            {
+                return unit::meter;
+            }
+
             virtual double pressure() const override
             {
                 return unit::atm;
@@ -241,6 +284,18 @@ Opm::ECLUnits::Impl::getUnitConvention(const int usys)
 
     throw std::runtime_error("Unsupported Unit Convention: "
                              + std::to_string(usys));
+}
+
+double Opm::ECLUnits::UnitSystem::dissolvedGasOilRat() const
+{
+    return this->surfaceVolumeGas()
+        /  this->surfaceVolumeLiquid();
+}
+
+double Opm::ECLUnits::UnitSystem::vaporisedOilGasRat() const
+{
+    return this->surfaceVolumeLiquid()
+        /  this->surfaceVolumeGas();
 }
 
 std::unique_ptr<const ::Opm::ECLUnits::UnitSystem>

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -57,6 +57,16 @@ namespace Opm { namespace ECLUnits {
                 return Metric::ReservoirVolume;
             }
 
+            virtual double surfaceVolumeGas() const override
+            {
+                return Metric::GasSurfaceVolume;
+            }
+
+            virtual double surfaceVolumeLiquid() const override
+            {
+                return Metric::LiquidSurfaceVolume;
+            }
+
             virtual double time() const override
             {
                 return Metric::Time;
@@ -92,6 +102,16 @@ namespace Opm { namespace ECLUnits {
                 return Field::ReservoirVolume;
             }
 
+            virtual double surfaceVolumeGas() const override
+            {
+                return Field::GasSurfaceVolume;
+            }
+
+            virtual double surfaceVolumeLiquid() const override
+            {
+                return Field::LiquidSurfaceVolume;
+            }
+
             virtual double time() const override
             {
                 return Field::Time;
@@ -125,6 +145,16 @@ namespace Opm { namespace ECLUnits {
             virtual double reservoirVolume() const override
             {
                 return Lab::ReservoirVolume;
+            }
+
+            virtual double surfaceVolumeGas() const override
+            {
+                return Lab::GasSurfaceVolume;
+            }
+
+            virtual double surfaceVolumeLiquid() const override
+            {
+                return Lab::LiquidSurfaceVolume;
             }
 
             virtual double time() const override
@@ -166,6 +196,16 @@ namespace Opm { namespace ECLUnits {
                 using namespace unit;
 
                 return cubic(meter);
+            }
+
+            virtual double surfaceVolumeGas() const override
+            {
+                return unit::cubic(unit::meter);
+            }
+
+            virtual double surfaceVolumeLiquid() const override
+            {
+                return unit::cubic(unit::meter);
             }
 
             virtual double time() const override

--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -33,6 +33,7 @@ namespace Opm {
             virtual double reservoirVolume()  const = 0;
             virtual double time()             const = 0;
             virtual double transmissibility() const = 0;
+            virtual double viscosity()        const = 0;
         };
 
         std::unique_ptr<const UnitSystem>

--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -28,12 +28,14 @@ namespace Opm {
 
         struct UnitSystem
         {
-            virtual double pressure()         const = 0;
-            virtual double reservoirRate()    const = 0;
-            virtual double reservoirVolume()  const = 0;
-            virtual double time()             const = 0;
-            virtual double transmissibility() const = 0;
-            virtual double viscosity()        const = 0;
+            virtual double pressure()            const = 0;
+            virtual double reservoirRate()       const = 0;
+            virtual double reservoirVolume()     const = 0;
+            virtual double surfaceVolumeLiquid() const = 0;
+            virtual double surfaceVolumeGas()    const = 0;
+            virtual double time()                const = 0;
+            virtual double transmissibility()    const = 0;
+            virtual double viscosity()           const = 0;
         };
 
         std::unique_ptr<const UnitSystem>

--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -28,6 +28,8 @@ namespace Opm {
 
         struct UnitSystem
         {
+            virtual double density()             const = 0;
+            virtual double depth()               const = 0;
             virtual double pressure()            const = 0;
             virtual double reservoirRate()       const = 0;
             virtual double reservoirVolume()     const = 0;
@@ -36,6 +38,9 @@ namespace Opm {
             virtual double time()                const = 0;
             virtual double transmissibility()    const = 0;
             virtual double viscosity()           const = 0;
+
+            double dissolvedGasOilRat() const; // Rs
+            double vaporisedOilGasRat() const; // Rv
         };
 
         std::unique_ptr<const UnitSystem>

--- a/tests/test_eclproptable.cpp
+++ b/tests/test_eclproptable.cpp
@@ -81,6 +81,19 @@ namespace {
 
         return t;
     }
+
+    Opm::SatFuncInterpolant::ConvertUnits
+    createDummyUnitConverter(const std::size_t ncol)
+    {
+        using Cvrt = Opm::SatFuncInterpolant::ConvertUnits::Converter;
+
+        auto id = [](const double x) { return x; };
+
+        return Opm::SatFuncInterpolant::ConvertUnits {
+            Cvrt{ id },
+            std::vector<Cvrt>(ncol, Cvrt{ id })
+        };
+    }
 } // Namespace Anonymous
 
 // =====================================================================
@@ -101,7 +114,8 @@ BOOST_AUTO_TEST_CASE (EmptyTable)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
+                                              createDummyUnitConverter(2)),
                       std::invalid_argument);
 }
 
@@ -118,7 +132,8 @@ BOOST_AUTO_TEST_CASE (SingleNode)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
+                                              createDummyUnitConverter(2)),
                       std::invalid_argument);
 }
 
@@ -138,7 +153,8 @@ BOOST_AUTO_TEST_CASE (NoResultColumns)
     t.numCols   = 1;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
+                                              createDummyUnitConverter(0)),
                       std::invalid_argument);
 }
 
@@ -162,7 +178,8 @@ BOOST_AUTO_TEST_CASE (EmptyTableLargeNodeAlloc)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
+                                              createDummyUnitConverter(2)),
                       std::invalid_argument);
 }
 
@@ -187,7 +204,8 @@ BOOST_AUTO_TEST_CASE (SingleNodeLargeNodeAlloc)
     t.numCols   = 3;
     t.numTables = 1;
 
-    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
+                                              createDummyUnitConverter(2)),
                       std::invalid_argument);
 }
 
@@ -215,7 +233,8 @@ BOOST_AUTO_TEST_CASE (NoResultColumnsLargeNodeAlloc)
     t.numCols   =  1;
     t.numTables =  1;
 
-    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t)),
+    BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
+                                              createDummyUnitConverter(2)),
                       std::invalid_argument);
 }
 
@@ -245,7 +264,10 @@ BOOST_AUTO_TEST_CASE (AtNodes)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s         = std::vector<double>{ 0.8, 0.3, 0.3, 0.2 };
     const auto kr_expect = std::vector<double>{ 0.5, 0.1, 0.1, 0.0 };
@@ -291,7 +313,10 @@ BOOST_AUTO_TEST_CASE (AboveAndBelow)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s         = std::vector<double>{ 0.80000001, 0.9, 0.199999999, 0.1 };
     const auto kr_expect = std::vector<double>{ 0.5,        0.5, 0.0,         0.0 };
@@ -325,7 +350,10 @@ BOOST_AUTO_TEST_CASE (Interpolation)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s = std::vector<double>{
         0.2000,
@@ -418,7 +446,10 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s = std::vector<double>{
         0.0000,
@@ -541,7 +572,10 @@ BOOST_AUTO_TEST_CASE (AtNodes)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s         = std::vector<double>{ 0.8, 0.3, 0.3, 0.2 };
     const auto kr_expect = std::vector<double>{ 0.5, 0.1, 0.1, 0.0 };
@@ -606,7 +640,10 @@ BOOST_AUTO_TEST_CASE (AboveAndBelow)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s         = std::vector<double>{ 0.80000001, 0.9, 0.199999999, 0.1 };
     const auto kr_expect = std::vector<double>{ 0.5,        0.5, 0.0,         0.0 };
@@ -662,7 +699,10 @@ BOOST_AUTO_TEST_CASE (Interpolation)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s = std::vector<double>{
         0.2000,
@@ -812,7 +852,10 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     const auto s = std::vector<double>{
         0.0000,
@@ -923,7 +966,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -972,7 +1018,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1009,7 +1058,10 @@ BOOST_AUTO_TEST_CASE (SWFN)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1059,7 +1111,10 @@ BOOST_AUTO_TEST_CASE (SWFN_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1096,7 +1151,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1147,7 +1205,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1187,7 +1248,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1239,7 +1303,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1279,7 +1346,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1331,7 +1401,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1373,7 +1446,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1425,7 +1501,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1486,7 +1565,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1586,7 +1668,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1641,7 +1726,10 @@ BOOST_AUTO_TEST_CASE (SWFN)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1745,7 +1833,10 @@ BOOST_AUTO_TEST_CASE (SWFN_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1797,7 +1888,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1899,7 +1993,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -1957,7 +2054,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -2063,7 +2163,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -2121,7 +2224,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -2227,7 +2333,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -2293,7 +2402,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 
@@ -2399,7 +2511,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn_LargeNodeAlloc)
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
     // data.
-    const auto swfunc = Opm::SatFuncInterpolant(toRawTableFormat(t));
+    const auto swfunc = Opm::SatFuncInterpolant {
+        toRawTableFormat(t),
+        createDummyUnitConverter(t.numCols - 1)
+    };
 
     using ResultColumn = Opm::SatFuncInterpolant::ResultColumn;
 

--- a/tests/test_eclproptable.cpp
+++ b/tests/test_eclproptable.cpp
@@ -110,9 +110,10 @@ BOOST_AUTO_TEST_CASE (EmptyTable)
         // s, kr  , pc
     };
 
-    t.numRows   = 0;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 0;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
                                               createDummyUnitConverter(2)),
@@ -128,9 +129,10 @@ BOOST_AUTO_TEST_CASE (SingleNode)
         0.3 , 0.1 , 0.0,
     };
 
-    t.numRows   = 1;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 1;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
                                               createDummyUnitConverter(2)),
@@ -149,9 +151,10 @@ BOOST_AUTO_TEST_CASE (NoResultColumns)
         0.8,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 1;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 1;
+    t.numTables  = 1;
 
     BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
                                               createDummyUnitConverter(0)),
@@ -174,9 +177,10 @@ BOOST_AUTO_TEST_CASE (EmptyTableLargeNodeAlloc)
         1.0e+20 ,  1.0e+20, 0.0,
     };
 
-    t.numRows   = 8;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 8;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
                                               createDummyUnitConverter(2)),
@@ -200,9 +204,10 @@ BOOST_AUTO_TEST_CASE (SingleNodeLargeNodeAlloc)
         1.0e+20 ,  1.0e+20, 0.0,
     };
 
-    t.numRows   = 9;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 9;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
                                               createDummyUnitConverter(2)),
@@ -229,9 +234,10 @@ BOOST_AUTO_TEST_CASE (NoResultColumnsLargeNodeAlloc)
         1.0e+20,
     };
 
-    t.numRows   = 12;
-    t.numCols   =  1;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 12;
+    t.numCols    =  1;
+    t.numTables  =  1;
 
     BOOST_CHECK_THROW(Opm::SatFuncInterpolant(toRawTableFormat(t),
                                               createDummyUnitConverter(2)),
@@ -257,9 +263,10 @@ BOOST_AUTO_TEST_CASE (AtNodes)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -306,9 +313,10 @@ BOOST_AUTO_TEST_CASE (AboveAndBelow)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -343,9 +351,10 @@ BOOST_AUTO_TEST_CASE (Interpolation)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -439,9 +448,10 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
         1.0e20 , 1.0e+100 , 0.0, // 15
     };
 
-    t.numRows   = 15;
-    t.numCols   =  3;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 15;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -565,9 +575,10 @@ BOOST_AUTO_TEST_CASE (AtNodes)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -633,9 +644,10 @@ BOOST_AUTO_TEST_CASE (AboveAndBelow)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -692,9 +704,10 @@ BOOST_AUTO_TEST_CASE (Interpolation)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -845,9 +858,10 @@ BOOST_AUTO_TEST_CASE (InterpolationLargeNodeAlloc)
         1.0e20 , 1.0e+100 , 0.0, // 15
     };
 
-    t.numRows   = 15;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 15;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Note: Need to convert input table to column major (Fortran) order
     // because that is the format in which PropTable1D expects the tabular
@@ -954,9 +968,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2 };
@@ -1006,9 +1021,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn_LargeNodeAlloc)
         1.0e20 , 1.0e+100 , 0.0, // 15
     };
 
-    t.numRows   = 15;
-    t.numCols   =  3;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 15;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2 };
@@ -1046,9 +1062,10 @@ BOOST_AUTO_TEST_CASE (SWFN)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2  };
@@ -1099,9 +1116,10 @@ BOOST_AUTO_TEST_CASE (SWFN_LargeNodeAlloc)
         1.0e20 , 1.0e+100 , 0.0, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2 };
@@ -1138,9 +1156,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn)
         0.8 , 0.5 , 0.8,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2 };
@@ -1192,9 +1211,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 15
     };
 
-    t.numRows   = 15;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary =  1;
+    t.numRows    = 15;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2 };
@@ -1235,9 +1255,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn)
         0.8 , 0.5 , 0.8,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2  };
@@ -1290,9 +1311,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2  };
@@ -1333,9 +1355,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn)
         0.8 , 0.5 , 0.8,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2  };
@@ -1388,9 +1411,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2  };
@@ -1433,9 +1457,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn)
         0.8  , 0.5 , 0.8,
     };
 
-    t.numRows   = 6;
-    t.numCols   = 3;
-    t.numTables = 1;
+    t.numPrimary = 1;
+    t.numRows    = 6;
+    t.numCols    = 3;
+    t.numTables  = 1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2   };
@@ -1488,9 +1513,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  1;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  1;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2   };
@@ -1553,9 +1579,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
@@ -1656,9 +1683,10 @@ BOOST_AUTO_TEST_CASE (SWFN_CritIsConn_LargeNodeAlloc)
         1.0e20 , 1.0e+100 , 0.0, // 15
     };
 
-    t.numRows   = 15;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 15;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
@@ -1714,9 +1742,10 @@ BOOST_AUTO_TEST_CASE (SWFN)
         0.8 , 0.5 , 0.0,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
@@ -1821,9 +1850,10 @@ BOOST_AUTO_TEST_CASE (SWFN_LargeNodeAlloc)
         1.0e20 , 1.0e+100 , 0.0, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Table end-points
     const auto sconn_expect = std::vector<double>{ 0.2 , 0.1 , 0.1 , 0.0  };
@@ -1875,9 +1905,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn)
         0.8 , 0.5 , 0.8,
     };
 
-    t.numRows   = 3;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 3;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2, 0.2, 0.2, 0.2 };
@@ -1980,9 +2011,10 @@ BOOST_AUTO_TEST_CASE (SOF3_CritIsConn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 15
     };
 
-    t.numRows   = 15;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 15;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2, 0.1, 0.0, 0.1 };
@@ -2041,9 +2073,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn)
         0.8 , 0.5 , 0.8,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
@@ -2150,9 +2183,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOGCR_is_Conn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.1 , 0.2 };
@@ -2211,9 +2245,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn)
         0.8 , 0.5 , 0.8,
     };
 
-    t.numRows   = 4;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 4;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.2 , 0.2  };
@@ -2320,9 +2355,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SOWCR_is_Conn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2 , 0.2 , 0.0 , 0.2     };
@@ -2389,9 +2425,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn)
         0.9  , 0.8 , 0.9,
     };
 
-    t.numRows   = 6;
-    t.numCols   = 3;
-    t.numTables = 4;
+    t.numPrimary = 1;
+    t.numRows    = 6;
+    t.numCols    = 3;
+    t.numTables  = 4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2  , 0.2  , 0.2  , 0.2   };
@@ -2498,9 +2535,10 @@ BOOST_AUTO_TEST_CASE (SOF3_SCR_Not_Conn_LargeNodeAlloc)
         1.0e20 ,  1.0e+100,  1.0e+100, // 16
     };
 
-    t.numRows   = 16;
-    t.numCols   =  3;
-    t.numTables =  4;
+    t.numPrimary =  1;
+    t.numRows    = 16;
+    t.numCols    =  3;
+    t.numTables  =  4;
 
     // Table end-points
     const auto sconn_expect      = std::vector<double>{ 0.2  , 0.1  , 0.2  , 0.2  };

--- a/tests/test_eclpvtcommon.cpp
+++ b/tests/test_eclpvtcommon.cpp
@@ -45,6 +45,7 @@ struct ConvertToSI
 {
     explicit ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys);
 
+    double dens   { 0.0 };
     double press  { 0.0 };
     double compr  { 0.0 };
     double disgas { 0.0 };
@@ -75,6 +76,9 @@ ConvertToSI::ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys)
     {
         return cnv(1.0);
     };
+
+    // Mass density
+    this->dens = apply(Cvrt::density(usys));
 
     // Pressure
     this->press = apply(Cvrt::pressure(usys));
@@ -156,6 +160,9 @@ BOOST_AUTO_TEST_CASE (Metric)
 
     const auto scale = ConvertToSI(*usys);
 
+    // Mass density
+    BOOST_CHECK_CLOSE(scale.dens, 1.0, 1.0e-10);
+
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 1.0e5, 1.0e-10);
 
@@ -215,6 +222,9 @@ BOOST_AUTO_TEST_CASE (Field)
     const auto usys = ::Opm::ECLUnits::createUnitSystem(2);
 
     const auto scale = ConvertToSI(*usys);
+
+    // Mass density
+    BOOST_CHECK_CLOSE(scale.dens, 1.601846337396014e+01, 1.0e-10);
 
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 6.894757293168360e+03, 1.0e-10);
@@ -286,6 +296,9 @@ BOOST_AUTO_TEST_CASE (Lab)
 
     const auto scale = ConvertToSI(*usys);
 
+    // Mass density
+    BOOST_CHECK_CLOSE(scale.dens, 1.0e3, 1.0e-10);
+
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 101.325e3, 1.0e-10);
 
@@ -351,6 +364,9 @@ BOOST_AUTO_TEST_CASE (PVT_M)
     const auto usys = ::Opm::ECLUnits::createUnitSystem(4);
 
     const auto scale = ConvertToSI(*usys);
+
+    // Mass density
+    BOOST_CHECK_CLOSE(scale.dens, 1.0, 1.0e-10);
 
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 101.325e3, 1.0e-10);

--- a/tests/test_eclpvtcommon.cpp
+++ b/tests/test_eclpvtcommon.cpp
@@ -143,6 +143,9 @@ ConvertToSI::ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys)
         apply(Cvrt::recipFvfGasViscDerivVapOil(usys));
 }
 
+template <std::size_t N>
+using DVec = ::Opm::ECLPVT::DenseVector<N>;
+
 // =====================================================================
 
 BOOST_AUTO_TEST_SUITE (Basic_Conversion)
@@ -405,6 +408,121 @@ BOOST_AUTO_TEST_CASE (PVT_M)
     // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
     // (Bg*mu_g)) w.r.t. Vaporised Oil-Gas Ratio.
     BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivVapOil, 1.0e3, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (DenseVector)
+
+BOOST_AUTO_TEST_CASE (Construct)
+{
+    // DenseVector<1>
+    {
+        const auto x = DVec<1>{ std::array<double, 1>{ { 1.0 } } };
+
+        BOOST_CHECK_CLOSE(x.array()[0], 1.0, 1.0e-10);
+    }
+
+    // DenseVector<2>
+    {
+        const auto x = DVec<2>{ std::array<double, 2>{ { 2.0, -1.0 } } };
+
+        BOOST_CHECK_CLOSE(x.array()[0],  2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(x.array()[1], -1.0, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Addition)
+{
+    const auto x = DVec<2>{
+        std::array<double,2>{ 0.1, 2.3 }
+    };
+
+    const auto two_x = x + x;
+
+    BOOST_CHECK_CLOSE(two_x.array()[0], 0.2, 1.0e-10);
+    BOOST_CHECK_CLOSE(two_x.array()[1], 4.6, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE (Subtraction)
+{
+    const auto x = DVec<2>{
+        std::array<double,2>{ 0.1, 2.3 }
+    };
+
+    const auto y = DVec<2>{
+        std::array<double,2>{ 10.9, 8.7 }
+    };
+
+    const auto x_minus_y = x - y;
+
+    BOOST_CHECK_CLOSE(x_minus_y.array()[0], -10.8, 1.0e-10);
+    BOOST_CHECK_CLOSE(x_minus_y.array()[1], - 6.4, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE (Mult_By_Scalar)
+{
+    // x *= a
+    {
+        auto x = DVec<2> {
+            std::array<double,2>{ 0.1, 2.3 }
+        };
+
+        x *= 5.0;
+
+        BOOST_CHECK_CLOSE(x.array()[0],  0.5, 1.0e-10);
+        BOOST_CHECK_CLOSE(x.array()[1], 11.5, 1.0e-10);
+    }
+
+    // y <- x * a
+    {
+        const auto x = DVec<2> {
+            std::array<double,2>{ 0.1, 2.3 }
+        };
+
+        {
+            const auto y = x * 5.0;
+
+            BOOST_CHECK_CLOSE(y.array()[0],  0.5, 1.0e-10);
+            BOOST_CHECK_CLOSE(y.array()[1], 11.5, 1.0e-10);
+        }
+
+        {
+            const auto y = 2.5 * x;
+
+            BOOST_CHECK_CLOSE(y.array()[0], 0.25, 1.0e-10);
+            BOOST_CHECK_CLOSE(y.array()[1], 5.75, 1.0e-10);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Divide_By_Scalar)
+{
+    // x /= a
+    {
+        auto x = DVec<2> {
+            std::array<double,2>{ 0.5, 11.5 }
+        };
+
+        x /= 5.0;
+
+        BOOST_CHECK_CLOSE(x.array()[0], 0.1, 1.0e-10);
+        BOOST_CHECK_CLOSE(x.array()[1], 2.3, 1.0e-10);
+    }
+
+    // y <- x / a
+    {
+        const auto x = DVec<2> {
+            std::array<double,2>{ 0.25, 5.75 }
+        };
+
+        const auto y = x / 2.5;
+
+        BOOST_CHECK_CLOSE(y.array()[0], 0.1, 1.0e-10);
+        BOOST_CHECK_CLOSE(y.array()[1], 2.3, 1.0e-10);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclpvtcommon.cpp
+++ b/tests/test_eclpvtcommon.cpp
@@ -1,0 +1,394 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ECLPVTCOMMON_UNITCONV
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/utility/ECLPvtCommon.hpp>
+
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <exception>
+#include <stdexcept>
+
+struct ConvertToSI
+{
+    explicit ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys);
+
+    double press  { 0.0 };
+    double disgas { 0.0 };
+    double vapoil { 0.0 };
+
+    double recipFvf            { 0.0 };
+    double recipFvfDerivPress  { 0.0 };
+    double recipFvfDerivVapOil { 0.0 };
+
+    double recipFvfVisc            { 0.0 };
+    double recipFvfViscDerivPress  { 0.0 };
+    double recipFvfViscDerivVapOil { 0.0 };
+
+    double recipFvfGas            { 0.0 };
+    double recipFvfGasDerivPress  { 0.0 };
+    double recipFvfGasDerivVapOil { 0.0 };
+
+    double recipFvfGasVisc            { 0.0 };
+    double recipFvfGasViscDerivPress  { 0.0 };
+    double recipFvfGasViscDerivVapOil { 0.0 };
+};
+
+ConvertToSI::ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys)
+{
+    using Cvrt = ::Opm::ECLPVT::CreateUnitConverter::ToSI;
+
+    auto apply = [](const ::Opm::ECLPVT::ConvertUnits::Converter& cnv)
+    {
+        return cnv(1.0);
+    };
+
+    // Pressure
+    this->press = apply(Cvrt::pressure(usys));
+
+    // Dissolved gas-oil ratio (Rs)
+    this->disgas = apply(Cvrt::disGas(usys));
+
+    // Vaporised oil-gas ratio (Rv)
+    this->vapoil = apply(Cvrt::vapOil(usys));
+
+    // Reciprocal formation volume factor (1/B)
+    this->recipFvf = apply(Cvrt::recipFvf(usys));
+
+    // Derivative of reciprocal formation volume factor (1/B) with respect
+    // to fluid (phase) pressure.
+    this->recipFvfDerivPress =
+        apply(Cvrt::recipFvfDerivPress(usys));
+
+    // Derivative of reciprocal formation volume factor (1/B) with respect
+    // to vaporised oil-gas ratio.
+    this->recipFvfDerivVapOil =
+        apply(Cvrt::recipFvfDerivVapOil(usys));
+
+    // Reciprocal product of formation volume factor and viscosity
+    // (1/(B*mu)).
+    this->recipFvfVisc = apply(Cvrt::recipFvfVisc(usys));
+
+    // Derivative of reciprocal product of formation volume factor and
+    // viscosity (1/(B*mu)) with respect to fluid (phase) pressure.
+    this->recipFvfViscDerivPress =
+        apply(Cvrt::recipFvfViscDerivPress(usys));
+
+    // Derivative of reciprocal product of formation volume factor and
+    // viscosity (1/(B*mu)) with respect to vaporised oil-gas ratio.
+    this->recipFvfViscDerivVapOil =
+        apply(Cvrt::recipFvfViscDerivVapOil(usys));
+
+    // Reciprocal formation volume factor for gas (1/Bg)
+    this->recipFvfGas = apply(Cvrt::recipFvfGas(usys));
+
+    // Derivative of reciprocal formation volume factor for gas (1/Bg) with
+    // respect to fluid (phase) pressure.
+    this->recipFvfGasDerivPress =
+        apply(Cvrt::recipFvfGasDerivPress(usys));
+
+    // Derivative of reciprocal formation volume factor for gas (1/Bg) with
+    // respect to vaporised oil-gas ratio.
+    this->recipFvfGasDerivVapOil =
+        apply(Cvrt::recipFvfGasDerivVapOil(usys));
+
+    // Reciprocal product of formation volume factor for gas and viscosity
+    // (1/(Bg*mu_g)).
+    this->recipFvfGasVisc = apply(Cvrt::recipFvfGasVisc(usys));
+
+    // Derivative of reciprocal product of formation volume factor for gas
+    // and viscosity (1/(Bg*mu_g)) with respect to fluid (phase) pressure.
+    this->recipFvfGasViscDerivPress =
+        apply(Cvrt::recipFvfGasViscDerivPress(usys));
+
+    // Derivative of reciprocal product of formation volume factor for gas
+    // and viscosity (1/(Bg*mu_g)) with respect to vaporised oil-gas ratio.
+    this->recipFvfGasViscDerivVapOil =
+        apply(Cvrt::recipFvfGasViscDerivVapOil(usys));
+}
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (Basic_Conversion)
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto usys = ::Opm::ECLUnits::createUnitSystem(1);
+
+    const auto scale = ConvertToSI(*usys);
+
+    // Pressure
+    BOOST_CHECK_CLOSE(scale.press, 1.0e5, 1.0e-10);
+
+    // Dissolved Gas-Oil Ratio (Rs)
+    BOOST_CHECK_CLOSE(scale.disgas, 1.0, 1.0e-10);
+
+    // Vaporised Oil-Gas Ratio (Rv)
+    BOOST_CHECK_CLOSE(scale.vapoil, 1.0, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor (1 / B)
+    BOOST_CHECK_CLOSE(scale.recipFvf, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivPress, 1.0e-5, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivVapOil, 1.0, 1.0e-10);
+
+    // Reciprocal Product of FVF and Viscosity (1 / (B*mu)).
+    BOOST_CHECK_CLOSE(scale.recipFvfVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivPress, 1.0e-2, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivVapOil, 1.0e3, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor for Gas (1 / Bg)
+    BOOST_CHECK_CLOSE(scale.recipFvfGas, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivPress, 1.0e-5, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg ) w.r.t. Vaporised
+    // Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivVapOil, 1.0, 1.0e-10);
+
+    // Reciprocal Product of FVF for Gas and Viscosity (1 / (Bg*mu_g)).
+    BOOST_CHECK_CLOSE(scale.recipFvfGasVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivPress, 1.0e-2, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivVapOil, 1.0e3, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto usys = ::Opm::ECLUnits::createUnitSystem(2);
+
+    const auto scale = ConvertToSI(*usys);
+
+    // Pressure
+    BOOST_CHECK_CLOSE(scale.press, 6.894757293168360e+03, 1.0e-10);
+
+    // Dissolved Gas-Oil Ratio (Rs)
+    BOOST_CHECK_CLOSE(scale.disgas, 1.781076066790352e+02, 1.0e-10);
+
+    // Vaporised Oil-Gas Ratio (Rv)
+    BOOST_CHECK_CLOSE(scale.vapoil, 5.614583333333335e-03, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor (1 / B)
+    BOOST_CHECK_CLOSE(scale.recipFvf, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivPress,
+                      1.450377377302092e-04, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivVapOil,
+                      1.781076066790352e+02, 1.0e-10);
+
+    // Reciprocal Product of FVF and Viscosity (1 / (B*mu)).
+    BOOST_CHECK_CLOSE(scale.recipFvfVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivPress,
+                      1.450377377302093e-01, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivVapOil,
+                      1.781076066790352e+05, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor for Gas (1 / Bg)
+    BOOST_CHECK_CLOSE(scale.recipFvfGas,
+                      1.781076066790352e+02, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivPress,
+                      2.583232434526917e-02, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg ) w.r.t. Vaporised
+    // Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivVapOil,
+                      3.172231955693390e+04, 1.0e-10);
+
+    // Reciprocal Product of FVF for Gas and Viscosity (1 / (Bg*mu_g)).
+    BOOST_CHECK_CLOSE(scale.recipFvfGasVisc,
+                      1.781076066790352e+05, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivPress,
+                      2.583232434526917e+01, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivVapOil,
+                      3.172231955693390e+07, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto usys = ::Opm::ECLUnits::createUnitSystem(3);
+
+    const auto scale = ConvertToSI(*usys);
+
+    // Pressure
+    BOOST_CHECK_CLOSE(scale.press, 101.325e3, 1.0e-10);
+
+    // Dissolved Gas-Oil Ratio (Rs)
+    BOOST_CHECK_CLOSE(scale.disgas, 1.0, 1.0e-10);
+
+    // Vaporised Oil-Gas Ratio (Rv)
+    BOOST_CHECK_CLOSE(scale.vapoil, 1.0, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor (1 / B)
+    BOOST_CHECK_CLOSE(scale.recipFvf, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivPress,
+                      9.869232667160129e-06, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivVapOil,
+                      1.0, 1.0e-10);
+
+    // Reciprocal Product of FVF and Viscosity (1 / (B*mu)).
+    BOOST_CHECK_CLOSE(scale.recipFvfVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivPress,
+                      9.869232667160128e-03, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivVapOil,
+                      1.0e3, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor for Gas (1 / Bg)
+    BOOST_CHECK_CLOSE(scale.recipFvfGas, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivPress,
+                      9.869232667160129e-06, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg) w.r.t. Vaporised
+    // Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivVapOil, 1.0, 1.0e-10);
+
+    // Reciprocal Product of FVF for Gas and Viscosity (1 / (Bg*mu_g)).
+    BOOST_CHECK_CLOSE(scale.recipFvfGasVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivPress,
+                      9.869232667160128e-03, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivVapOil, 1.0e3, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto usys = ::Opm::ECLUnits::createUnitSystem(4);
+
+    const auto scale = ConvertToSI(*usys);
+
+    // Pressure
+    BOOST_CHECK_CLOSE(scale.press, 101.325e3, 1.0e-10);
+
+    // Dissolved Gas-Oil Ratio (Rs)
+    BOOST_CHECK_CLOSE(scale.disgas, 1.0, 1.0e-10);
+
+    // Vaporised Oil-Gas Ratio (Rv)
+    BOOST_CHECK_CLOSE(scale.vapoil, 1.0, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor (1 / B)
+    BOOST_CHECK_CLOSE(scale.recipFvf, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivPress,
+                      9.869232667160129e-06, 1.0e-10);
+
+    // Derivative of Reciprocal FVF (1 / B) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfDerivVapOil, 1.0, 1.0e-10);
+
+    // Reciprocal Product of FVF and Viscosity (1 / (B*mu)).
+    BOOST_CHECK_CLOSE(scale.recipFvfVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivPress,
+                      9.869232667160128e-03, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF and Viscosity (1 / (B*mu))
+    // w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfViscDerivVapOil, 1.0e3, 1.0e-10);
+
+    // Reciprocal Formation Volume Factor for Gas (1 / Bg)
+    BOOST_CHECK_CLOSE(scale.recipFvfGas, 1.0, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivPress,
+                      9.869232667160129e-06, 1.0e-10);
+
+    // Derivative of Reciprocal FVF for Gas (1 / Bg ) w.r.t. Vaporised
+    // Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasDerivVapOil, 1.0, 1.0e-10);
+
+    // Reciprocal Product of FVF for Gas and Viscosity (1 / (Bg*mu_g)).
+    BOOST_CHECK_CLOSE(scale.recipFvfGasVisc, 1.0e3, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Pressure
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivPress,
+                      9.869232667160128e-03, 1.0e-10);
+
+    // Derivative of Reciprocal Product of FVF for Gas and Viscosity (1 /
+    // (Bg*mu_g)) w.r.t. Vaporised Oil-Gas Ratio.
+    BOOST_CHECK_CLOSE(scale.recipFvfGasViscDerivVapOil, 1.0e3, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclpvtcommon.cpp
+++ b/tests/test_eclpvtcommon.cpp
@@ -46,6 +46,7 @@ struct ConvertToSI
     explicit ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys);
 
     double press  { 0.0 };
+    double compr  { 0.0 };
     double disgas { 0.0 };
     double vapoil { 0.0 };
 
@@ -77,6 +78,9 @@ ConvertToSI::ConvertToSI(const ::Opm::ECLUnits::UnitSystem& usys)
 
     // Pressure
     this->press = apply(Cvrt::pressure(usys));
+
+    // Compressibility
+    this->compr = apply(Cvrt::compressibility(usys));
 
     // Dissolved gas-oil ratio (Rs)
     this->disgas = apply(Cvrt::disGas(usys));
@@ -152,6 +156,9 @@ BOOST_AUTO_TEST_CASE (Metric)
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 1.0e5, 1.0e-10);
 
+    // Compressibility
+    BOOST_CHECK_CLOSE(scale.compr, 1.0e-5, 1.0e-10);
+
     // Dissolved Gas-Oil Ratio (Rs)
     BOOST_CHECK_CLOSE(scale.disgas, 1.0, 1.0e-10);
 
@@ -208,6 +215,9 @@ BOOST_AUTO_TEST_CASE (Field)
 
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 6.894757293168360e+03, 1.0e-10);
+
+    // Compressibility
+    BOOST_CHECK_CLOSE(scale.compr, 1.450377377302092e-04, 1.0e-10);
 
     // Dissolved Gas-Oil Ratio (Rs)
     BOOST_CHECK_CLOSE(scale.disgas, 1.781076066790352e+02, 1.0e-10);
@@ -276,6 +286,9 @@ BOOST_AUTO_TEST_CASE (Lab)
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 101.325e3, 1.0e-10);
 
+    // Compressibility
+    BOOST_CHECK_CLOSE(scale.compr, 9.869232667160129e-06, 1.0e-10);
+
     // Dissolved Gas-Oil Ratio (Rs)
     BOOST_CHECK_CLOSE(scale.disgas, 1.0, 1.0e-10);
 
@@ -338,6 +351,9 @@ BOOST_AUTO_TEST_CASE (PVT_M)
 
     // Pressure
     BOOST_CHECK_CLOSE(scale.press, 101.325e3, 1.0e-10);
+
+    // Compressibility
+    BOOST_CHECK_CLOSE(scale.compr, 9.869232667160129e-06, 1.0e-10);
 
     // Dissolved Gas-Oil Ratio (Rs)
     BOOST_CHECK_CLOSE(scale.disgas, 1.0, 1.0e-10);

--- a/tests/test_eclsimple1dinterpolant.cpp
+++ b/tests/test_eclsimple1dinterpolant.cpp
@@ -1,0 +1,1309 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ECL1DINTERPOLATION
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/utility/ECLPiecewiseLinearInterpolant.hpp>
+#include <opm/utility/ECLTableInterpolation1D.hpp>
+
+#include <exception>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace PP = ::Opm::Interp1D::PiecewisePolynomial;
+
+namespace {
+    template <class Collection1, class Collection2>
+    void check_is_close(const Collection1& c1, const Collection2& c2)
+    {
+        BOOST_REQUIRE_EQUAL(c1.size(), c2.size());
+
+        if (! c1.empty()) {
+            auto i1 = c1.begin(), e1 = c1.end();
+            auto i2 = c2.begin();
+
+            for (; i1 != e1; ++i1, ++i2) {
+                BOOST_CHECK_CLOSE(*i1, *i2, 1.0e-10);
+            }
+        }
+    }
+
+    std::vector<double>
+    makeTable(const std::size_t             ncol,
+              std::initializer_list<double> data)
+    {
+        auto result = std::vector<double>(data.size(), 0.0);
+        const auto nrows = data.size() / ncol;
+
+        auto di = std::begin(data);
+        for (auto i = 0*nrows; i < nrows; ++i) {
+            for (auto j = 0*ncol; j < ncol; ++j, ++di) {
+                result[i + j*nrows] = *di;
+            }
+        }
+
+        return result;
+    }
+
+    std::vector<double> spe1_swof()
+    {
+        return makeTable(4, {
+                0.12,    0,                       1,       0,     //  0
+                0.18,    4.64876033057851E-008,   1,       0,     //  1
+                0.24,    0.000000186,             0.997,   0,     //  2
+                0.3 ,    4.18388429752066E-007,   0.98,    0,     //  3
+                0.36,    7.43801652892562E-007,   0.7,     0,     //  4
+                0.42,    1.16219008264463E-006,   0.35,    0,     //  5
+                0.48,    1.67355371900826E-006,   0.2,     0,     //  6
+                0.54,    2.27789256198347E-006,   0.09,    0,     //  7
+                0.6 ,    2.97520661157025E-006,   0.021,   0,     //  8
+                0.66,    3.7654958677686E-006,    0.01,    0,     //  9
+                0.72,    4.64876033057851E-006,   0.001,   0,     // 10
+                0.78,    0.000005625,             0.0001,  0,     // 11
+                0.84,    6.69421487603306E-006,   0,       0,     // 12
+                0.91,    8.05914256198347E-006,   0,       0,     // 13
+                1   ,    0.00001,                 0,       0, }); // 14
+    }
+
+    std::vector<double> spe1_pvdg_incl_der()
+    {
+        return makeTable(5, {
+                // Pg                     1/Bg                      1/(Bg*vg)                 d[1/Bg]/dp                d[1/(Bg*vg)]/dp
+                1.470000000000000e+01,    6.000024000096000e-03,    7.500030000120000e-01,    0,                        0,                     // 0
+                2.647000000000000e+02,    8.269246671628200e-02,    8.613798616279400e+00,    3.067697708647400e-04,    3.145518246507000e-02, // 1
+                5.147000000000000e+02,    1.593879502709600e-01,    1.423106698847900e+01,    3.067819342187100e-04,    2.246907348879700e-02, // 2
+                1.014700000000000e+03,    3.127932436659400e-01,    2.234237454756700e+01,    3.068105867899500e-04,    1.622261511817700e-02, // 3
+                2.014700000000000e+03,    6.195786864931800e-01,    3.278194108429500e+01,    3.067854428272500e-04,    1.043956653672900e-02, // 4
+                2.514700000000000e+03,    7.727975270479100e-01,    3.715372726191900e+01,    3.064376811094600e-04,    8.743572355246899e-03, // 5
+                3.014700000000000e+03,    9.259259259259300e-01,    4.061078622482100e+01,    3.062567977560200e-04,    6.914117925804800e-03, // 6
+                4.014700000000000e+03,    1.233045622688000e+00,    4.600916502567300e+01,    3.071196967621100e-04,    5.398378800851800e-03, // 7
+                5.014700000000000e+03,    1.540832049306600e+00,    4.986511486429200e+01,    3.077864266185900e-04,    3.855949838619000e-03, // 8
+                9.014700000000001e+03,    2.590673575129500e+00,    5.512071436445800e+01,    2.624603814557300e-04,    1.313899875041500e-03, // 9
+                    });
+    }
+
+    std::vector<double> pvtg_subtable_zero_der()
+    {
+        return makeTable(5, {
+                // Rv     1/Bg                   1/(Bg*vg               d[1/Bg]/dRv  d[1/(Bg*vg)]/dRv
+                4.97e-06, 4.006731308598445e+01, 2.780521380012800e+03, 0,           0,                     // 0
+                2.48e-06, 4.006731308598445e+01, 2.782452297637809e+03, 0,          -7.754689257064208e+05, // 1
+                0       , 4.006731308598445e+01, 2.782452297637809e+03, 0,           0,                     // 2
+                    });
+    }
+
+    std::vector<double> pvtg_subtable_incl_der()
+    {
+        return makeTable(5, {
+                // Rv        1/Bg                      1/(Bg*vg)                 d[1/Bg]/dRv               d[1/(Bg*vg)]/dRv
+                5.21e-06,    5.669255626736210e+01,    3.802317657100074e+03,    8.312621590688825e-01,    5.108981385436368e+01, // 0
+                2.61e-06,    5.668612890425712e+01,    3.804438181493767e+03,    2.472062732683009e+03,   -8.155863052665014e+05, // 1
+                0       ,    5.667970299835629e+01,    3.804006912641362e+03,    2.462032912196776e+03,    1.652371082011811e+05, // 2
+                    });
+    }
+
+    std::function<double(const double)>
+    createDummyTransform()
+    {
+        return { [](const double x) { return x; } };
+    }
+
+    std::vector<std::function<double(const double)>>
+    createDummyTransform(const std::size_t ncol)
+    {
+        return std::vector<std::function<double(const double)>>
+            (ncol, createDummyTransform());
+    }
+} // Namespace Anonymous
+
+// =====================================================================
+// Point Binning
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (PointLocationBinning)
+
+BOOST_AUTO_TEST_CASE (NonExistentRange)
+{
+    const auto xi = std::vector<double>{};
+
+    BOOST_CHECK_THROW(PP::LocalInterpPoint::identify(xi, 0.0),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (SingleAbscissa)
+{
+    const auto abscissas = std::vector<double>{ 0.0 };
+
+    // Left of range's left (only) end-point.
+    {
+        const auto x = -1.0;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        // Left of range's interval is always 0 (multiplied by .size() to
+        // enforce correct integer type in '==' check within Boost.Test).
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - xmin.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.front(), 1.0e-10);
+    }
+
+    // Right of range's right (only) end-point.
+    {
+        const auto x = 1.0;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        // Right of range's interval is always one less than the number of
+        // abscissas.
+        BOOST_CHECK_EQUAL(pt.interval, abscissas.size() - 1);
+
+        // t = x - xmax.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.back(), 1.0e-10);
+    }
+
+    // Single abscissa point.
+    {
+        const auto x = abscissas[0];
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        // We should identify this as being in range.
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+        // Interval should correspond to left (only) end-point.
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - abscissas[interval] (== 0.0).
+        BOOST_CHECK_CLOSE(pt.t, 0.0, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SingleInterval)
+{
+    const auto abscissas = std::vector<double>{ 0.0, 1.0 };
+
+    // Left of range's left end-point.
+    {
+        const auto x = -1.0;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        // Left of range's interval is always 0 (multiplied by .size() to
+        // enforce correct integer type in '==' check within Boost.Test).
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - xmin.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.front(), 1.0e-10);
+    }
+
+    // Right of range's right end-point.
+    {
+        const auto x = 2.0;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        // Right of range's interval is always one less than the number of
+        // abscissas.
+        BOOST_CHECK_EQUAL(pt.interval, abscissas.size() - 1);
+
+        // t = x - xmax.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.back(), 1.0e-10);
+    }
+
+    // Single abscissa point (left end point).
+    {
+        const auto x = abscissas[0];
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        // We should identify this as being in range.
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+        // Interval should correspond to left (only) end-point.
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - abscissas[interval] (== 0.0).
+        BOOST_CHECK_CLOSE(pt.t, 0.0, 1.0e-10);
+    }
+
+    // Single abscissa point (right end point).
+    {
+        const auto x = abscissas[1];
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        // We should identify this as being in range.
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+        // Interval should correspond to left end-point.
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - abscissas[interval] (== 1.0).
+        BOOST_CHECK_CLOSE(pt.t, 1.0, 1.0e-10);
+    }
+
+    // Common case: Points within range
+    {
+        const auto x = std::vector<double> {
+            0.1, 0.2, 0.4, 0.5, 0.75, 0.8,
+            1.0 - std::numeric_limits<double>::epsilon(),
+        };
+
+        for (const auto& xi : x) {
+            const auto pt =
+                PP::LocalInterpPoint::identify(abscissas, xi);
+
+            // We should identify this as being in range.
+            BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+            // Interval should correspond to left end-point.
+            BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+            // t = x - abscissas[interval] (== xi).
+            BOOST_CHECK_CLOSE(pt.t, xi, 1.0e-10);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (MultipleIntervals)
+{
+    const auto abscissas = []() -> std::vector<double>
+    {
+        auto       pvdg = spe1_pvdg_incl_der();
+        const auto nrow = pvdg.size() / 5;
+
+        return {
+            std::make_move_iterator(std::begin(pvdg)),
+            std::make_move_iterator(std::begin(pvdg) + nrow)
+        };
+    }();
+
+    // Left of range's left end-point.
+    {
+        const auto x = 10.0;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        // Left of range's interval is always 0 (multiplied by .size() to
+        // enforce correct integer type in '==' check within Boost.Test).
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - xmin (== -4.7).
+        BOOST_CHECK_CLOSE(pt.t, -4.7, 1.0e-10);
+    }
+
+    // Right of range's right end-point.
+    {
+        const auto x = 10.0147e3;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        // Right of range's interval is always one less than the number of
+        // abscissas.
+        BOOST_CHECK_EQUAL(pt.interval, abscissas.size() - 1);
+
+        // t = x - xmax (== 1000).
+        BOOST_CHECK_CLOSE(pt.t, 1.0e3, 1.0e-10);
+    }
+
+    // Check that every abscissa is classified as being in range and that it
+    // is associated to the point to the left of itself, except for the
+    // first.  The first abscissa must be associated with itself.
+    //
+    // Note: This behaviour is an "emergent" property of the implementation
+    // of LocalInterpPoint::identify().
+    {
+        const auto n = abscissas.size();
+        auto i = 0*n;
+
+        for (const auto& xi : abscissas) {
+            const auto pt =
+                PP::LocalInterpPoint::identify(abscissas, xi);
+
+            const auto interval_expect = (i == 0) ? i : (i - 1);
+
+            BOOST_CHECK_EQUAL(pt.interval, interval_expect);
+
+            BOOST_CHECK_CLOSE(pt.t, xi - abscissas[interval_expect], 1.0e-10);
+
+            i += 1;
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Piecewise Linear 1D Interpolation
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (PiecewiseLinear)
+
+BOOST_AUTO_TEST_CASE (SWOF)
+{
+    const auto swof = spe1_swof();
+
+    const auto nRows = swof.size() / 4;
+    auto xBegin = std::begin(swof);
+    auto xEnd   = xBegin + nRows;
+
+    auto colIt = std::vector<decltype(xBegin)>{ xEnd };
+    for (auto j = 1; j < 3; ++j) {
+        colIt.push_back(colIt.back() + nRows);
+    }
+
+    using Extrap = PP::ExtrapolationPolicy::Constant;
+    auto interp  = PP::Linear<Extrap>
+        { Extrap{}, xBegin, xEnd, colIt,
+          createDummyTransform(),
+          createDummyTransform(colIt.size()) };
+
+    // Extrapolation to the left of the interval.
+    {
+        const auto pt = interp.classifyPoint(0.0);
+
+        const auto krw  = interp.evaluate(0, pt);
+        const auto krow = interp.evaluate(1, pt);
+        const auto pcow = interp.evaluate(2, pt);
+
+        BOOST_CHECK_CLOSE(krw , 0.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(krow, 1.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(pcow, 0.0, 1.0e-10);
+    }
+
+    // Extrapolation to the right of the interval.
+    {
+        const auto pt = interp.classifyPoint(1.1);
+
+        const auto krw  = interp.evaluate(0, pt);
+        const auto krow = interp.evaluate(1, pt);
+        const auto pcow = interp.evaluate(2, pt);
+
+        BOOST_CHECK_CLOSE(krw , 1.0e-5, 1.0e-10);
+        BOOST_CHECK_CLOSE(krow, 0.0   , 1.0e-10);
+        BOOST_CHECK_CLOSE(pcow, 0.0   , 1.0e-10);
+    }
+
+    // First sub-interval (Sw \in [0.12, 0.18)).
+    {
+        const auto sw = std::vector<double> {
+            0.12, 0.13, 0.14, 0.15, 0.16, 0.17 };
+
+        //             (swof(1,1) - swof(0,1))
+        // swof(0,0) + ----------------------- * (sw - swof(0,0))
+        //             (swof(1,0) - swof(0,0))
+        const auto krw_expect = std::vector<double> {
+            0,
+            7.747933884297524e-09,
+            1.549586776859505e-08,
+            2.324380165289255e-08,
+            3.099173553719008e-08,
+            3.873966942148760e-08,
+        };
+
+        const auto krow_expect = std::vector<double> {
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        };
+
+        const auto pcow_expect = std::vector<double> {
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        };
+
+        auto krw  = std::vector<double>{}; krw .reserve(sw.size());
+        auto krow = std::vector<double>{}; krow.reserve(sw.size());
+        auto pcow = std::vector<double>{}; pcow.reserve(sw.size());
+
+        for (const auto& swi : sw) {
+            const auto pt = interp.classifyPoint(swi);
+
+            krw .push_back(interp.evaluate(0, pt));
+            krow.push_back(interp.evaluate(1, pt));
+            pcow.push_back(interp.evaluate(2, pt));
+        }
+
+        check_is_close(krw , krw_expect );
+        check_is_close(krow, krow_expect);
+        check_is_close(pcow, pcow_expect);
+    }
+
+    // Second sub-interval (Sw \in [0.18, 0.24)).
+    {
+        const auto sw = std::vector<double> {
+            0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24,
+        };
+
+        //             (swof(2,1) - swof(1,1))
+        // swof(1,0) + ----------------------- * (sw - swof(1,0))
+        //             (swof(2,0) - swof(1,0))
+        const auto krw_expect = std::vector<double> {
+            4.648760330578510e-08,
+            6.973966942148761e-08,
+            9.299173553719010e-08,
+            1.162438016528925e-07,
+            1.394958677685950e-07,
+            1.627479338842975e-07,
+            1.860000000000000e-07,
+        };
+
+        const auto krow_expect = std::vector<double> {
+            1.000000000000000e+00,
+            9.994999999999999e-01,
+            9.990000000000000e-01,
+            9.984999999999999e-01,
+            9.980000000000000e-01,
+            9.974999999999999e-01,
+            9.970000000000000e-01,
+        };
+
+        const auto pcow_expect = std::vector<double> {
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        };
+
+        auto krw  = std::vector<double>{}; krw .reserve(sw.size());
+        auto krow = std::vector<double>{}; krow.reserve(sw.size());
+        auto pcow = std::vector<double>{}; pcow.reserve(sw.size());
+
+        for (const auto& swi : sw) {
+            const auto pt = interp.classifyPoint(swi);
+
+            krw .push_back(interp.evaluate(0, pt));
+            krow.push_back(interp.evaluate(1, pt));
+            pcow.push_back(interp.evaluate(2, pt));
+        }
+
+        check_is_close(krw , krw_expect );
+        check_is_close(krow, krow_expect);
+        check_is_close(pcow, pcow_expect);
+    }
+
+    // Fifth sub-interval (Sw \in [0.36, 0.42)).
+    {
+        const auto sw = std::vector<double> {
+            0.36, 0.37, 0.38, 0.39, 0.40, 0.41, 0.42, 0.39, 0.365,
+        };
+
+        //             (swof(5,1) - swof(4,1))
+        // swof(4,0) + ----------------------- * (sw - swof(4,0))
+        //             (swof(5,0) - swof(4,0))
+        const auto krw_expect = std::vector<double> {
+            7.438016528925620e-07,
+            8.135330578512400e-07,
+            8.832644628099181e-07,
+            9.529958677685962e-07,
+            1.022727272727274e-06,
+            1.092458677685952e-06,
+            1.162190082644630e-06,
+            9.529958677685962e-07,
+            7.786673553719010e-07,
+        };
+
+        const auto krow_expect = std::vector<double> {
+            7.000000000000000e-01,
+            6.416666666666666e-01,
+            5.833333333333331e-01,
+            5.249999999999998e-01,
+            4.666666666666665e-01,
+            4.083333333333334e-01,
+            3.500000000000000e-01,
+            5.249999999999998e-01,
+            6.708333333333333e-01,
+        };
+
+        const auto pcow_expect = std::vector<double>(sw.size(), 0.0);
+
+        auto krw  = std::vector<double>{}; krw .reserve(sw.size());
+        auto krow = std::vector<double>{}; krow.reserve(sw.size());
+        auto pcow = std::vector<double>{}; pcow.reserve(sw.size());
+
+        for (const auto& swi : sw) {
+            const auto pt = interp.classifyPoint(swi);
+
+            krw .push_back(interp.evaluate(0, pt));
+            krow.push_back(interp.evaluate(1, pt));
+            pcow.push_back(interp.evaluate(2, pt));
+        }
+
+        check_is_close(krw , krw_expect );
+        check_is_close(krow, krow_expect);
+        check_is_close(pcow, pcow_expect);
+    }
+
+    // Eleventh sub-interval (Sw \in [0.72, 0.78)).
+    {
+        const auto sw = std::vector<double> {
+            0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.725,
+        };
+
+        //              (swof(11,1) - swof(10,1))
+        // swof(10,0) + ------------------------- * (sw - swof(10,0))
+        //              (swof(11,0) - swof(10,0))
+        const auto krw_expect = std::vector<double> {
+            4.648760330578510e-06,
+            4.811466942148759e-06,
+            4.974173553719007e-06,
+            5.136880165289256e-06,
+            5.299586776859503e-06,
+            5.462293388429752e-06,
+            5.625000000000000e-06,
+            4.730113636363634e-06,
+        };
+
+        const auto krow_expect = std::vector<double> {
+            1.000000000000000e-03,
+            8.500000000000001e-04,
+            7.000000000000001e-04,
+            5.500000000000000e-04,
+            4.000000000000001e-04,
+            2.500000000000001e-04,
+            1.000000000000000e-04,
+            9.250000000000000e-04,
+        };
+
+        const auto pcow_expect = std::vector<double>(sw.size(), 0.0);
+
+        auto krw  = std::vector<double>{}; krw .reserve(sw.size());
+        auto krow = std::vector<double>{}; krow.reserve(sw.size());
+        auto pcow = std::vector<double>{}; pcow.reserve(sw.size());
+
+        for (const auto& swi : sw) {
+            const auto pt = interp.classifyPoint(swi);
+
+            krw .push_back(interp.evaluate(0, pt));
+            krow.push_back(interp.evaluate(1, pt));
+            pcow.push_back(interp.evaluate(2, pt));
+        }
+
+        check_is_close(krw , krw_expect );
+        check_is_close(krow, krow_expect);
+        check_is_close(pcow, pcow_expect);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVDG)
+{
+    const auto pvdg = spe1_pvdg_incl_der();
+
+    const auto nRows = pvdg.size() / 5;
+    auto xBegin = std::begin(pvdg);
+    auto xEnd   = xBegin + nRows;
+
+    auto colIt = std::vector<decltype(xBegin)>{ xEnd };
+    for (auto j = 1; j < 4; ++j) {
+        colIt.push_back(colIt.back() + nRows);
+    }
+
+    const auto nResCol = std::size_t{2}; // 1/B, 1/(B*v)
+    using Extrap = PP::ExtrapolationPolicy::LinearlyWithDerivatives;
+    auto interp  = PP::Linear<Extrap>
+        { Extrap{nResCol}, xBegin, xEnd, colIt,
+          createDummyTransform(),
+          createDummyTransform(colIt.size()) };
+
+    // Extrapolation to the left (d/dp = 0, from table).
+    {
+        const auto pt = interp.classifyPoint(10.0);
+
+        const auto bg       = interp.evaluate(0, pt);
+        const auto bg_by_vg = interp.evaluate(1, pt);
+
+        BOOST_CHECK_CLOSE(bg, 6.000024000096000e-03, 1.0e-10);
+        BOOST_CHECK_CLOSE(bg_by_vg, 7.500030000120000e-01, 1.0e-10);
+    }
+
+    // Extrapolation to the right (d/dp > 0, from table).
+    {
+        const auto pt = interp.classifyPoint(10.0147e+3);
+
+        const auto bg       = interp.evaluate(0, pt);
+        const auto bg_by_vg = interp.evaluate(1, pt);
+
+        BOOST_CHECK_CLOSE(bg, 2.853133956585230e+00, 1.0e-10);
+        BOOST_CHECK_CLOSE(bg_by_vg, 5.643461423949950e+01, 1.0e-10);
+    }
+
+    // First interval.  Pg \in [14.7, 264.7).
+    {
+        const auto Pg = std::vector<double> {
+            14.7, 64.7, 114.7, 164.7, 214.7, 264.7 };
+
+        const auto bg_expect = std::vector<double> {
+            6.000024000096000e-03,
+            2.133851254333320e-02,
+            3.667700108657040e-02,
+            5.201548962980759e-02,
+            6.735397817304480e-02,
+            8.269246671628200e-02,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            7.500030000120000e-01,
+            2.322762123265480e+00,
+            3.895521246518960e+00,
+            5.468280369772439e+00,
+            7.041039493025919e+00,
+            8.613798616279400e+00,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Pg.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Pg.size());
+
+        for (const auto& pgi : Pg) {
+            const auto pt = interp.classifyPoint(pgi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+
+    // Second interval.  Pg \in [264.7, 514.7).
+    {
+
+        const auto Pg = std::vector<double> {
+            264.7, 314.7, 364.7, 414.7, 464.7, 514.7 };
+
+        const auto bg_expect = std::vector<double> {
+            8.269246671628200e-02,
+            9.803156342721760e-02,
+            1.133706601381532e-01,
+            1.287097568490888e-01,
+            1.440488535600244e-01,
+            1.593879502709600e-01,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            8.613798616279400e+00,
+            9.737252290719320e+00,
+            1.086070596515924e+01,
+            1.198415963959916e+01,
+            1.310761331403908e+01,
+            1.423106698847900e+01,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Pg.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Pg.size());
+
+        for (const auto& pgi : Pg) {
+            const auto pt = interp.classifyPoint(pgi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+
+    // Last interval.  Pg \in [5014.7, 9014.7).
+    {
+
+        const auto Pg = std::vector<double> {
+            5014.7, 5514.7, 6014.7, 6514.7, 7014.7, 7514.7, 8014.7, 8514.7, 9014.7 };
+
+        const auto bg_expect = std::vector<double> {
+            1.540832049306600e+00,
+            1.672062240034462e+00,
+            1.803292430762325e+00,
+            1.934522621490187e+00,
+            2.065752812218050e+00,
+            2.196983002945912e+00,
+            2.328213193673775e+00,
+            2.459443384401637e+00,
+            2.590673575129500e+00,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            4.986511486429200e+01,
+            5.052206480181275e+01,
+            5.117901473933350e+01,
+            5.183596467685425e+01,
+            5.249291461437500e+01,
+            5.314986455189575e+01,
+            5.380681448941650e+01,
+            5.446376442693725e+01,
+            5.512071436445800e+01,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Pg.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Pg.size());
+
+        for (const auto& pgi : Pg) {
+            const auto pt = interp.classifyPoint(pgi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Descendingly Sorted Input Ranges (B and mu a.f.o. decreasing Rv)
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (PointLocationBinning_Descending)
+
+BOOST_AUTO_TEST_CASE (NonExistentRange)
+{
+    const auto xi = std::vector<double>{};
+
+    const auto is_ascending = std::false_type{};
+
+    BOOST_CHECK_THROW(PP::LocalInterpPoint::identify(xi, 0.0, is_ascending),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (SingleAbscissa)
+{
+    const auto abscissas = std::vector<double>{ 0.0 };
+
+    auto identify = [&abscissas](const double x)
+    {
+        return PP::LocalInterpPoint::
+            identify(abscissas, x, std::false_type{});
+    };
+
+    // Left of range's left (only) end-point.
+    {
+        const auto x  = 1.0;
+        const auto pt = identify(x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        // Left of range's interval is always 0 (multiplied by .size() to
+        // enforce correct integer type in '==' check within Boost.Test).
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - xmin.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.front(), 1.0e-10);
+    }
+
+    // Right of range's right (only) end-point.
+    {
+        const auto x  = -1.0;
+        const auto pt = identify(x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        // Right of range's interval is always one less than the number of
+        // abscissas.
+        BOOST_CHECK_EQUAL(pt.interval, abscissas.size() - 1);
+
+        // t = x - xmax.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.back(), 1.0e-10);
+    }
+
+    // Single abscissa point.
+    {
+        const auto x  = abscissas[0];
+        const auto pt = identify(x);
+
+        // We should identify this as being in range.
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+        // Interval should correspond to left (only) end-point.
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - abscissas[interval] (== 0.0).
+        BOOST_CHECK_CLOSE(pt.t, 0.0, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SingleInterval)
+{
+    const auto abscissas = std::vector<double>{ 1.0, 0.0 };
+
+    auto identify = [&abscissas](const double x)
+    {
+        return PP::LocalInterpPoint::
+            identify(abscissas, x, std::false_type{});
+    };
+
+    // Left of range's left end-point.
+    {
+        const auto x  = 2.0;
+        const auto pt = identify(x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        // Left of range's interval is always 0 (multiplied by .size() to
+        // enforce correct integer type in '==' check within Boost.Test).
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - xmin.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.front(), 1.0e-10);
+    }
+
+    // Right of range's right end-point.
+    {
+        const auto x  = -1.0;
+        const auto pt = identify(x);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        // Right of range's interval is always one less than the number of
+        // abscissas.
+        BOOST_CHECK_EQUAL(pt.interval, abscissas.size() - 1);
+
+        // t = x - xmax.
+        BOOST_CHECK_CLOSE(pt.t, x - abscissas.back(), 1.0e-10);
+    }
+
+    // Single abscissa point (left end point).
+    {
+        const auto x  = abscissas[0];
+        const auto pt = identify(x);
+
+        // We should identify this as being in range.
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+        // Interval should correspond to left (only) end-point.
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - abscissas[interval] (== 0.0).
+        BOOST_CHECK_CLOSE(pt.t, 0.0, 1.0e-10);
+    }
+
+    // Single abscissa point (right end point).
+    {
+        const auto x  = abscissas[1];
+        const auto pt = identify(x);
+
+        // We should identify this as being in range.
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+        // Interval should correspond to left end-point.
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - abscissas[interval] (== -1.0).
+        BOOST_CHECK_CLOSE(pt.t, -1.0, 1.0e-10);
+    }
+
+    // Common case: Points within range
+    {
+        const auto x = std::vector<double> {
+            0.1, 0.2, 0.4, 0.5, 0.75, 0.8,
+            1.0 - std::numeric_limits<double>::epsilon(),
+        };
+
+        for (const auto& xi : x) {
+            const auto pt = identify(xi);
+
+            // We should identify this as being in range.
+            BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::InRange);
+
+            // Interval should correspond to left end-point.
+            BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+            // t = x - abscissas[interval] (== xi - 1.0).
+            BOOST_CHECK_CLOSE(pt.t, xi - 1.0, 1.0e-10);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (MultipleIntervals)
+{
+    const auto abscissas = []() -> std::vector<double>
+    {
+        auto       pvtg = pvtg_subtable_zero_der();
+        const auto nrow = pvtg.size() / 5;
+
+        return {
+            std::make_move_iterator(std::begin(pvtg)),
+            std::make_move_iterator(std::begin(pvtg) + nrow)
+        };
+    }();
+
+    const auto is_descending = std::false_type{};
+
+    // Left of range's left end-point.
+    {
+        const auto x = 1.0;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x, is_descending);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        // Left of range's interval is always 0 (multiplied by .size() to
+        // enforce correct integer type in '==' check within Boost.Test).
+        BOOST_CHECK_EQUAL(pt.interval, 0*abscissas.size());
+
+        // t = x - xmin (== 9.999950300000000e-01).
+        BOOST_CHECK_CLOSE(pt.t, 9.999950300000000e-01, 1.0e-10);
+    }
+
+    // Right of range's right end-point.
+    {
+        const auto x = -0.5;
+
+        const auto pt =
+            PP::LocalInterpPoint::identify(abscissas, x, is_descending);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        // Right of range's interval is always one less than the number of
+        // abscissas.
+        BOOST_CHECK_EQUAL(pt.interval, abscissas.size() - 1);
+
+        // t = x - xmax (== -0.5).
+        BOOST_CHECK_CLOSE(pt.t, -0.5, 1.0e-10);
+    }
+
+    // Check that every abscissa is classified as being in range and that it
+    // is associated to the point to the left of itself, except for the
+    // first.  The first abscissa must be associated with itself.
+    //
+    // Note: This behaviour is an "emergent" property of the implementation
+    // of LocalInterpPoint::identify().
+    {
+        const auto n = abscissas.size();
+        auto i = 0*n;
+
+        for (const auto& xi : abscissas) {
+            const auto pt =
+                PP::LocalInterpPoint::identify(abscissas, xi, is_descending);
+
+            const auto interval_expect = (i == 0) ? i : (i - 1);
+
+            BOOST_CHECK_EQUAL(pt.interval, interval_expect);
+
+            BOOST_CHECK_CLOSE(pt.t, xi - abscissas[interval_expect], 1.0e-10);
+
+            i += 1;
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Piecewise Linear 1D Interpolation in Descendingly Sorted Input Range
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (PicewiseLinar_Descending)
+
+BOOST_AUTO_TEST_CASE (PVTGSingleSubTable_ConstantExtrap)
+{
+    const auto pvtg = pvtg_subtable_zero_der();
+
+    const auto nRows = pvtg.size() / 5;
+    auto xBegin = std::begin(pvtg);
+    auto xEnd   = xBegin + nRows;
+
+    auto colIt = std::vector<decltype(xBegin)>{ xEnd };
+    for (auto j = 1; j < 4; ++j) {
+        colIt.push_back(colIt.back() + nRows);
+    }
+
+    const auto IsAscendingRange = false;
+    using Extrap = PP::ExtrapolationPolicy::Constant;
+    auto interp  = PP::Linear<Extrap, IsAscendingRange>
+        { Extrap{}, xBegin, xEnd, colIt,
+          createDummyTransform(),
+          createDummyTransform(colIt.size()) };
+
+    // Extrapolation to the left.
+    {
+        const auto pt = interp.classifyPoint(5.0e-6);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        const auto bg       = interp.evaluate(0, pt);
+        const auto bg_by_vg = interp.evaluate(1, pt);
+
+        BOOST_CHECK_CLOSE(bg, 4.006731308598445e+01, 1.0e-10);
+        BOOST_CHECK_CLOSE(bg_by_vg, 2.780521380012800e+03, 1.0e-10);
+    }
+
+    // Extrapolation to the right.
+    {
+        const auto pt = interp.classifyPoint(-1.0e-6);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        const auto bg       = interp.evaluate(0, pt);
+        const auto bg_by_vg = interp.evaluate(1, pt);
+
+        BOOST_CHECK_CLOSE(bg, 4.006731308598445e+01, 1.0e-10);
+        BOOST_CHECK_CLOSE(bg_by_vg, 2.782452297637809e+03, 1.0e-10);
+    }
+
+    // First interval.  Rv \in (2.48e-6, 4.97e-6].
+    {
+        const auto Rv = std::vector<double> {
+            4.97e-6, 4.47e-6, 3.97e-6, 3.47e-6, 2.97e-6, 2.48e-6 };
+
+        const auto bg_expect = std::vector<double> {
+            // Unchanging in interval...
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            2.780521380012800e+03,
+            2.780909114475653e+03,
+            2.781296848938506e+03,
+            2.781684583401360e+03,
+            2.782072317864213e+03,
+            2.782452297637809e+03,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Rv.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Rv.size());
+
+        for (const auto& Rvi : Rv) {
+            const auto pt = interp.classifyPoint(Rvi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+
+    // Second interval.  Rv \in (0, 2.48e-6].
+    {
+        const auto Rv = std::vector<double> {
+            2.48e-6, 2.0e-6, 1.5e-6, 1.0e-6, 0.75e-6, 0.5e-6, 0.25e-6, 0.0,
+        };
+
+        const auto bg_expect = std::vector<double> {
+            // Constant in interval
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+            4.006731308598445e+01,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            // Constant in range.
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+            2.782452297637809e+03,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Rv.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Rv.size());
+
+        for (const auto& Rvi : Rv) {
+            const auto pt = interp.classifyPoint(Rvi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVTSingleSubTable_ExtrapWithDerivatives)
+{
+    const auto pvtg = pvtg_subtable_incl_der();
+
+    const auto nRows = pvtg.size() / 5;
+    auto xBegin = std::begin(pvtg);
+    auto xEnd   = xBegin + nRows;
+
+    auto colIt = std::vector<decltype(xBegin)>{ xEnd };
+    for (auto j = 1; j < 4; ++j) {
+        colIt.push_back(colIt.back() + nRows);
+    }
+
+    const auto nResCol = std::size_t{2};
+    const auto IsAscendingRange = false;
+    using Extrap = PP::ExtrapolationPolicy::LinearlyWithDerivatives;
+    auto interp  = PP::Linear<Extrap, IsAscendingRange>
+        { Extrap{nResCol}, xBegin, xEnd, colIt,
+          createDummyTransform(),
+          createDummyTransform(colIt.size()) };
+
+    // Extrapolation to the left.
+    {
+        const auto pt = interp.classifyPoint(6.0e-6);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::LeftOfRange);
+
+        const auto bg       = interp.evaluate(0, pt);
+        const auto bg_by_vg = interp.evaluate(1, pt);
+
+        BOOST_CHECK_CLOSE(bg, 5.669255692405920e+01, 1.0e-10);
+        BOOST_CHECK_CLOSE(bg_by_vg, 3.802317697461027e+03, 1.0e-10);
+    }
+
+    // Extrapolation to the right.
+    {
+        const auto pt = interp.classifyPoint(-1.0e-6);
+
+        BOOST_CHECK(pt.cat == Opm::Interp1D::PointCategory::RightOfRange);
+
+        const auto bg       = interp.evaluate(0, pt);
+        const auto bg_by_vg = interp.evaluate(1, pt);
+
+        BOOST_CHECK_CLOSE(bg, 5.667724096544409e+01, 1.0e-10);
+        BOOST_CHECK_CLOSE(bg_by_vg, 3.803841675533160e+03, 1.0e-10);
+    }
+
+    // First interval.  Rv \in (2.61e-6, 5.21e-6].
+    {
+        const auto Rv = std::vector<double> {
+            5.21e-6, 4.81e-6, 4.41e-6, 4.01e-6, 3.61e-6, 3.21e-6, 2.81e-6, 2.61e-6, };
+
+        const auto bg_expect = std::vector<double> {
+            5.669255626736210e+01,
+            5.669156744226903e+01,
+            5.669057861717595e+01,
+            5.668958979208288e+01,
+            5.668860096698980e+01,
+            5.668761214189673e+01,
+            5.668662331680365e+01,
+            5.668612890425712e+01,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            3.802317657100074e+03,
+            3.802643891622180e+03,
+            3.802970126144287e+03,
+            3.803296360666394e+03,
+            3.803622595188500e+03,
+            3.803948829710607e+03,
+            3.804275064232714e+03,
+            3.804438181493767e+03,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Rv.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Rv.size());
+
+        for (const auto& Rvi : Rv) {
+            const auto pt = interp.classifyPoint(Rvi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+
+    // Second interval.  Rv \in (0, 2.61e-6].
+    {
+        const auto Rv = std::vector<double> {
+            2.61e-6, 2.2e-6, 1.8e-6, 1.4e-6, 1.0e-6, 0.6e-6, 0.4e-6, 0.2e-6, 0.0,
+        };
+
+        const auto bg_expect = std::vector<double> {
+            5.668612890425712e+01,
+            5.668511947076312e+01,
+            5.668413465759824e+01,
+            5.668314984443336e+01,
+            5.668216503126848e+01,
+            5.668118021810361e+01,
+            5.668068781152117e+01,
+            5.668019540493873e+01,
+            5.667970299835629e+01,
+        };
+
+        const auto bg_by_vg_expect = std::vector<double> {
+            3.804438181493767e+03,
+            3.804370434279404e+03,
+            3.804304339436124e+03,
+            3.804238244592843e+03,
+            3.804172149749563e+03,
+            3.804106054906283e+03,
+            3.804073007484642e+03,
+            3.804039960063002e+03,
+            3.804006912641362e+03,
+        };
+
+        auto bg       = std::vector<double>{}; bg      .reserve(Rv.size());
+        auto bg_by_vg = std::vector<double>{}; bg_by_vg.reserve(Rv.size());
+
+        for (const auto& Rvi : Rv) {
+            const auto pt = interp.classifyPoint(Rvi);
+
+            bg      .push_back(interp.evaluate(0, pt));
+            bg_by_vg.push_back(interp.evaluate(1, pt));
+        }
+
+        check_is_close(bg      , bg_expect      );
+        check_is_close(bg_by_vg, bg_by_vg_expect);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclunithandling.cpp
+++ b/tests/test_eclunithandling.cpp
@@ -28,7 +28,7 @@
 
 #define NVERBOSE
 
-#define BOOST_TEST_MODULE TEST_ASSEMBLED_CONNECTIONS
+#define BOOST_TEST_MODULE TEST_UNIT_HANDLING
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
@@ -55,6 +55,22 @@ BOOST_AUTO_TEST_CASE (Constructor)
 BOOST_AUTO_TEST_CASE (Metric)
 {
     auto M = ::Opm::ECLUnits::createUnitSystem(1);
+
+    // Density (kilogram/cubic(metres))
+    {
+        const auto scale  = M->density();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Depth (metres)
+    {
+        const auto scale  = M->depth();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 
     // Pressure (bars)
     {
@@ -119,11 +135,43 @@ BOOST_AUTO_TEST_CASE (Metric)
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
+
+    // Dissolved Gas-Oil Ratio (Sm^3/Sm^3)
+    {
+        const auto scale  = M->dissolvedGasOilRat();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Vaporised Oil-Gas Ratio (Sm^3/Sm^3)
+    {
+        const auto scale  = M->vaporisedOilGasRat();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (Field)
 {
     auto F = ::Opm::ECLUnits::createUnitSystem(2);
+
+    // Density (pound/cubic(feet))
+    {
+        const auto scale  = F->density();
+        const auto expect = 1.601846337396014e+01;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Depth (feet)
+    {
+        const auto scale  = F->depth();
+        const auto expect = 0.3048; // 12 * 2.54
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 
     // Pressure (psi)
     {
@@ -188,11 +236,43 @@ BOOST_AUTO_TEST_CASE (Field)
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
+
+    // Dissolved Gas-Oil Ratio (Mscf/stb)
+    {
+        const auto scale  = F->dissolvedGasOilRat();
+        const auto expect = 1.781076066790352e+02;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Vaporised Oil-Gas Ratio (stb/Mscf)
+    {
+        const auto scale  = F->vaporisedOilGasRat();
+        const auto expect = 5.614583333333335e-03;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (Lab)
 {
     auto L = ::Opm::ECLUnits::createUnitSystem(3);
+
+    // Density (gram/cubic(centi*meter))
+    {
+        const auto scale  = L->density();
+        const auto expect = 1.0e3;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Depth (cm)
+    {
+        const auto scale  = L->depth();
+        const auto expect = 0.01;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 
     // Pressure (atm)
     {
@@ -257,11 +337,43 @@ BOOST_AUTO_TEST_CASE (Lab)
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
+
+    // Dissolved Gas-Oil Ratio (s(cm)^3/s(cm)^3)
+    {
+        const auto scale  = L->dissolvedGasOilRat();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Vaporised Oil-Gas Ratio (s(cm)^3/s(cm)^3)
+    {
+        const auto scale  = L->vaporisedOilGasRat();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (PVT_M)
 {
     auto P = ::Opm::ECLUnits::createUnitSystem(4);
+
+    // Density (kilogram/cubic(meter))
+    {
+        const auto scale  = P->density();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Depth (metres)
+    {
+        const auto scale  = P->depth();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 
     // Pressure (atm)
     {
@@ -323,6 +435,22 @@ BOOST_AUTO_TEST_CASE (PVT_M)
     {
         const auto scale  = P->viscosity();
         const auto expect = 1.0e-3;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Dissolved Gas-Oil Ratio (sm^3/sm^3)
+    {
+        const auto scale  = P->dissolvedGasOilRat();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Vaporised Oil-Gas Ratio (sm^3/sm^3)
+    {
+        const auto scale  = P->vaporisedOilGasRat();
+        const auto expect = 1.0;
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }

--- a/tests/test_eclunithandling.cpp
+++ b/tests/test_eclunithandling.cpp
@@ -80,6 +80,22 @@ BOOST_AUTO_TEST_CASE (Metric)
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
 
+    // Surface Volume, Gas (sm3)
+    {
+        const auto scale  = M->surfaceVolumeGas();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Surface Volume, Liquid (sm3)
+    {
+        const auto scale  = M->surfaceVolumeLiquid();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
     // Time (day)
     {
         const auto scale  = M->time();
@@ -128,6 +144,22 @@ BOOST_AUTO_TEST_CASE (Field)
     // Reservoir Volume (rb)
     {
         const auto scale  = F->reservoirVolume();
+        const auto expect = 1.589872949280001e-01;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Surface Volume, Gas (Mscf)
+    {
+        const auto scale  = F->surfaceVolumeGas();
+        const auto expect = 2.831684659200000e+01;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Surface Volume, Liquid (stb)
+    {
+        const auto scale  = F->surfaceVolumeLiquid();
         const auto expect = 1.589872949280001e-01;
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
@@ -186,6 +218,22 @@ BOOST_AUTO_TEST_CASE (Lab)
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
 
+    // Surface Volume, Gas (s(cm)^3)
+    {
+        const auto scale  = L->surfaceVolumeGas();
+        const auto expect = 1.0e-06;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Surface Volume, Liquid (s(cm)^3)
+    {
+        const auto scale  = L->surfaceVolumeLiquid();
+        const auto expect = 1.0e-06;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
     // Time (hour)
     {
         const auto scale  = L->time();
@@ -234,6 +282,22 @@ BOOST_AUTO_TEST_CASE (PVT_M)
     // Reservoir Volume (rm^3)
     {
         const auto scale  = P->reservoirVolume();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Surface Volume, Gas (sm^3)
+    {
+        const auto scale  = P->surfaceVolumeGas();
+        const auto expect = 1.0;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Surface Volume, Liquid (sm^3)
+    {
+        const auto scale  = P->surfaceVolumeLiquid();
         const auto expect = 1.0;
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);

--- a/tests/test_eclunithandling.cpp
+++ b/tests/test_eclunithandling.cpp
@@ -95,6 +95,14 @@ BOOST_AUTO_TEST_CASE (Metric)
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
+
+    // Viscosity (cP)
+    {
+        const auto scale  = M->viscosity();
+        const auto expect = 1.0e-3;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (Field)
@@ -137,6 +145,14 @@ BOOST_AUTO_TEST_CASE (Field)
     {
         const auto scale  = F->transmissibility();
         const auto expect = 2.668883979653090e-13;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Viscosity (cP)
+    {
+        const auto scale  = F->viscosity();
+        const auto expect = 1.0e-3;
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
@@ -185,6 +201,14 @@ BOOST_AUTO_TEST_CASE (Lab)
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }
+
+    // Viscosity (cP)
+    {
+        const auto scale  = L->viscosity();
+        const auto expect = 1.0e-3;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (PVT_M)
@@ -227,6 +251,14 @@ BOOST_AUTO_TEST_CASE (PVT_M)
     {
         const auto scale  = P->transmissibility();
         const auto expect = 1.142272299439830e-13;
+
+        BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
+    }
+
+    // Viscosity (cP)
+    {
+        const auto scale  = P->viscosity();
+        const auto expect = 1.0e-3;
 
         BOOST_CHECK_CLOSE(scale, expect, 1.0e-10);
     }


### PR DESCRIPTION
Known limitations: Does not distinguish saturated from unsaturated conditions when evaluating density or viscosity of live oil/wet gas.  Does not support capillary pressure.  Does not support keyword `PVCDO` (single record pr. PVT region in the INIT-file's `TAB` vector).

Most of the implementation is contained in the new classes `ECLPvtGas`, `ECLPvtOil`, and `ECLPvtWater` that use the `TAB` vector to initialise one-D and two-D piecewise linear interpolants.  We extract the basic support interpolants out to a new helper class, `PiecewisePolynomial::Linear` that has configurable behaviour for extrapolation outside the range of the independent variable.  At present we support constant extrapolation (useful for saturation functions), linear extrapolation based on estimated derivatives at the end-points of the range, and linear extrapolation based on tabulated derivatives.  We also add the requisite unit conversion support to guarantee that we perform all calculations in strict SI unit conventions.

Finally, we correct two mistakes in the computation of the three-phase relative permeability for oil and the definition of a `vector<bool>` extracted from a LOGIHEAD-like result-set vector.