### PR TITLE
Add Support for Extracting Raw PVT Curves for Miscible Tables

### DIFF
--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -200,6 +200,33 @@ namespace {
 
         printGraph(std::cout, "mu_o", graph);
     }
+
+    // -----------------------------------------------------------------
+    // Saturated states (RvSat(Pg) and RsSat(Po))
+
+    void rvSat(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCurves,
+               const int                                 activeCell)
+    {
+        using RC = Opm::ECLPVT::RawCurve;
+        using PI = Opm::ECLPhaseIndex;
+
+        const auto graph = pvtCurves
+            .getPvtCurve(RC::SaturatedState, PI::Vapour, activeCell);
+
+        printGraph(std::cout, "rvSat", graph);
+    }
+
+    void rsSat(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCurves,
+               const int                                 activeCell)
+    {
+        using RC = Opm::ECLPVT::RawCurve;
+        using PI = Opm::ECLPhaseIndex;
+
+        const auto graph = pvtCurves
+            .getPvtCurve(RC::SaturatedState, PI::Liquid, activeCell);
+
+        printGraph(std::cout, "rsSat", graph);
+    }
 } // namespace Anonymous
 
 int main(int argc, char* argv[])
@@ -229,6 +256,9 @@ try {
     if (prm.getDefault("mu_g", false)) { mu_g(pvtCC, cellID); }
     if (prm.getDefault("Bo"  , false)) { Bo  (pvtCC, cellID); }
     if (prm.getDefault("mu_o", false)) { mu_o(pvtCC, cellID); }
+
+    if (prm.getDefault("rvSat", false)) { rvSat(pvtCC, cellID); }
+    if (prm.getDefault("rsSat", false)) { rsSat(pvtCC, cellID); }
 }
 catch (const std::exception& e) {
     std::cerr << "Caught Exception: " << e.what() << '\n';

--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -37,23 +37,27 @@
 
 namespace {
     template <class OStream>
-    void printGraph(OStream&                           os,
-                    const std::string&                 name,
-                    const Opm::FlowDiagnostics::Graph& graph)
+    void printGraph(OStream&                                        os,
+                    const std::string&                              name,
+                    const std::vector<Opm::FlowDiagnostics::Graph>& graphs)
     {
-        const auto& x = graph.first;
-        const auto& y = graph.second;
-
         const auto oprec  = os.precision(16);
         const auto oflags = os.setf(std::ios_base::scientific);
 
-        os << name << " = [\n";
+        auto k = 1;
+        for (const auto& graph : graphs) {
+            const auto& x = graph.first;
+            const auto& y = graph.second;
 
-        for (auto n = x.size(), i = 0*n; i < n; ++i) {
-            os << x[i] << ' ' << y[i] << '\n';
+            os << name << '{' << k << "} = [\n";
+
+            for (auto n = x.size(), i = 0*n; i < n; ++i) {
+                os << x[i] << ' ' << y[i] << '\n';
+            }
+
+            os << "];\n\n";
+            k += 1;
         }
-
-        os << "];\n\n";
 
         os.setf(oflags);
         os.precision(oprec);
@@ -81,7 +85,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, useEPS);
 
-        printGraph(std::cout, "krg", graph[0]);
+        printGraph(std::cout, "krg", graph);
     }
 
     void krog(const Opm::ECLSaturationFunc& sfunc,
@@ -103,7 +107,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, useEPS);
 
-        printGraph(std::cout, "krog", graph[0]);
+        printGraph(std::cout, "krog", graph);
     }
 
     void krow(const Opm::ECLSaturationFunc& sfunc,
@@ -125,7 +129,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, useEPS);
 
-        printGraph(std::cout, "krow", graph[0]);
+        printGraph(std::cout, "krow", graph);
     }
 
     void krw(const Opm::ECLSaturationFunc& sfunc,
@@ -147,7 +151,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, useEPS);
 
-        printGraph(std::cout, "krw", graph[0]);
+        printGraph(std::cout, "krw", graph);
     }
 
     // -----------------------------------------------------------------

