### PR TITLE
Add Support for Retrieving PVT Property Curves

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -54,6 +54,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
         examples/computeToFandTracers.cpp
         examples/computeTracers.cpp
         examples/extractFromRestart.cpp
+        examples/extractPropCurves.cpp
         tests/runAcceptanceTest.cpp
         tests/runLinearisedCellDataTest.cpp
         tests/runTransTest.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -27,6 +27,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLGraph.cpp
         opm/utility/ECLPropTable.cpp
         opm/utility/ECLPvtCommon.cpp
+        opm/utility/ECLPvtCurveCollection.cpp
         opm/utility/ECLPvtGas.cpp
         opm/utility/ECLPvtOil.cpp
         opm/utility/ECLPvtWater.cpp
@@ -69,6 +70,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLPiecewiseLinearInterpolant.hpp
         opm/utility/ECLPropTable.hpp
         opm/utility/ECLPvtCommon.hpp
+        opm/utility/ECLPvtCurveCollection.hpp
         opm/utility/ECLPvtGas.hpp
         opm/utility/ECLPvtOil.hpp
         opm/utility/ECLPvtWater.hpp

--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -1,0 +1,169 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <examples/exampleSetup.hpp>
+
+#include <opm/utility/ECLCaseUtilities.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLSaturationFunc.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <iomanip>
+#include <ios>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+namespace {
+    template <class OStream>
+    void printGraph(OStream&                           os,
+                    const std::string&                 name,
+                    const Opm::FlowDiagnostics::Graph& graph)
+    {
+        const auto& x = graph.first;
+        const auto& y = graph.second;
+
+        const auto oprec  = os.precision(16);
+        const auto oflags = os.setf(std::ios_base::scientific);
+
+        os << name << " = [\n";
+
+        for (auto n = x.size(), i = 0*n; i < n; ++i) {
+            os << x[i] << ' ' << y[i] << '\n';
+        }
+
+        os << "];\n\n";
+
+        os.setf(oflags);
+        os.precision(oprec);
+    }
+
+    void krg(const Opm::ECLSaturationFunc& sfunc,
+             const int                     activeCell,
+             const bool                    useEPS)
+    {
+        using RC = Opm::ECLSaturationFunc::RawCurve;
+
+        auto func = std::vector<RC>{};
+        func.reserve(1);
+
+        // Request krg (gas rel-perm in oil-gas system)
+        func.push_back(RC{
+            RC::Function::RelPerm,
+            RC::SubSystem::OilGas,
+            Opm::ECLPhaseIndex::Vapour
+        });
+
+        const auto graph =
+            sfunc.getSatFuncCurve(func, activeCell, useEPS);
+
+        printGraph(std::cout, "krg", graph[0]);
+    }
+
+    void krog(const Opm::ECLSaturationFunc& sfunc,
+              const int                     activeCell,
+              const bool                    useEPS)
+    {
+        using RC = Opm::ECLSaturationFunc::RawCurve;
+
+        auto func = std::vector<RC>{};
+        func.reserve(1);
+
+        // Request krog (oil rel-perm in oil-gas system)
+        func.push_back(RC{
+            RC::Function::RelPerm,
+            RC::SubSystem::OilGas,
+            Opm::ECLPhaseIndex::Liquid
+        });
+
+        const auto graph =
+            sfunc.getSatFuncCurve(func, activeCell, useEPS);
+
+        printGraph(std::cout, "krog", graph[0]);
+    }
+
+    void krow(const Opm::ECLSaturationFunc& sfunc,
+              const int                     activeCell,
+              const bool                    useEPS)
+    {
+        using RC = Opm::ECLSaturationFunc::RawCurve;
+
+        auto func = std::vector<RC>{};
+        func.reserve(1);
+
+        // Request krow (oil rel-perm in oil-water system)
+        func.push_back(RC{
+            RC::Function::RelPerm,
+            RC::SubSystem::OilWater,
+            Opm::ECLPhaseIndex::Liquid
+        });
+
+        const auto graph =
+            sfunc.getSatFuncCurve(func, activeCell, useEPS);
+
+        printGraph(std::cout, "krow", graph[0]);
+    }
+
+    void krw(const Opm::ECLSaturationFunc& sfunc,
+             const int                     activeCell,
+             const bool                    useEPS)
+    {
+        using RC = Opm::ECLSaturationFunc::RawCurve;
+
+        auto func = std::vector<RC>{};
+        func.reserve(1);
+
+        // Request krw (water rel-perm in oil-water system)
+        func.push_back(RC{
+            RC::Function::RelPerm,
+            RC::SubSystem::OilWater,
+            Opm::ECLPhaseIndex::Aqua
+        });
+
+        const auto graph =
+            sfunc.getSatFuncCurve(func, activeCell, useEPS);
+
+        printGraph(std::cout, "krw", graph[0]);
+    }
+} // namespace Anonymous
+
+int main(int argc, char* argv[])
+try {
+    const auto prm    = example::initParam(argc, argv);
+    const auto useEPS = prm.getDefault("useEPS", false);
+    const auto cellID = prm.getDefault("cell", 0);
+
+    const auto rset  = example::identifyResultSet(prm);
+    const auto init  = Opm::ECLInitFileData(rset.initFile());
+    const auto graph = Opm::ECLGraph::load(rset.gridFile(), init);
+    const auto sfunc = Opm::ECLSaturationFunc(graph, init, useEPS);
+
+    if (prm.getDefault("krg" , false)) { krg (sfunc, cellID, useEPS); }
+    if (prm.getDefault("krog", false)) { krog(sfunc, cellID, useEPS); }
+    if (prm.getDefault("krow", false)) { krow(sfunc, cellID, useEPS); }
+    if (prm.getDefault("krw" , false)) { krw (sfunc, cellID, useEPS); }
+}
+catch (const std::exception& e) {
+    std::cerr << "Caught Exception: " << e.what() << '\n';
+
+    return EXIT_FAILURE;
+}

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -262,6 +262,45 @@ Opm::ECLPVT::PVDx::viscosity(const std::vector<double>& p) const
     });
 }
 
