### PR TITLE
Do not require RSSPEC file.

### DIFF
--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -225,7 +225,7 @@ namespace example {
 
         bool selectReportStep(const int step)
         {
-            if (this->available_steps.count(step) == 0) {
+            if (!this->available_steps.empty() && this->available_steps.count(step) == 0) {
                 // Requested report step not amongst those stored in the
                 // result set.
                 return false;

--- a/opm/utility/ECLCaseUtilities.cpp
+++ b/opm/utility/ECLCaseUtilities.cpp
@@ -305,6 +305,11 @@ Opm::ECLCaseUtilities::ResultSet::reportStepIDs() const
         ecl_file_open(rsspec_fn.generic_string().c_str(), open_flags)
     };
 
+    // If spec file was not found, return empty vector.
+    if (!rsspec) {
+        return {};
+    }
+
     auto* globView = ecl_file_get_global_view(rsspec.get());
 
     const auto* ITIME_kw = "ITIME";


### PR DESCRIPTION
If present, we can still do early return from Setup::selectReportStep(), if not we will use the return value from ECLRestartData::selectReportStep() as we did before merging the ECLCaseUtilities class.

This restores the ability to use the various example tools with RSSPEC-missing cases. I'll self-merge immediately.