--- a/opm/utility/ECLCaseUtilities.cpp
+++ b/opm/utility/ECLCaseUtilities.cpp
@@ -1,3 +1,22 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include <opm/utility/ECLCaseUtilities.hpp>
 
 #include <exception>

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -265,40 +265,7 @@ Opm::ECLPVT::PVDx::viscosity(const std::vector<double>& p) const
 Opm::FlowDiagnostics::Graph
 Opm::ECLPVT::PVDx::getPvtCurve(const RawCurve curve) const
 {
-    assert ((curve == RawCurve::FVF) ||
-            (curve == RawCurve::Viscosity));
-
-    const auto colID = (curve == RawCurve::FVF)
-        ? std::size_t{0} : std::size_t{1};
-
-    auto x = this->interp_.independentVariable();
-    auto y = this->interp_.resultVariable(colID);
-
-    assert ((x.size() == y.size()) && "Setup Error");
-
-    // Post-process ordinates according to which curve is requested.
-    if (curve == RawCurve::FVF) {
-        // y == 1/B.  Convert to proper FVF.
-        for (auto& yi : y) {
-            yi = 1.0 / yi;
-        }
-    }
-    else {
-        // y == 1/(B*mu).  Extract viscosity term through the usual
-        // conversion formula:
-        //
-        //    (1 / B) / (1 / (B*mu)).
-        const auto b = this->interp_.resultVariable(0); // 1/B
-
-        assert ((b.size() == y.size()) && "Setup Error");
-
-        for (auto n = y.size(), i = 0*n; i < n; ++i) {
-            y[i] = b[i] / y[i];
-        }
-    }
-
-    // Graph == pair<vector<double>, vector<double>>
-    return FlowDiagnostics::Graph { std::move(x), std::move(y) };
+    return extractRawPVTCurve(this->interp_, curve);
 }
 
 // =====================================================================

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -296,6 +296,9 @@ namespace Opm { namespace ECLPVT {
 
         /// Viscosity
         Viscosity,
+
+        /// Enveloping curve for saturated state (wet gas or live oil)
+        SaturatedState,
     };
 
     template <std::size_t N>
@@ -674,6 +677,20 @@ namespace Opm { namespace ECLPVT {
             }
 
             return ret;
+        }
+
+        std::vector<double> getSaturatedPoints() const
+        {
+            auto y = std::vector<double>{};
+            y.reserve(this->propInterp_.size());
+
+            for (const auto& interp : this->propInterp_) {
+                const auto& yi = interp.independentVariable();
+
+                y.push_back(yi[0]);
+            }
+
+            return y;
         }
 
     private:

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -645,6 +645,37 @@ namespace Opm { namespace ECLPVT {
             });
         }
 
+        /// Retrieve 2D graph representation PVT property function.
+        ///
+        /// \param[in] curve PVT property curve descriptor
+        ///
+        /// \return Collection of 2D graphs for PVT property curve
+        ///    identified by requests represented by \p func.
+        ///
+        /// \return Collection of 2D graphs for PVT property curve
+        ///    identified by requests represented by \p curve.  One curve
+        ///    (vector element) for each tabulated value of the function's
+        ///    primary lookup key.
+        ///
+        /// Example: Retrieve formation volume factor curves.
+        ///
+        ///    \code
+        ///       const auto graph =
+        ///           pvtx.getPvtCurve(ECLPVT::RawCurve::FVF);
+        ///    \endcode
+        std::vector<FlowDiagnostics::Graph>
+        getPvtCurve(const RawCurve curve) const
+        {
+            auto ret = std::vector<FlowDiagnostics::Graph>{};
+            ret.reserve(this->propInterp_.size());
+
+            for (const auto& interp : this->propInterp_) {
+                ret.push_back(extractRawPVTCurve(interp, curve));
+            }
+
+            return ret;
+        }
+
     private:
         using InnerEvalPoint = typename std::decay<
             decltype(std::declval<SubtableInterpolant>().classifyPoint(0.0))