+Opm::FlowDiagnostics::Graph
+Opm::ECLPVT::PVDx::getPvtCurve(const RawCurve curve) const
+{
+    assert ((curve == RawCurve::FVF) ||
+            (curve == RawCurve::Viscosity));
+
+    const auto colID = (curve == RawCurve::FVF)
+        ? std::size_t{0} : std::size_t{1};
+
+    auto x = this->interp_.independentVariable();
+    auto y = this->interp_.resultVariable(colID);
+
+    assert ((x.size() == y.size()) && "Setup Error");
+
+    // Post-process ordinates according to which curve is requested.
+    if (curve == RawCurve::FVF) {
+        // y == 1/B.  Convert to proper FVF.
+        for (auto& yi : y) {
+            yi = 1.0 / yi;
+        }
+    }
+    else {
+        // y == 1/(B*mu).  Extract viscosity term through the usual
+        // conversion formula:
+        //
+        //    (1 / B) / (1 / (B*mu)).
+        const auto b = this->interp_.resultVariable(0); // 1/B
+
+        assert ((b.size() == y.size()) && "Setup Error");
+
+        for (auto n = y.size(), i = 0*n; i < n; ++i) {
+            y[i] = b[i] / y[i];
+        }
+    }
+
+    // Graph == pair<vector<double>, vector<double>>
+    return FlowDiagnostics::Graph { std::move(x), std::move(y) };
+}
+
 // =====================================================================
 
 std::vector<double>

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_ECLPVTCOMMON_HEADER_INCLUDED
 #define OPM_ECLPVTCOMMON_HEADER_INCLUDED
 
+#include <opm/flowdiagnostics/DerivedQuantities.hpp>
 #include <opm/utility/ECLPhaseIndex.hpp>
 #include <opm/utility/ECLPiecewiseLinearInterpolant.hpp>
 #include <opm/utility/ECLPropTable.hpp>
@@ -287,6 +288,14 @@ namespace Opm { namespace ECLPVT {
         };
     };
 
