### PR TITLE
Extract Relative Permeability Curves

### DIFF
--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -87,6 +87,27 @@ namespace Opm { namespace SatFunc {
         eval(const TableEndPoints&   tep,
              const SaturationPoints& sp) const = 0;
 
+        /// Derive unscaled (raw) input saturations from a sequence of table
+        /// points (independent variate in a tabulated saturation function).
+        ///
+        /// This function maps the result of \code eval() \endcode back to
+        /// its original arguments.  In other words, this is the inverse of
+        /// member function \code eval() \endcode.
+        ///
+        /// \param[in] tep Static end points that identify the saturation
+        ///    scaling intervals of a particular tabulated saturation
+        ///    function.
+        ///
+        /// \param[in] sp Sequence of saturation points.
+        ///
+        /// \return Sequence of input saturation values in order of the
+        ///    input sequence.  In particular the \c i-th element of this
+        ///    result is the scaled version of \code sp[i].sat \endcode.
+        virtual std::vector<double>
+        reverse(const TableEndPoints&   tep,
+                const SaturationPoints& sp) const = 0;
+
+        /// Virtual copy constructor.
         virtual std::unique_ptr<EPSEvalInterface> clone() const = 0;
 
         /// Destructor.  Must be virtual.
@@ -152,7 +173,7 @@ namespace Opm { namespace SatFunc {
         ///    scaling intervals of a particular tabulated saturation
         ///    function.  The evaluation procedure considers only \code
         ///    tep.low \endcode and \code tep.high \endcode.  The value of
-        ///    \code tep.disp \endcode is never read.
+        ///    \code tep.disp \endcode is never referenced.
         ///
         /// \param[in] sp Sequence of saturation points.  The maximum cell
         ///    index (\code sp[i].cell \endcode) must be strictly less than
@@ -166,6 +187,29 @@ namespace Opm { namespace SatFunc {
         eval(const TableEndPoints&   tep,
              const SaturationPoints& sp) const override;
 
+        /// Derive unscaled (raw) input saturations from a sequence of table
+        /// points (independent variate in a tabulated saturation function).
+        ///
+        /// This function maps the result of \code eval() \endcode back to
+        /// its original arguments.  In other words, this is the inverse of
+        /// member function \code eval() \endcode.
+        ///
+        /// \param[in] tep Static end points that identify the saturation
+        ///    scaling intervals of a particular tabulated saturation
+        ///    function.  The reverse mapping procedure considers only \code
+        ///    tep.low \endcode and \code tep.high \endcode.  The value of
+        ///    \code tep.disp \endcode is never referenced.
+        ///
+        /// \param[in] sp Sequence of saturation points.
+        ///
+        /// \return Sequence of input saturation values in order of the
+        ///    input sequence.  In particular the \c i-th element of this
+        ///    result is the scaled version of \code sp[i].sat \endcode.
+        virtual std::vector<double>
+        reverse(const TableEndPoints&   tep,
+                const SaturationPoints& sp) const override;
+
+        /// Virtual copy constructor.
         virtual std::unique_ptr<EPSEvalInterface> clone() const override;
 
     private:
@@ -237,9 +281,9 @@ namespace Opm { namespace SatFunc {
         ///
         /// \param[in] tep Static end points that identify the saturation
         ///    scaling intervals of a particular tabulated saturation
-        ///    function.  The evaluation procedure considers only \code
-        ///    tep.low \endcode and \code tep.high \endcode.  The value of
-        ///    \code tep.disp \endcode is never read.
+        ///    function.  All defined end points---\code tep.low \endcode,
+        ///    \code \tep.disp \endcode, and \code tep.high \endcode---are
+        ///    relevant and referenced in the evaluation procedure.
         ///
         /// \param[in] sp Sequence of saturation points.  The maximum cell
         ///    index (\code sp[i].cell \endcode) must be strictly less than
@@ -253,6 +297,29 @@ namespace Opm { namespace SatFunc {
         eval(const TableEndPoints&   tep,
              const SaturationPoints& sp) const override;
 
+        /// Derive unscaled (raw) input saturations from a sequence of table
+        /// points (independent variate in a tabulated saturation function).
+        ///
+        /// This function maps the result of \code eval() \endcode back to
+        /// its original arguments.  In other words, this is the inverse of
+        /// member function \code eval() \endcode.
+        ///
+        /// \param[in] tep Static end points that identify the saturation
+        ///    scaling intervals of a particular tabulated saturation
+        ///    function.  All defined end points---\code tep.low \endcode,
+        ///    \code \tep.disp \endcode, and \code tep.high \endcode---are
+        ///    relevant and referenced in the reverse mapping procedure.
+        ///
+        /// \param[in] sp Sequence of saturation points.
+        ///
+        /// \return Sequence of input saturation values in order of the
+        ///    input sequence.  In particular the \c i-th element of this
+        ///    result is the scaled version of \code sp[i].sat \endcode.
+        virtual std::vector<double>
+        reverse(const TableEndPoints&   tep,
+                const SaturationPoints& sp) const override;
+
+        /// Virtual copy constructor.
         virtual std::unique_ptr<EPSEvalInterface> clone() const override;
 
     private:

--- a/opm/utility/ECLPropTable.cpp
+++ b/opm/utility/ECLPropTable.cpp
@@ -90,6 +90,12 @@ Opm::SatFuncInterpolant::SingleTable::maximumSat() const
     return this->interp_.independentVariable().back();
 }
 
+const std::vector<double>&
+Opm::SatFuncInterpolant::SingleTable::saturationPoints() const
+{
+    return this->interp_.independentVariable();
+}
+
 // =====================================================================
 
 Opm::SatFuncInterpolant::SatFuncInterpolant(const ECLPropTableRawData& raw,
@@ -176,4 +182,16 @@ Opm::SatFuncInterpolant::maximumSat() const
     }
 
     return smax;
+}
+
+const std::vector<double>&
+Opm::SatFuncInterpolant::saturationPoints(const InTable& t) const
+{
+    if (t.i >= this->table_.size()) {
+        throw std::invalid_argument {
+            "Invalid Table ID"
+        };
+    }
+
+    return this->table_[t.i].saturationPoints();
 }

--- a/opm/utility/ECLPropTable.hpp
+++ b/opm/utility/ECLPropTable.hpp
@@ -226,6 +226,15 @@ namespace Opm {
         /// Retrieve maximum saturation in all tables.
         std::vector<double> maximumSat() const;
 
+        /// Retrieve unscaled sample points of independent variable in
+        /// particular sub-table (saturation region).
+        ///
+        /// \param[in] t ID of sub-table of interpolant.
+        ///
+        /// \return Abscissas of tabulated saturation function corresponding
+        ///    to particular saturation region.
+        const std::vector<double>& saturationPoints(const InTable& t) const;
+
     private:
         /// Single tabulated 1D interpolant.
         class SingleTable
@@ -279,6 +288,9 @@ namespace Opm {
 
             /// Retrieve maximum saturation in table.
             double maximumSat() const;
+
+            /// Retrieve unscaled sample points of independent variable.
+            const std::vector<double>& saturationPoints() const;
 
         private:
             /// Extrapolation policy for property evaluator/interpolant.

--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -1366,7 +1366,7 @@ namespace Opm {
         this->setActiveBlock(kwloc.sectID);
 
         if (! gridName.empty()) {
-            // We're cons
+            // Local grid.  Further restrict view to relevant LGR section.
             this->activeBlock_ =
                 ecl_file_view_add_blockview(this->activeBlock_, LGR_KW,
                                             kwloc.gridSectID);

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -99,7 +99,6 @@ BOOST_AUTO_TEST_CASE (NoScaling)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0.0,
         0.2,
@@ -111,9 +110,21 @@ BOOST_AUTO_TEST_CASE (NoScaling)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.eval(tep, sp);
+
+        check_is_close(s_inp, s);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledConnate)
@@ -136,7 +147,6 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0,
         0,
@@ -148,9 +158,30 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        const auto s_inp_expect = std::vector<double> {
+            0.2,                // t.s <= smin => smin
+            0.2,                // t.s <= smin => smin
+            0.4,
+            0.6,
+            0.8,
+            1.0,
+        };
+
+        check_is_close(s_inp, s_inp_expect);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledMax)
@@ -173,7 +204,6 @@ BOOST_AUTO_TEST_CASE (ScaledMax)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0,
         0.25,
@@ -185,9 +215,30 @@ BOOST_AUTO_TEST_CASE (ScaledMax)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        const auto s_inp_expect = std::vector<double> {
+            0.0,
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            0.8,                // t.s >= smax => smax
+        };
+
+        check_is_close(s_inp, s_inp_expect);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledBoth)
@@ -210,7 +261,6 @@ BOOST_AUTO_TEST_CASE (ScaledBoth)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0,
         0.0,
@@ -222,9 +272,30 @@ BOOST_AUTO_TEST_CASE (ScaledBoth)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        const auto s_inp_expect = std::vector<double> {
+            0.2,                // t.s <= smin => smin
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            0.8,                // t.s >= smax => smax
+        };
+
+        check_is_close(s_inp, s_inp_expect);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END ()
@@ -252,7 +323,6 @@ BOOST_AUTO_TEST_CASE (NoScaling)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0.2,
         0.2,
@@ -264,9 +334,21 @@ BOOST_AUTO_TEST_CASE (NoScaling)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        check_is_close(s_inp, expect);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledConnate)
@@ -290,7 +372,6 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0.20,
         0.32,
@@ -302,9 +383,21 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        check_is_close(s_inp, s);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledMax)
@@ -328,7 +421,6 @@ BOOST_AUTO_TEST_CASE (ScaledMax)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0.20,
         0.20,
@@ -340,9 +432,30 @@ BOOST_AUTO_TEST_CASE (ScaledMax)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        const auto s_inp_expect = std::vector<double> {
+            0.2,                // t.s <= smin -> smin
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            1.0,
+        };
+
+        check_is_close(s_inp, s_inp_expect);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledBoth)
@@ -366,7 +479,6 @@ BOOST_AUTO_TEST_CASE (ScaledBoth)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0.2,
         0.2,
@@ -378,9 +490,30 @@ BOOST_AUTO_TEST_CASE (ScaledBoth)
 
     const auto eps = SF::TwoPointScaling{ smin, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp     = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        const auto s_inp_expect = std::vector<double> {
+            0.5,                // t.s <= smin -> smin
+            0.5,                // t.s <= smin -> smin
+            0.5,                // t.s <= smin -> smin
+            0.6,
+            0.7,                // t.s >= smax -> smax
+            0.7,                // t.s >= smax -> smax
+        };
+
+        check_is_close(s_inp, s_inp_expect);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END ()
@@ -411,7 +544,6 @@ BOOST_AUTO_TEST_CASE (NoScaling)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0.0,
         0.2,
@@ -423,9 +555,21 @@ BOOST_AUTO_TEST_CASE (NoScaling)
 
     const auto eps = SF::ThreePointScaling{ smin, sdisp, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        check_is_close(s_inp, s);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (ScaledConnate)
@@ -449,7 +593,6 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
         1.0,
     };
 
-    const auto sp     = associate(s);
     const auto expect = std::vector<double> {
         0,
         1.0  / 15,
@@ -461,9 +604,30 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
 
     const auto eps = SF::ThreePointScaling{ smin, sdisp, smax };
 
-    const auto s_eff = eps.eval(tep, sp);
+    // Input saturation -> Scaled saturation
+    {
+        const auto sp    = associate(s);
+        const auto s_eff = eps.eval(tep, sp);
 
-    check_is_close(s_eff, expect);
+        check_is_close(s_eff, expect);
+    }
+
+    // Tabulated saturation -> Input saturation
+    {
+        const auto sp    = associate(expect);
+        const auto s_inp = eps.reverse(tep, sp);
+
+        const auto s_inp_expect = std::vector<double> {
+            0.1,                // t.s <= smin -> smin
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            1.0,
+        };
+
+        check_is_close(s_inp, s_inp_expect);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE (NoScaling)
     // Tabulated saturation -> Input saturation
     {
         const auto sp    = associate(expect);
-        const auto s_inp = eps.eval(tep, sp);
+        const auto s_inp = eps.reverse(tep, sp);
 
         check_is_close(s_inp, s);
     }


### PR DESCRIPTION
This change-set adds a new member function
```C++
ECLSaturationFunc::getSatFuncCurve();
```
that enables retrieving the tabulated or effective curves of a sequence of one or more saturation functions--represented as `FlowDiagnostics::Graph` objects.  At present we support the relative
permeability functions of the basic two-dimensional sub-systems (i.e., O/G and O/W).

This facility is aware of end-point scaling and will allow retrieval of the raw curves or the (horizontally) scaled, effective curves based on a run-time parameter.  Scaling mode for rel-perm is not configurable, but uses the INIT file's setting of item 20 of the LOGIHEAD vector (activates alternative/three-point scaling).

---

Example: Retrieve the effective (i.e., including horizontal end-point scaling) relative permeability of oil in oil-gas system in global cell (27,18,28) of the main grid of a particular model
```C++
Opm::FlowDiagnostics::Graph
krog(const Opm::ECLGraph&          G,
     const Opm::ECLSaturationFunc& sfunc)
{
    const auto ijk = std::array<int, 3>{ { 27, 18, 28 } };
    const auto activeCell = G.activeCell(ijk);
    if (activeCell < 0) {
        // Cell 'ijk' is not active.
        return Opm::FlowDiagnostics::Graph{};
    }

    using RC = Opm::ECLSaturationFunc::RawCurve;

    auto func = std::vector<RC>{};
    func.reserve(1);

    // Request krog (oil rel-perm in oil-gas system)
    func.push_back(RC{
        RC::Function::RelPerm,
        RC::SubSystem::OilGas,
        Opm::ECLPhaseIndex::Liquid
    });

    const auto useEPS = true;
    return sfunc.getSatFuncCurve(func, activeCell, useEPS);
}
```