--- a/opm/utility/ECLPvtCurveCollection.cpp
+++ b/opm/utility/ECLPvtCurveCollection.cpp
@@ -1,3 +1,22 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include <opm/utility/ECLPvtCurveCollection.hpp>
 
 #include <opm/utility/ECLResultData.hpp>

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -46,9 +46,46 @@ namespace Opm { namespace ECLPVT {
     class ECLPvtCurveCollection
     {
     public:
+        /// Constructor
+        ///
+        /// \param[in] G Connected topology of current model's active cells.
+        ///    Needed to linearise region mapping (e.g., SATNUM) that is
+        ///    distributed on local grids to all of the model's active cells
+        ///    (\code member function G.rawLinearisedCellData() \endcode).
+        ///
+        /// \param[in] init Container of tabulated PVT functions for all PVT
+        ///    regions in the model \p G.
         ECLPvtCurveCollection(const ECLGraph&        G,
                               const ECLInitFileData& init);
 
+        /// Retrieve 2D graph representation of Phase PVT property function
+        /// in a specific active cell.
+        ///
+        /// \param[in] curve PVT property curve descriptor
+        ///
+        /// \param[in] phase Phase for which to compute extract graph
+        ///    representation of PVT property function.
+        ///
+        /// \param[in] activeCell Index of particular active cell in model..
+        ///
+        /// \return Collection of 2D graphs for PVT property curve
+        ///    identified by requests represented by \p curve, \p phase and
+        ///    \p activeCell.  One curve (vector element) for each tabulated
+        ///    node of the primary look-up key.  Single curve (i.e., a
+        ///    single element vector) in the case of dry gas (no vaporised
+        ///    oil) or dead oil (no dissolved gas).
+        ///
+        ///    No curves for water or dead oil with constant compressibility
+        ///    (i.e., keyword 'PVCDO' in the input deck).
+        ///
+        /// Example: Retrieve collection of gas viscosity curves pertaining
+        ///    to model's active cell 31415.
+        ///
+        ///    \code
+        ///       const auto curves =
+        ///           pvtCC.getPvtCurve(ECLPVT::RawCurve::Viscosity,
+        ///                             ECLPhaseIndex::Vapour, 31415);
+        ///    \endcode
         std::vector<FlowDiagnostics::Graph>
         getPvtCurve(const RawCurve      curve,
                     const ECLPhaseIndex phase,

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -25,6 +25,7 @@
 #include <opm/utility/ECLPvtCommon.hpp>
 #include <opm/utility/ECLPvtGas.hpp>
 #include <opm/utility/ECLPvtOil.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
 
 #include <memory>
 #include <vector>
@@ -62,6 +63,9 @@ namespace Opm { namespace ECLPVT {
 
         /// Oil PVT property evaluator.
         std::shared_ptr<Oil> oil_;
+
+        /// Unit handling (SI -> result-set convention)
+        std::shared_ptr<const ECLUnits::UnitSystem> usys_;
     };
 
 }} // Opm::ECLPVT

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -48,7 +48,7 @@ namespace Opm { namespace ECLPVT {
         ECLPvtCurveCollection(const ECLGraph&        G,
                               const ECLInitFileData& init);
 
-        FlowDiagnostics::Graph
+        std::vector<FlowDiagnostics::Graph>
         getPvtCurve(const RawCurve      curve,
                     const ECLPhaseIndex phase,
                     const int           activeCell) const;

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -188,12 +188,9 @@ public:
     }
 
     virtual std::vector<Opm::FlowDiagnostics::Graph>
-    getPvtCurve(const Opm::ECLPVT::RawCurve /* curve */) const override
+    getPvtCurve(const Opm::ECLPVT::RawCurve curve) const override
     {
-        throw std::runtime_error {
-            "Property Evaluator for Wet Gas Does not "
-            "Support Retrieving Raw Curves (Blame BSKA)"
-        };
+        return this->interp_.getPvtCurve(curve);
     }
 
     virtual std::unique_ptr<PVxGBase> clone() const override

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -95,7 +95,7 @@ public:
     viscosity(const std::vector<double>& rv,
               const std::vector<double>& pg) const = 0;
 
-    virtual Opm::FlowDiagnostics::Graph
+    virtual std::vector<Opm::FlowDiagnostics::Graph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const = 0;
 
     virtual std::unique_ptr<PVxGBase> clone() const = 0;
@@ -130,10 +130,10 @@ public:
         return this->interpolant_.viscosity(pg);
     }
 
-    virtual Opm::FlowDiagnostics::Graph
+    virtual std::vector<Opm::FlowDiagnostics::Graph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const override
     {
-        return this->interpolant_.getPvtCurve(curve);
+        return { this->interpolant_.getPvtCurve(curve) };
     }
 
     virtual std::unique_ptr<PVxGBase> clone() const override
@@ -187,7 +187,7 @@ public:
         return this->interp_.viscosity(key, x);
     }
 
-    virtual Opm::FlowDiagnostics::Graph
+    virtual std::vector<Opm::FlowDiagnostics::Graph>
     getPvtCurve(const Opm::ECLPVT::RawCurve /* curve */) const override
     {
         throw std::runtime_error {
@@ -391,7 +391,7 @@ public:
         return this->rhoS_[region];
     }
 
-    FlowDiagnostics::Graph
+    std::vector<FlowDiagnostics::Graph>
     getPvtCurve(const RegIdx   region,
                 const RawCurve curve) const;
 
@@ -460,7 +460,7 @@ viscosity(const RegIdx               region,
     return this->eval_[region]->viscosity(rv, pg);
 }
 
-Opm::FlowDiagnostics::Graph
+std::vector<Opm::FlowDiagnostics::Graph>
 Opm::ECLPVT::Gas::Impl::
 getPvtCurve(const RegIdx   region,
             const RawCurve curve) const
@@ -543,7 +543,7 @@ double Opm::ECLPVT::Gas::surfaceMassDensity(const int region) const
     return this->pImpl_->surfaceMassDensity(region);
 }
 
-Opm::FlowDiagnostics::Graph
+std::vector<Opm::FlowDiagnostics::Graph>
 Opm::ECLPVT::Gas::
 getPvtCurve(const RawCurve curve, const int region) const
 {

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/flowdiagnostics/DerivedQuantities.hpp>
 #include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
 
 #include <memory>
 #include <vector>
@@ -161,6 +162,11 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] region Region ID.  Non-negative integer typically
         ///    derived from the PVTNUM mapping vector.
         ///
+        /// \param[in] usys Unit system.  Collection of units to which the
+        ///    raw, tabulated PVT curve data will be converted.  Usually
+        ///    created by function \code ECLUnits::createUnitSystem()
+        ///    \endcode or a similar facility.
+        ///
         /// \return Collection of 2D graphs for PVT property curve
         ///    identified by requests represented by \p func and \p region.
         ///    One curve (vector element) for each pressure node.  Single
@@ -175,7 +181,9 @@ namespace Opm { namespace ECLPVT {
         ///           pvtGas.getPvtCurve(ECLPVT::RawCurve::FVF, 0);
         ///    \endcode
         std::vector<FlowDiagnostics::Graph>
-        getPvtCurve(const RawCurve curve, const int region) const;
+        getPvtCurve(const RawCurve              curve,
+                    const int                   region,
+                    const ECLUnits::UnitSystem& usys) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -161,8 +161,11 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] region Region ID.  Non-negative integer typically
         ///    derived from the PVTNUM mapping vector.
         ///
-        /// \return 2D graph for PVT property curve identified by
-        ///    requests represented by \p func and \p region.
+        /// \return Collection of 2D graphs for PVT property curve
+        ///    identified by requests represented by \p func and \p region.
+        ///    One curve (vector element) for each pressure node.  Single
+        ///    curve (i.e., a single vector element) in the case of dry gas
+        ///    (no vaporised oil).
         ///
         /// Example: Retrieve gas formation volume factor curve in PVT
         ///    region 0 (zero based, i.e., cells for which PVTNUM==1).
@@ -171,7 +174,7 @@ namespace Opm { namespace ECLPVT {
         ///       const auto graph =
         ///           pvtGas.getPvtCurve(ECLPVT::RawCurve::FVF, 0);
         ///    \endcode
-        FlowDiagnostics::Graph
+        std::vector<FlowDiagnostics::Graph>
         getPvtCurve(const RawCurve curve, const int region) const;
 
     private:

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -185,12 +185,9 @@ public:
     }
 
     virtual std::vector<Opm::FlowDiagnostics::Graph>
-    getPvtCurve(const Opm::ECLPVT::RawCurve /* curve */) const override
+    getPvtCurve(const Opm::ECLPVT::RawCurve curve) const override
     {
-        throw std::runtime_error {
-            "Property Evaluator for Live Oil Does not "
-            "Support Retrieving Raw Curves (Blame BSKA)"
-        };
+        return this->interp_.getPvtCurve(curve);
     }
 
     virtual std::unique_ptr<PVxOBase> clone() const override

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -92,7 +92,7 @@ public:
     viscosity(const std::vector<double>& rs,
               const std::vector<double>& po) const = 0;
 
-    virtual Opm::FlowDiagnostics::Graph
+    virtual std::vector<Opm::FlowDiagnostics::Graph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const = 0;
 
     virtual std::unique_ptr<PVxOBase> clone() const = 0;
@@ -127,10 +127,10 @@ public:
         return this->interpolant_.viscosity(po);
     }
 
-    virtual Opm::FlowDiagnostics::Graph
+    virtual std::vector<Opm::FlowDiagnostics::Graph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const override
     {
-        return this->interpolant_.getPvtCurve(curve);
+        return { this->interpolant_.getPvtCurve(curve) };
     }
 
     virtual std::unique_ptr<PVxOBase> clone() const override
@@ -184,7 +184,7 @@ public:
         return this->interp_.viscosity(key, x);
     }
 
-    virtual Opm::FlowDiagnostics::Graph
+    virtual std::vector<Opm::FlowDiagnostics::Graph>
     getPvtCurve(const Opm::ECLPVT::RawCurve /* curve */) const override
     {
         throw std::runtime_error {
@@ -388,7 +388,7 @@ public:
         return this->rhoS_[region];
     }
 
-    FlowDiagnostics::Graph
+    std::vector<FlowDiagnostics::Graph>
     getPvtCurve(const RegIdx   region,
                 const RawCurve curve) const;
 
@@ -457,7 +457,7 @@ viscosity(const RegIdx               region,
     return this->eval_[region]->viscosity(rs, po);
 }
 
-Opm::FlowDiagnostics::Graph
+std::vector<Opm::FlowDiagnostics::Graph>
 Opm::ECLPVT::Oil::Impl::
 getPvtCurve(const RegIdx   region,
             const RawCurve curve) const
@@ -540,7 +540,7 @@ double Opm::ECLPVT::Oil::surfaceMassDensity(const int region) const
     return this->pImpl_->surfaceMassDensity(region);
 }
 
-Opm::FlowDiagnostics::Graph
+std::vector<Opm::FlowDiagnostics::Graph>
 Opm::ECLPVT::Oil::
 getPvtCurve(const RawCurve curve, const int region) const
 {

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -21,6 +21,7 @@
 #define OPM_ECLPVTOIL_HEADER_INCLUDED
 
 #include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
 
 #include <memory>
 #include <vector>
@@ -158,6 +159,11 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] region Region ID.  Non-negative integer typically
         ///    derived from the PVTNUM mapping vector.
         ///
+        /// \param[in] usys Unit system.  Collection of units to which the
+        ///    raw, tabulated PVT curve data will be converted.  Usually
+        ///    created by function \code ECLUnits::createUnitSystem()
+        ///    \endcode or a similar facility.
+        ///
         /// \return Collection of 2D graphs for PVT property curve
         ///    identified by requests represented by \p func and \p region.
         ///    One curve (vector element) for each dissolved gas/oil ratio
@@ -172,7 +178,9 @@ namespace Opm { namespace ECLPVT {
         ///           pvtOil.getPvtCurve(ECLPVT::RawCurve::Viscosity, 3);
         ///    \endcode
         std::vector<FlowDiagnostics::Graph>
-        getPvtCurve(const RawCurve curve, const int region) const;
+        getPvtCurve(const RawCurve              curve,
+                    const int                   region,
+                    const ECLUnits::UnitSystem& usys) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -158,8 +158,11 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] region Region ID.  Non-negative integer typically
         ///    derived from the PVTNUM mapping vector.
         ///
-        /// \return 2D graph for PVT property curve identified by
-        ///    requests represented by \p func and \p region.
+        /// \return Collection of 2D graphs for PVT property curve
+        ///    identified by requests represented by \p func and \p region.
+        ///    One curve (vector element) for each dissolved gas/oil ratio
+        ///    node.  Single curve (i.e., a single vector element) in the
+        ///    case of dead oil (no dissolved gas).
         ///
         /// Example: Retrieve oil viscosity curve in PVT region 3 (zero
         ///    based, i.e., those cells for which PVTNUM==4).
@@ -168,7 +171,7 @@ namespace Opm { namespace ECLPVT {
         ///       const auto graph =
         ///           pvtOil.getPvtCurve(ECLPVT::RawCurve::Viscosity, 3);
         ///    \endcode
-        FlowDiagnostics::Graph
+        std::vector<FlowDiagnostics::Graph>
         getPvtCurve(const RawCurve curve, const int region) const;
 
     private:


### PR DESCRIPTION
This change-set extends function
```C++
ECLPvtCurveCollection::getPvtCurve()
```
to support retrieving the viscosity or formation-volume factor also in the case of miscible property descriptions (input keywords `PVTG` or `PVTO`).  We furthermore ensure that we return the raw table data according to the unit conventions of the "INIT" result set and provide a specialised query for retrieving the enveloping "saturated state" functions `RvSat(Pg)` and `RsSat(Po)`.  These are interesting in their own right and the former is more or less required when producing a graphical representation of a dynamic property in a diagram versus phase pressure.