### PR TITLE
Saturation Functions: Return KroX as Function of Sx

### DIFF
--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -94,6 +94,31 @@ namespace {
 
         return satnum;
     }
+
+    Opm::FlowDiagnostics::Graph
+    transformOilCurve(const Opm::FlowDiagnostics::Graph& curve,
+                      const double                       So_offset)
+    {
+        auto Sx = std::vector<double>{};  Sx.reserve(curve.first.size());
+        {
+            const auto& So = curve.first;
+
+            std::transform(So.rbegin(), So.rend(), std::back_inserter(Sx),
+                           [So_offset](const double so)
+                           {
+                               return So_offset - so;
+                           });
+        }
+
+        auto y = std::vector<double>{};  y.reserve(curve.second.size());
+        {
+            const auto& val = curve.second;
+
+            std::copy(val.rbegin(), val.rend(), std::back_inserter(y));
+        }
+
+        return { std::move(Sx), std::move(y) };
+    }
 } // Anonymous
 
 // =====================================================================
@@ -1300,10 +1325,15 @@ getSatFuncCurve(const std::vector<RawCurve>& func,
                     .reset(new ECLRegionMapping(this->satnum_, subset));
             }
 
-            auto kro = this->kroCurve(*oil_assoc.second, regID,
-                                      fi.subsys, oil_assoc.first, useEPS);
+            const auto kro =
+                this->kroCurve(*oil_assoc.second, regID,
+                               fi.subsys, oil_assoc.first, useEPS);
 
-            graph.push_back(std::move(kro));
+            const auto So_off = (fi.subsys == RawCurve::SubSystem::OilGas)
+                ? oil_assoc.first.back() // Sg = Max{So} - So in G/O system
+                : 1.0;                   // Sw = 1.0 - So     in O/W system
+
+            graph.push_back(transformOilCurve(kro, So_off));
         }
         break;
 

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -110,12 +110,10 @@ namespace {
                            });
         }
 
-        auto y = std::vector<double>{};  y.reserve(curve.second.size());
-        {
-            const auto& val = curve.second;
-
-            std::copy(val.rbegin(), val.rend(), std::back_inserter(y));
-        }
+        auto y = std::vector<double>{
+            curve.second.rbegin(),
+            curve.second.rend()
+        };
 
         return { std::move(Sx), std::move(y) };
     }


### PR DESCRIPTION
This commit introduces a slight transformation of the relative permeability functions for oil (i.e., `Krog` and `Krow`) to ensure that these are given as functions of the corresponding "other" phase saturation (i.e., `Krog = Krog(Sg)` and `Krow = Krow(Sw)`) rather than as functions of oil saturation.

These functions are **stored** in the INIT result set as functions of So, but it is customary to present them as functions of Sg or Sw in the context a graphical outputs.