+    enum class RawCurve {
+        /// Formation volume factor (B_\alpha)
+        FVF,
+
+        /// Viscosity
+        Viscosity,
+    };
+
     template <std::size_t N>
     class DenseVector {
     public:
@@ -425,6 +434,21 @@ namespace Opm { namespace ECLPVT {
         /// \return Phase viscosity for each pressure point.
         std::vector<double>
         viscosity(const std::vector<double>& p) const;
+
+        /// Retrieve 2D graph representation PVT property function.
+        ///
+        /// \param[in] curve PVT property curve descriptor
+        ///
+        /// \return 2D graph for PVT property curve identified by
+        ///    requests represented by \p func.
+        ///
+        /// Example: Retrieve formation volume factor curve.
+        ///
+        ///    \code
+        ///       const auto graph =
+        ///           pvdx.getPvtCurve(ECLPVT::RawCurve::FVF);
+        ///    \endcode
+        FlowDiagnostics::Graph getPvtCurve(const RawCurve curve) const;
 
     private:
         /// Extrapolation policy for property evaluator/interpolant.

--- a/opm/utility/ECLPvtCurveCollection.cpp
+++ b/opm/utility/ECLPvtCurveCollection.cpp
@@ -1,0 +1,68 @@
+#include <opm/utility/ECLPvtCurveCollection.hpp>
+
+#include <opm/utility/ECLResultData.hpp>
+
+#include <vector>
+
+namespace {
+    std::vector<int>
+    pvtnumVector(const ::Opm::ECLGraph&        G,
+                 const ::Opm::ECLInitFileData& init)
+    {
+        auto pvtnum = G.rawLinearisedCellData<int>(init, "PVTNUM");
+
+        if (pvtnum.empty()) {
+            // PVTNUM missing in one or more of the grids managed by 'G'.
+            // Put all cells in PVTNUM region 1.
+            pvtnum.assign(G.numCells(), 1);
+        }
+
+        return pvtnum;
+    }
+}
+
+Opm::ECLPVT::ECLPvtCurveCollection::
+ECLPvtCurveCollection(const ECLGraph&        G,
+                      const ECLInitFileData& init)
+    : pvtnum_(pvtnumVector(G, init))
+    , gas_   (CreateGasPVTInterpolant::fromECLOutput(init)) // u_p<> -> s_p<>
+    , oil_   (CreateOilPVTInterpolant::fromECLOutput(init)) // u_p<> -> s_p<>
+{}
+
+Opm::FlowDiagnostics::Graph
+Opm::ECLPVT::ECLPvtCurveCollection::
+getPvtCurve(const RawCurve      curve,
+            const ECLPhaseIndex phase,
+            const int           activeCell) const
+{
+    if (phase == ECLPhaseIndex::Aqua) {
+        // Not supported at this time.
+        // Return empty.
+        return FlowDiagnostics::Graph{};
+    }
+
+    if (static_cast<decltype(this->pvtnum_.size())>(activeCell)
+        >= this->pvtnum_.size())
+    {
+        // Active cell index out of bounds.  Return empty.
+        return FlowDiagnostics::Graph{};
+    }
+
+    // PVTNUM is traditional one-based region identifier.  Subtract one to
+    // form valid index into std::vector<>s.
+    const auto regID = this->pvtnum_[activeCell] - 1;
+
+    if (phase == ECLPhaseIndex::Liquid) {
+        // return this->oil_->getPvtCurve(curve, regID);
+        return FlowDiagnostics::Graph{};
+    }
+
+    if (this->gas_) {
+        return this->gas_->getPvtCurve(curve, regID);
+    }
+    else {
+        // Result set does not provide tabulated gas properties.  Return
+        // empty.
+        return FlowDiagnostics::Graph{};
+    }
+}

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -1,0 +1,69 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPVTCURVECOLLECTION_HEADER_INCLUDED
+#define OPM_ECLPVTCURVECOLLECTION_HEADER_INCLUDED
+
+#include <opm/utility/ECLGraph.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLPvtGas.hpp>
+#include <opm/utility/ECLPvtOil.hpp>
+
+#include <memory>
+#include <vector>
+
+/// \file
+///
+/// Facility for evaluating pressure-dependent fluid properties (formation
+/// volume factor, viscosities &c) for oil or gas based on tabulated
+/// descriptions as represented in an ECL result set (INIT file 'TAB'
+/// vector).
+
+namespace Opm {
+    class ECLInitFileData;
+} // Opm
+
+namespace Opm { namespace ECLPVT {
+
+    class ECLPvtCurveCollection
+    {
+    public:
+        ECLPvtCurveCollection(const ECLGraph&        G,
+                              const ECLInitFileData& init);
+
+        FlowDiagnostics::Graph
+        getPvtCurve(const RawCurve      curve,
+                    const ECLPhaseIndex phase,
+                    const int           activeCell) const;
+
+    private:
+        /// Forward map: Cell -> PVT Region ID
+        std::vector<int> pvtnum_;
+
+        /// Gas PVT property evaluator.
+        std::shared_ptr<Gas> gas_; // shared => default special member funcs.
+
+        /// Oil PVT property evaluator.
+        std::shared_ptr<Oil> oil_;
+    };
+
+}} // Opm::ECLPVT
+
+#endif // OPM_ECLPVTCURVECOLLECTION_HEADER_INCLUDED

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -20,6 +20,9 @@
 #ifndef OPM_ECLPVTGAS_HEADER_INCLUDED
 #define OPM_ECLPVTGAS_HEADER_INCLUDED
 
+#include <opm/flowdiagnostics/DerivedQuantities.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+
 #include <memory>
 #include <vector>
 
@@ -149,6 +152,27 @@ namespace Opm { namespace ECLPVT {
         /// \return Mass density of gas at surface in particular model
         ///    region.
         double surfaceMassDensity(const int region) const;
+
+        /// Retrieve 2D graph representation of Gas PVT property function in
+        /// partcular PVT region.
+        ///
+        /// \param[in] curve PVT property curve descriptor
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \return 2D graph for PVT property curve identified by
+        ///    requests represented by \p func and \p region.
+        ///
+        /// Example: Retrieve gas formation volume factor curve in PVT
+        ///    region 0 (zero based, i.e., cells for which PVTNUM==1).
+        ///
+        ///    \code
+        ///       const auto graph =
+        ///           pvtGas.getPvtCurve(ECLPVT::RawCurve::FVF, 0);
+        ///    \endcode
+        FlowDiagnostics::Graph
+        getPvtCurve(const RawCurve curve, const int region) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_ECLPVTOIL_HEADER_INCLUDED
 #define OPM_ECLPVTOIL_HEADER_INCLUDED
 
+#include <opm/utility/ECLPvtCommon.hpp>
+
 #include <memory>
 #include <vector>
 
@@ -147,6 +149,27 @@ namespace Opm { namespace ECLPVT {
         /// \return Mass density of oil at surface in particular model
         ///    region.
         double surfaceMassDensity(const int region) const;
+
+        /// Retrieve 2D graph representation of Oil PVT property function in
+        /// partcular PVT region.
+        ///
+        /// \param[in] curve PVT property curve descriptor
+        ///
+        /// \param[in] region Region ID.  Non-negative integer typically
+        ///    derived from the PVTNUM mapping vector.
+        ///
+        /// \return 2D graph for PVT property curve identified by
+        ///    requests represented by \p func and \p region.
+        ///
+        /// Example: Retrieve oil viscosity curve in PVT region 3 (zero
+        ///    based, i.e., those cells for which PVTNUM==4).
+        ///
+        ///    \code
+        ///       const auto graph =
+        ///           pvtOil.getPvtCurve(ECLPVT::RawCurve::Viscosity, 3);
+        ///    \endcode
+        FlowDiagnostics::Graph
+        getPvtCurve(const RawCurve curve, const int region) const;
 
     private:
         /// Implementation class.


### PR DESCRIPTION
This change-set defines a simple protocol for retrieving the "raw" PVT property curves directly from an ECL INIT file.  At present we recognise requests for the formation volume factor and viscosity curves from immiscible tables (i.e., those represented by input keywords `PVDG` and `PVDO`).

Water properties are not supported at this time.

Note as well that the common requests generate instant runtime failure (`std::runtime_error` exception) if the backing function is from a miscible table.  This is, obviously, not a long-term solution.

Finally, we add a wrapper class `ECLPvtCurveCollection` that simplifies retrieving PVT curves for multiple phases in a single active cell.