### PR TITLE
Refactor result-set identification

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -21,6 +21,7 @@
 #                             the library needs it.
 
 list (APPEND MAIN_SOURCE_FILES
+        opm/utility/ECLCaseUtilities.cpp
         opm/utility/ECLEndPointScaling.cpp
         opm/utility/ECLFluxCalc.cpp
         opm/utility/ECLGraph.cpp
@@ -58,6 +59,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
         )
 
 list (APPEND PUBLIC_HEADER_FILES
+        opm/utility/ECLCaseUtilities.hpp
         opm/utility/ECLEndPointScaling.hpp
         opm/utility/ECLFluxCalc.hpp
         opm/utility/ECLGraph.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND TEST_SOURCE_FILES
 list (APPEND EXAMPLE_SOURCE_FILES
         examples/computeFlowStorageCurve.cpp
         examples/computeLocalSolutions.cpp
+        examples/computePhaseFluxes.cpp
         examples/computeToFandTracers.cpp
         examples/computeTracers.cpp
         examples/extractFromRestart.cpp

--- a/examples/computePhaseFluxes.cpp
+++ b/examples/computePhaseFluxes.cpp
@@ -1,0 +1,209 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <examples/exampleSetup.hpp>
+
+#include <opm/utility/ECLCaseUtilities.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLResultData.hpp>
+
+#include <chrono>
+#include <exception>
+#include <ios>
+#include <iostream>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/system/error_code.hpp>
+
+namespace {
+    template <class OStream, class Task>
+    void timeIt(OStream& os, Task&& task)
+    {
+        const auto start = ::std::chrono::steady_clock::now();
+
+        task();
+
+        const auto stop = ::std::chrono::steady_clock::now();
+
+        os << std::setprecision(3) << std::scientific
+           << std::chrono::duration<double>(stop - start).count()
+           << " [s]" << std::endl;
+    }
+
+    std::string phaseName(const Opm::ECLPhaseIndex p)
+    {
+        switch (p) {
+        case Opm::ECLPhaseIndex::Aqua:   return "water";
+        case Opm::ECLPhaseIndex::Liquid: return "oil";
+        case Opm::ECLPhaseIndex::Vapour: return "gas";
+        }
+
+        throw std::invalid_argument {
+            "Invalid Phase ID"
+        };
+    }
+
+    int numDigits(const std::vector<int>& steps)
+    {
+        if (steps.empty()) {
+            return 1;
+        }
+
+        const auto m =
+            *std::max_element(std::begin(steps), std::end(steps));
+
+        if (m == 0) {
+            return 1;
+        }
+
+        assert (m > 0);
+
+        return std::floor(std::log10(static_cast<double>(m))) + 1;
+    }
+
+    void openRestartSet(const Opm::ECLCaseUtilities::ResultSet& rset,
+                        const int                               step,
+                        std::unique_ptr<Opm::ECLRestartData>&   rstrt)
+    {
+        if (! (rset.isUnifiedRestart() && rstrt)) {
+            // Not a unified restart file or this is the first time we're
+            // seeing the result set.
+            rstrt.reset(new Opm::ECLRestartData(rset.restartFile(step)));
+        }
+    }
+
+    void savePhaseFlux(const std::string&         phase,
+                       const std::string&         type,
+                       const int                  step,
+                       const int                  ndgt,
+                       const std::vector<double>& pflux)
+    {
+        namespace fs = boost::filesystem;
+
+        const auto dir = fs::path{ phase };
+
+        boost::system::error_code ec{};
+        if (fs::create_directories(dir, ec) ||
+            (ec.value() == boost::system::errc::errc_t::success))
+        {
+            auto fn = dir;
+            {
+                std::ostringstream os;
+
+                os << type << '-'
+                   << std::setw(ndgt) << std::setfill('0')
+                   << step << ".txt";
+
+                fn /= os.str();
+            }
+
+            fs::ofstream os(fn);
+            if (os) {
+                os.precision(16);
+                os.setf(std::ios::scientific);
+
+                for (const auto& qi : pflux) {
+                    os << qi << '\n';
+                }
+            }
+        }
+    }
+
+    void computePhaseFluxes(const Opm::ECLGraph&                    G,
+                            const Opm::ECLCaseUtilities::ResultSet& rset,
+                            const Opm::ECLFluxCalc&                 fcalc,
+                            const int                               step,
+                            const int                               ndgt,
+                            std::unique_ptr<Opm::ECLRestartData>&   rstrt)
+    {
+        openRestartSet(rset, step, rstrt);
+
+        if (! (rstrt && rstrt->selectReportStep(step))) {
+            std::cout << "    Failed (No Such Report Step)\n";
+        }
+
+        for (const auto& phase : G.activePhases()) {
+            const auto pname = phaseName(phase);
+            auto       pflux = std::vector<double>{};
+
+            timeIt(std::cout, [&fcalc, &rstrt, phase, &pname, &pflux]()
+            {
+                pflux = fcalc.flux(*rstrt, phase);
+
+                std::cout << "    - " << std::right
+                          << std::setw(5) << std::setfill(' ')
+                          << pname << ": ";
+            });
+
+            if (! pflux.empty()) {
+                savePhaseFlux(pname, "calc", step, ndgt, pflux);
+            }
+
+            // Extract reference fluxes if available.
+            pflux = G.flux(*rstrt, phase);
+            if (! pflux.empty()) {
+                savePhaseFlux(pname, "ref", step, ndgt, pflux);
+            }
+        }
+    }
+} // namespace Anonymous
+
+int main(int argc, char* argv[])
+try {
+    const auto prm    = example::initParam(argc, argv);
+    const auto grav   = prm.getDefault("grav"  , 9.80665);
+    const auto useEPS = prm.getDefault("useEPS", false);
+
+    const auto rset  = example::identifyResultSet(prm);
+    const auto steps = rset.reportStepIDs();
+    const auto ndgt  = numDigits(steps);
+    const auto init  = Opm::ECLInitFileData(rset.initFile());
+    const auto graph = Opm::ECLGraph::load(rset.gridFile(), init);
+    const auto fcalc = Opm::ECLFluxCalc(graph, init, grav, useEPS);
+
+    auto rstrt = std::unique_ptr<Opm::ECLRestartData>{};
+
+    for (const auto& step : steps) {
+        timeIt(std::cout, [&rset, &graph, &rstrt, &fcalc, ndgt, step]()
+        {
+            std::cout << "Phase Fluxes for Report Step "
+                      << std::setw(ndgt) << std::setfill('0')
+                      << step << std::endl;
+
+            computePhaseFluxes(graph, rset, fcalc, step, ndgt, rstrt);
+
+            std::cout << "  - Step Time: ";
+        });
+
+        std::cout << std::endl;
+    }
+}
+catch (const std::exception& e) {
+    std::cerr << "Caught Exception: " << e.what() << '\n';
+
+    return EXIT_FAILURE;
+}

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -29,6 +29,7 @@
 #include <opm/flowdiagnostics/ConnectionValues.hpp>
 #include <opm/flowdiagnostics/Toolbox.hpp>
 
+#include <opm/utility/ECLCaseUtilities.hpp>
 #include <opm/utility/ECLFluxCalc.hpp>
 #include <opm/utility/ECLGraph.hpp>
 #include <opm/utility/ECLPhaseIndex.hpp>
@@ -36,52 +37,16 @@
 #include <opm/utility/ECLWellSolution.hpp>
 
 #include <exception>
+#include <initializer_list>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 namespace example {
-    inline bool isFile(const boost::filesystem::path& p)
-    {
-        namespace fs = boost::filesystem;
-
-        auto is_regular_file = [](const fs::path& pth)
-        {
-            return fs::exists(pth) && fs::is_regular_file(pth);
-        };
-
-        return is_regular_file(p)
-            || (fs::is_symlink(p) &&
-                is_regular_file(fs::read_symlink(p)));
-    }
-
-    inline boost::filesystem::path
-    deriveFileName(boost::filesystem::path         file,
-                   const std::vector<std::string>& extensions)
-    {
-        for (const auto& ext : extensions) {
-            file.replace_extension(ext);
-
-            if (isFile(file)) {
-                return file;
-            }
-        }
-
-        const auto prefix = file.parent_path() / file.stem();
-
-        std::ostringstream os;
-
-        os << "Unable to derive valid filename from model prefix "
-           << prefix.generic_string();
-
-        throw std::invalid_argument(os.str());
-    }
-
-
     template <class FluxCalc>
     inline Opm::FlowDiagnostics::ConnectionValues
     extractFluxField(const Opm::ECLGraph& G,
@@ -169,26 +134,34 @@ namespace example {
 
 
 
-    struct FilePaths
+    inline Opm::ECLCaseUtilities::ResultSet
+    identifyResultSet(const Opm::ParameterGroup& param)
     {
-        FilePaths(const Opm::ParameterGroup& param)
+        for (const auto* p : { "case", "grid", "init", "restart" })
         {
-            const string casename = param.getDefault<string>("case", "DEFAULT_CASE_NAME");
-            grid = param.has("grid") ? param.get<string>("grid")
-                : deriveFileName(casename, { ".EGRID", ".FEGRID", ".GRID", ".FGRID" });
-            init = param.has("init") ? param.get<string>("init")
-                : deriveFileName(casename, { ".INIT", ".FINIT" });
-            restart = param.has("restart") ? param.get<string>("restart")
-                : deriveFileName(casename, { ".UNRST", ".FUNRST" });
+            if (param.has(p)) {
+                return Opm::ECLCaseUtilities::ResultSet {
+                    param.get<std::string>(p)
+                };
+            }
         }
 
-        using path = boost::filesystem::path;
-        using string = std::string;
+        throw std::invalid_argument {
+            "No Valid Result Set Identified by Input Parameters"
+        };
+    }
 
-        path grid;
-        path init;
-        path restart;
-    };
+
+
+
+    inline std::unordered_set<int>
+    getAvailableSteps(const ::Opm::ECLCaseUtilities::ResultSet& result_set)
+    {
+        const auto steps = result_set.reportStepIDs();
+
+        return { std::begin(steps), std::end(steps) };
+    }
+
 
 
 
@@ -227,10 +200,10 @@ namespace example {
     {
         Setup(int argc, char** argv)
             : param          (initParam(argc, argv))
-            , file_paths     (param)
-            , init           (file_paths.init)
-            , rstrt          (file_paths.restart)
-            , graph          (::Opm::ECLGraph::load(file_paths.grid, init))
+            , result_set     (identifyResultSet(param))
+            , init           (result_set.initFile())
+            , graph          (::Opm::ECLGraph::load(result_set.gridFile(), init))
+            , available_steps(getAvailableSteps(result_set))
             , well_fluxes    ()
             , toolbox        (initToolbox(graph))
             , compute_fluxes_(param.getDefault("compute_fluxes", false))
@@ -243,7 +216,7 @@ namespace example {
 
                 os << "Report Step " << step
                    << " is Not Available in Result Set "
-                   << file_paths.grid.stem();
+                   << this->result_set.gridFile().stem();
 
                 throw std::domain_error(os.str());
             }
@@ -251,16 +224,33 @@ namespace example {
 
         bool selectReportStep(const int step)
         {
-            if (! rstrt.selectReportStep(step)) {
+            if (this->available_steps.count(step) == 0) {
+                // Requested report step not amongst those stored in the
+                // result set.
+                return false;
+            }
+
+            if (! (this->result_set.isUnifiedRestart() &&
+                   bool(this->restart)))
+            {
+                // Non-unified (separate) restart files, or first time-step
+                // selection in a unified restart file case.
+                const auto restart_file =
+                    this->result_set.restartFile(step);
+
+                this->openRestartFile(restart_file);
+            }
+
+            if (! this->restart->selectReportStep(step)) {
                 return false;
             }
 
             {
                 auto wsol = Opm::ECLWellSolution{};
-                well_fluxes = wsol.solution(rstrt, graph.activeGrids());
+                well_fluxes = wsol.solution(*restart, graph.activeGrids());
             }
 
-            toolbox.assignConnectionFlux(extractFluxField(graph, init, rstrt,
+            toolbox.assignConnectionFlux(extractFluxField(graph, init, *restart,
                                                           compute_fluxes_, useEPS_));
 
             toolbox.assignInflowFlux(extractWellFlows(graph, well_fluxes));
@@ -269,14 +259,22 @@ namespace example {
         }
 
         Opm::ParameterGroup param;
-        FilePaths file_paths;
+        Opm::ECLCaseUtilities::ResultSet result_set;
         Opm::ECLInitFileData init;
-        Opm::ECLRestartData rstrt;
         Opm::ECLGraph graph;
+        std::unordered_set<int> available_steps;
         std::vector<Opm::ECLWellSolution::WellData> well_fluxes;
         Opm::FlowDiagnostics::Toolbox toolbox;
         bool compute_fluxes_ = false;
         bool useEPS_ = false;
+
+        std::shared_ptr<Opm::ECLRestartData> restart;
+
+    private:
+        void openRestartFile(const boost::filesystem::path& rstrt)
+        {
+            this->restart.reset(new Opm::ECLRestartData{ rstrt });
+        }
     };
 
 

--- a/opm/utility/ECLCaseUtilities.cpp
+++ b/opm/utility/ECLCaseUtilities.cpp
@@ -16,13 +16,46 @@
 #include <ert/ecl/ecl_file_view.h>
 #include <ert/util/ert_unique_ptr.hpp>
 
+/// Function object that matches strings with a common prefix (i.e., a file
+/// name base) followed by .F or .X and then exactly four digits and nothing
+/// further.
+///
+/// In other words, if prefix is "NORNE_ATW2013", then the function will
+/// return true for strings of the form
+///
+///   -* NORNE_ATW2013.F0000
+///   -* NORNE_ATW2013.X1234
+///
+/// but it will return false for anything else like strings of the form
+///
+///   -* NORNE_ATW2013.S0123
+///   -* NORNE_ATW2013.FUNRST
+///   -* NORNE_ATW2013.X12345
+///   -* NORNE_ATW2013.F012
+///   -* NORNE_ATW2013.X012Y
+///   -* NORNE_ATW2013.X0123.4
+///   -* NORNE_ATW2014.F0001
+///
 class IsSeparateRestart
 {
 public:
+    /// Constructor.
+    ///
+    /// \param[in] prefix Common string prefix (file name base).
     IsSeparateRestart(const std::string& prefix)
         : restart_(prefix + R"~~(\.(F|X)\d{4}$)~~")
-    {}
+    {
+        // Common prefix + '.' + (F or X) + four digits + "end of string".
+    }
 
+    /// Match string against stored regular expression engine.
+    ///
+    /// \param[in] e Name, possibly full path, of file system element.
+    ///    Typically names a regular file.
+    ///
+    /// \return True if the element matches the entire stored regular
+    ///    expression (\code regex_match() \endcode rather than \code
+    ///    regex_search() \endcode), false otherwise.
     bool operator()(const boost::filesystem::path& e) const
     {
         return std::regex_match(e.filename().generic_string(),
@@ -30,6 +63,7 @@ public:
     }
 
 private:
+    /// Regular expression against which to match filesystem elements.
     std::regex restart_;
 };
 

--- a/opm/utility/ECLCaseUtilities.cpp
+++ b/opm/utility/ECLCaseUtilities.cpp
@@ -94,7 +94,7 @@ namespace {
             return casefile;
         }
 
-        return casefile.parent_path() / (casefile.stem() + ".Ignore-This");
+        return casefile.parent_path() / (casefile.stem() + ".Imp-Detail-Hack");
     }
 
     // Look for separate restart files (.X000n or .F000n) that match the

--- a/opm/utility/ECLCaseUtilities.cpp
+++ b/opm/utility/ECLCaseUtilities.cpp
@@ -1,0 +1,291 @@
+#include <opm/utility/ECLCaseUtilities.hpp>
+
+#include <exception>
+#include <initializer_list>
+#include <iomanip>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+#include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_file_kw.h>
+#include <ert/ecl/ecl_file_view.h>
+#include <ert/util/ert_unique_ptr.hpp>
+
+class IsSeparateRestart
+{
+public:
+    IsSeparateRestart(const std::string& prefix)
+        : restart_(prefix + R"~~(\.(F|X)\d{4}$)~~")
+    {}
+
+    bool operator()(const boost::filesystem::path& e) const
+    {
+        return std::regex_match(e.filename().generic_string(),
+                                this->restart_);
+    }
+
+private:
+    std::regex restart_;
+};
+
+namespace {
+    template <class String>
+    boost::filesystem::path
+    operator+(boost::filesystem::path p, const String& e)
+    {
+        return p += e;
+    }
+
+    bool isFile(const boost::filesystem::path& p)
+    {
+        namespace fs = boost::filesystem;
+
+        auto is_regular_file = [](const fs::path& pth)
+            {
+                return fs::exists(pth) && fs::is_regular_file(pth);
+            };
+
+        return is_regular_file(p)
+            || (fs::is_symlink(p) &&
+                is_regular_file(fs::read_symlink(p)));
+    }
+
+    boost::filesystem::path
+    deriveFileName(boost::filesystem::path            file,
+                   std::initializer_list<const char*> ext)
+    {
+        for (const auto& e : ext) {
+            file.replace_extension(e);
+
+            if (isFile(file)) {
+                return file;
+            }
+        }
+
+        return "";
+    }
+
+    // Handle the possibility that a case prefix ends in a substring that
+    // looks like a file extension (e.g., "path/to/CASE.01").  This
+    // substring would be stripped off during deriveFileName() processing.
+    boost::filesystem::path
+    safeCasePrefix(const boost::filesystem::path& casename)
+    {
+        auto casefile = boost::filesystem::path{};
+
+        for (const auto* ignore : { "", ".@@@-HACK-@@@" }) {
+            casefile = deriveFileName(casename + ignore,
+                                      { ".DATA" ,
+                                        ".EGRID", ".FEGRID" ,
+                                        ".GRID" , ".FGRID"  });
+
+            if (! casefile.empty()) {
+                // Valid case file found.
+                break;
+            }
+        }
+
+        if (casefile.empty()) {
+            return casefile;
+        }
+
+        return casefile.parent_path() / (casefile.stem() + ".Ignore-This");
+    }
+
+    // Look for separate restart files (.X000n or .F000n) that match the
+    // case-name prefix in the directory implied by prefix.  Pick the most
+    // recent one (as defined by the element's write/modification time).
+    //
+    // Return empty if there are no separate restart files (that match the
+    // prefix).
+    boost::filesystem::path
+    mostRecentSeparateRestart(const boost::filesystem::path& prefix)
+    {
+        namespace fs = boost::filesystem;
+
+        const auto isSepRstrt = IsSeparateRestart {
+            prefix.stem().generic_string()
+        };
+
+        auto most_recent = fs::path{};
+        auto max_mtime   = 0 * fs::last_write_time(prefix.parent_path());
+
+        for (auto i = fs::directory_iterator(prefix.parent_path()),
+                  e = fs::directory_iterator();
+             i != e; ++i)
+        {
+            if (! fs::is_regular_file(i->status())) {
+                // Not a file.  Ignore.
+                continue;
+            }
+
+            const auto& elem = i->path();
+
+            if (! isSepRstrt(elem)) {
+                // Not a (separate) restart file.  Ignore.
+                continue;
+            }
+
+            const auto mtime = fs::last_write_time(elem);
+
+            if (mtime > max_mtime) {
+                max_mtime   = mtime;
+                most_recent = elem;
+            }
+        }
+
+        return most_recent;
+    }
+
+    // Determine whether or not result set uses a unified restart file.
+    //
+    // Steps:
+    //   1) Return false if no unified restart file matches prefix.
+    //
+    //   2) Otherwise, return true if no *separate* restart file matches
+    //      prefix.
+    //
+    //   3) Otherwise, return true if unified restart file is more recent
+    //      (in terms of modification/write time) than most recent separate
+    //      restart file that matches prefix.
+    bool restartIsUnified(const boost::filesystem::path& prefix)
+    {
+        const auto unif = deriveFileName(prefix, { ".UNRST", ".FUNRST" });
+
+        if (unif.empty()) {
+            // No unified restart file matches the 'prefix'.  Definitely not
+            // a unified restart case.
+            return false;
+        }
+
+        // There *is* a unified restart file, but there might be separate
+        // restart files too--e.g., if the .DATA file was modified between
+        // runs.  Look for those, and pick the one with the most recent
+        // write time (i.e., stat::m_time on POSIX).
+        const auto separate = mostRecentSeparateRestart(prefix);
+
+        if (separate.empty()) {
+            // There are no separate restart files that match the 'prefix'.
+            // This is definitely a unified restart case.
+            return true;
+        }
+
+        // There are *both* unified and separte candidate restart files.
+        // Choose the unified file if more recent than most recent separate
+        // file.
+        using boost::filesystem::last_write_time;
+
+        return ! (last_write_time(unif) < last_write_time(separate));
+    }
+
+    boost::filesystem::path
+    separateRestartFile(const boost::filesystem::path& prefix,
+                        const int                      reportStepID)
+    {
+        auto makeExt = [reportStepID](const std::string& cat) -> std::string
+        {
+            std::ostringstream os;
+
+            os << cat << std::setw(4) << std::setfill('0') << reportStepID;
+
+            return os.str();
+        };
+
+        // Formatted
+        const auto F = makeExt("F");
+
+        // Unformatted
+        const auto X = makeExt("X");
+
+        // Note: .c_str() is a bit of a hack--needed to match
+        // initializer_list<const char*>.
+        return deriveFileName(prefix, { X.c_str(), F.c_str() });
+    }
+}
+
+Opm::ECLCaseUtilities::ResultSet::ResultSet(const Path& casename)
+    : prefix_(safeCasePrefix(casename))
+{
+    if (this->prefix_.empty()) {
+        throw std::invalid_argument {
+            casename.generic_string() +
+            " Is Not a Valid ECL Result Set Name"
+        };
+    }
+
+    // Don't check for unified/separate until we've verified that this is
+    // even a valid result set.
+    this->isUnified_ = restartIsUnified(this->prefix_);
+}
+
+Opm::ECLCaseUtilities::ResultSet::Path
+Opm::ECLCaseUtilities::ResultSet::gridFile() const
+{
+    return deriveFileName(this->prefix_,
+                          { ".EGRID", ".FEGRID",
+                            ".GRID" , ".FGRID" });
+}
+
+Opm::ECLCaseUtilities::ResultSet::Path
+Opm::ECLCaseUtilities::ResultSet::initFile() const
+{
+    return deriveFileName(this->prefix_,
+                          { ".INIT", ".FINIT" });
+}
+
+Opm::ECLCaseUtilities::ResultSet::Path
+Opm::ECLCaseUtilities::ResultSet::restartFile(const int reportStepID) const
+{
+    if (this->isUnifiedRestart()) {
+        return deriveFileName(this->prefix_, { ".UNRST", ".FUNRST" });
+    }
+
+    return separateRestartFile(this->prefix_, reportStepID);
+}
+
+bool
+Opm::ECLCaseUtilities::ResultSet::isUnifiedRestart() const
+{
+    return this->isUnified_;
+}
+
+std::vector<int>
+Opm::ECLCaseUtilities::ResultSet::reportStepIDs() const
+{
+    using FilePtr = ::ERT::
+        ert_unique_ptr<ecl_file_type, ecl_file_close>;
+
+    const auto rsspec_fn =
+        deriveFileName(this->prefix_, { ".RSSPEC", ".FRSSPEC" });
+
+    // Read-only, keep open between requests
+    const auto open_flags = 0;
+
+    auto rsspec = FilePtr{
+        ecl_file_open(rsspec_fn.generic_string().c_str(), open_flags)
+    };
+
+    auto* globView = ecl_file_get_global_view(rsspec.get());
+
+    const auto* ITIME_kw = "ITIME";
+    const auto n = ecl_file_view_get_num_named_kw(globView, ITIME_kw);
+
+    auto steps = std::vector<int>(n);
+
+    for (auto i = 0*n; i < n; ++i) {
+        const auto* itime =
+            ecl_file_view_iget_named_kw(globView, ITIME_kw, i);
+
+        const auto* itime_data =
+            static_cast<const int*>(ecl_kw_iget_ptr(itime, 0));
+
+        steps[i] = itime_data[0];
+    }
+
+    return steps;
+}

--- a/opm/utility/ECLCaseUtilities.hpp
+++ b/opm/utility/ECLCaseUtilities.hpp
@@ -1,0 +1,56 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLCASEUTILITIES_HEADER_INCLUDED
+#define OPM_ECLCASEUTILITIES_HEADER_INCLUDED
+
+#include <vector>
+
+#include <boost/filesystem/path.hpp>
+
+namespace Opm { namespace ECLCaseUtilities {
+
+    class ResultSet
+    {
+    public:
+        using Path = boost::filesystem::path;
+
+        explicit ResultSet(const Path& casename);
+
+        Path gridFile() const;
+        Path initFile() const;
+        Path restartFile(const int reportStepID) const;
+
+        bool isUnifiedRestart() const;
+
+        std::vector<int> reportStepIDs() const;
+
+    private:
+        /// Case prefix.  Typical form is "path/to/case", but might be
+        /// "path/to/case.01" too.
+        boost::filesystem::path prefix_;
+
+        /// Whether or not this result set has a unified restart file
+        /// (.UNRST, .FUNRST).
+        bool isUnified_;
+    };
+
+}} // Opm::ECLCaseUtilities
+
+#endif // OPM_ECLCASEUTILITIES_HEADER_INCLUDED

--- a/opm/utility/ECLCaseUtilities.hpp
+++ b/opm/utility/ECLCaseUtilities.hpp
@@ -26,19 +26,61 @@
 
 namespace Opm { namespace ECLCaseUtilities {
 
+    /// Basic information about an ECL result set.
     class ResultSet
     {
     public:
         using Path = boost::filesystem::path;
 
+        /// Constructor.
+        ///
+        /// \param[in] casename File name prefix or full path to one of a
+        ///    result set's common representative files.  Usually one of the
+        ///    '.DATA', '.EGRID' (or .GRID) or .UNRST files.
         explicit ResultSet(const Path& casename);
 
+        /// Retrieve name of result set's grid file.
         Path gridFile() const;
+
+        /// Retrieve name of result set's init file.
         Path initFile() const;
+
+        /// Retrieve name of result set's restart file corresponding to a
+        /// particular report/restart step ID.
+        ///
+        /// \param[in] reportStepID Numeric report (restart) step
+        ///    identifier.  Must be non-negative.  Typically one of the IDs
+        ///    produced by member function reportStepIDs().
+        ///
+        /// \return name of result set's restart file corresponding to \p
+        ///    reportStepID.
         Path restartFile(const int reportStepID) const;
 
+        /// Predicate for whether or not this particular result set uses a
+        /// unified restart file.
+        ///
+        /// If this function returns true, then all calls to function
+        /// restartFile() will return the same file name.  In other words,
+        /// the restart file need not be reopened when switching from one
+        /// report step to another.
+        ///
+        /// \return Whether or not this result set uses a unified restart
+        ///    file.
         bool isUnifiedRestart() const;
 
+        /// Retrieve set of report step IDs stored in result set.
+        ///
+        /// Starts at zero (i.e., \code reportStepIDs()[0] == 0 \endcode) if
+        /// the run is configured to output the initial solution state.
+        /// Otherwise, typically starts at one.  Uses the restart
+        /// specification (RSSPEC) file to identify the stored report steps.
+        ///
+        /// Note: Report step IDs will be increasing, but need not be
+        /// contiguous.  Non-contiguous IDs arise when the simulation run
+        /// does not store all of its report/restart steps (Mnemonics
+        /// 'BASIC' and 'FREQ' of input keyword RPTRST).
+        ///
+        /// \return Sequence of increasing report step IDs.
         std::vector<int> reportStepIDs() const;
 
     private:

--- a/tests/runTransTest.cpp
+++ b/tests/runTransTest.cpp
@@ -18,9 +18,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/utility/ECLGraph.hpp>
-
 #include <examples/exampleSetup.hpp>
+
+#include <opm/utility/ECLCaseUtilities.hpp>
+#include <opm/utility/ECLGraph.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -186,7 +187,7 @@ namespace {
     }
 
     bool transfieldAcceptable(const ::Opm::ParameterGroup& param,
-                              const std::vector<double>&              trans)
+                              const std::vector<double>&   trans)
     {
         const auto Tref = loadReference(param);
 
@@ -208,21 +209,21 @@ namespace {
     }
 
     ::Opm::ECLGraph
-    constructGraph(const example::FilePaths& pth)
+    constructGraph(const Opm::ECLCaseUtilities::ResultSet& rset)
     {
-        const auto I = ::Opm::ECLInitFileData(pth.init);
+        const auto I = ::Opm::ECLInitFileData(rset.initFile());
 
-        return ::Opm::ECLGraph::load(pth.grid, I);
+        return ::Opm::ECLGraph::load(rset.gridFile(), I);
     }
 } // namespace Anonymous
 
 int main(int argc, char* argv[])
 try {
-    const auto prm = example::initParam(argc, argv);
-    const auto pth = example::FilePaths(prm);
-    const auto G   = constructGraph(pth);
-    const auto T   = G.transmissibility();
-    const auto ok  = transfieldAcceptable(prm, T);
+    const auto prm  = example::initParam(argc, argv);
+    const auto rset = example::identifyResultSet(prm);
+    const auto G    = constructGraph(rset);
+    const auto T    = G.transmissibility();
+    const auto ok   = transfieldAcceptable(prm, T);
 
     std::cout << (ok ? "OK" : "FAIL") << '\n';
 


### PR DESCRIPTION
This change-set introduces a new, centralised facility (class `ResultSet`) that, when initialised from either a case-name prefix or a path to one of the typical output files (`.EGRID`, `.UNRST` &c) will collect the paths that represent all output files of that case.

We support both formatted and unformatted, unified and separate restart files and provide a way of extracting all recorded/saved report steps from the result-set's "RSSPEC" file.

We reimplement several test and example utilities to use class `ResultSet` as their back-end and add a new example utility, `examples/computePhaseFluxes.cpp`, that uses the flux calculator from PR #57 to compute phase fluxes.  For comparison purposes, this utility also emits the corresponding reference phase fluxes from the restart data if it is available.

Class `ResultSet` is controversial because it uses `std::regex<>` to match names of separate restart files (.X* or .F*).  That, in turn, means that the class is only supported on GCC >= 4.9.  It will compile in earlier versions of the GCC compiler too, but will generate a run-time error due to missing support for regular expressions in libstdc++.