### PR TITLE
Make example programs handle crossflow.

### DIFF
--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -247,7 +247,7 @@ namespace example {
             }
 
             {
-                auto wsol = Opm::ECLWellSolution{};
+                auto wsol = Opm::ECLWellSolution{-1.0, false};
                 well_fluxes = wsol.solution(*restart, graph.activeGrids());
             }
 


### PR DESCRIPTION
With this, the example programs behave more like ResInsight by default (accept crossflow, do not ignore wells with zero total rate).

Trivial change, all tests work, will self-merge.