### PR TITLE
ECL PVT: Calculated FVF and Viscosity per Cell

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -25,6 +25,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/utility/ECLEndPointScaling.cpp
         opm/utility/ECLFluxCalc.cpp
         opm/utility/ECLGraph.cpp
+        opm/utility/ECLPropertyUnitConversion.cpp
         opm/utility/ECLPropTable.cpp
         opm/utility/ECLPvtCommon.cpp
         opm/utility/ECLPvtCurveCollection.cpp
@@ -41,6 +42,7 @@ list (APPEND MAIN_SOURCE_FILES
 
 list (APPEND TEST_SOURCE_FILES
         tests/test_eclendpointscaling.cpp
+        tests/test_eclpropertyunitconversion.cpp
         tests/test_eclproptable.cpp
         tests/test_eclpvtcommon.cpp
         tests/test_eclregionmapping.cpp
@@ -69,6 +71,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/utility/ECLGraph.hpp
         opm/utility/ECLPhaseIndex.hpp
         opm/utility/ECLPiecewiseLinearInterpolant.hpp
+        opm/utility/ECLPropertyUnitConversion.hpp
         opm/utility/ECLPropTable.hpp
         opm/utility/ECLPvtCommon.hpp
         opm/utility/ECLPvtCurveCollection.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -54,6 +54,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
         examples/computePhaseFluxes.cpp
         examples/computeToFandTracers.cpp
         examples/computeTracers.cpp
+        examples/dynamicCellProperty.cpp
         examples/extractFromRestart.cpp
         examples/extractPropCurves.cpp
         tests/runAcceptanceTest.cpp

--- a/examples/dynamicCellProperty.cpp
+++ b/examples/dynamicCellProperty.cpp
@@ -1,0 +1,238 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <examples/exampleSetup.hpp>
+
+#include <opm/utility/ECLCaseUtilities.hpp>
+#include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLPvtCurveCollection.hpp>
+#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+namespace {
+    void openRestartSet(const Opm::ECLCaseUtilities::ResultSet& rset,
+                        const int                               step,
+                        std::unique_ptr<Opm::ECLRestartData>&   rstrt)
+    {
+        if (! (rset.isUnifiedRestart() && rstrt)) {
+            // Not a unified restart file or this is the first time we're
+            // seeing the result set.
+            rstrt.reset(new Opm::ECLRestartData(rset.restartFile(step)));
+        }
+    }
+}
+
+struct CellState
+{
+    CellState(const Opm::ECLGraph&                    G,
+              const Opm::ECLCaseUtilities::ResultSet& rset,
+              const int                               cellID_);
+
+    int                 cellID;
+    std::vector<double> time;
+    std::vector<double> Po;
+    std::vector<double> Rs;
+    std::vector<double> Rv;
+};
+
+CellState::CellState(const Opm::ECLGraph&                    G,
+                     const Opm::ECLCaseUtilities::ResultSet& rset,
+                     const int                               cellID_)
+    : cellID(cellID_)
+{
+    const auto u_press = &Opm::ECLUnits::UnitSystem::pressure;
+    const auto u_Rs    = &Opm::ECLUnits::UnitSystem::dissolvedGasOilRat;
+    const auto u_Rv    = &Opm::ECLUnits::UnitSystem::vaporisedOilGasRat;
+
+    const auto rsteps = rset.reportStepIDs();
+
+    this->time.reserve(rsteps.size());
+    this->Po  .reserve(rsteps.size());
+    this->Rs  .reserve(rsteps.size());
+    this->Rv  .reserve(rsteps.size());
+
+    auto rstrt = std::unique_ptr<Opm::ECLRestartData>{};
+
+    for (const auto& step : rsteps) {
+        openRestartSet(rset, step, rstrt);
+
+        rstrt->selectReportStep(step);
+
+        this->time.push_back(example::simulationTime(*rstrt));
+
+        {
+            const auto& Po =
+                G.linearisedCellData(*rstrt, "PRESSURE", u_press);
+
+            this->Po.push_back(Po[cellID]);
+        }
+
+        {
+            const auto& R = G.linearisedCellData(*rstrt, "RS", u_Rs);
+
+            this->Rs.push_back(R.empty() ? 0.0 : R[cellID]);
+        }
+
+        {
+            const auto& R = G.linearisedCellData(*rstrt, "RV", u_Rv);
+
+            this->Rv.push_back(R.empty() ? 0.0 : R[cellID]);
+        }
+    }
+}
+
+struct Property
+{
+    std::string         name;
+    std::vector<double> data;
+};
+
+namespace {
+
+    // -----------------------------------------------------------------------
+    // Gas Properties
+
+    std::vector<double>
+    Bg(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCC,
+       const CellState&                          x)
+    {
+        using RC = Opm::ECLPVT::RawCurve;
+        using PI = Opm::ECLPhaseIndex;
+
+        return pvtCC.getDynamicProperty(RC::FVF, PI::Vapour,
+                                        x.cellID, x.Po, x.Rv);
+    }
+
+    std::vector<double>
+    mu_g(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCC,
+         const CellState&                          x)
+    {
+        using RC = Opm::ECLPVT::RawCurve;
+        using PI = Opm::ECLPhaseIndex;
+
+        return pvtCC.getDynamicProperty(RC::Viscosity, PI::Vapour,
+                                        x.cellID, x.Po, x.Rv);
+    }
+
+    // -----------------------------------------------------------------------
+    // Oil Properties
+
+    std::vector<double>
+    Bo(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCC,
+       const CellState&                          x)
+    {
+        using RC = Opm::ECLPVT::RawCurve;
+        using PI = Opm::ECLPhaseIndex;
+
+        return pvtCC.getDynamicProperty(RC::FVF, PI::Liquid,
+                                        x.cellID, x.Po, x.Rs);
+    }
+
+    std::vector<double>
+    mu_o(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCC,
+         const CellState&                          x)
+    {
+        using RC = Opm::ECLPVT::RawCurve;
+        using PI = Opm::ECLPhaseIndex;
+
+        return pvtCC.getDynamicProperty(RC::Viscosity, PI::Liquid,
+                                        x.cellID, x.Po, x.Rs);
+    }
+
+    using DynProp = std::vector<double>
+        (*)(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCC,
+            const CellState&                          x);
+
+    std::map<std::string, DynProp> enumerateProperties()
+    {
+        return {
+            { "Bg"   , &Bg   },
+            { "mu_g" , &mu_g },
+            { "Bo"   , &Bo   },
+            { "mu_o" , &mu_o },
+        };
+    }
+
+    void writeVector(const std::vector<double>& x, const std::string& var)
+    {
+        std::cout << var << " = [\n";
+
+        for (const auto& xi : x) {
+            std::cout << "  " << xi << '\n';
+        }
+
+        std::cout << "]\n\n";
+    }
+
+    void writeResults(const CellState& x, const std::vector<Property>& props)
+    {
+        writeVector(x.time, "time");
+        writeVector(x.Po  , "Po");
+        writeVector(x.Rs  , "Rs");
+        writeVector(x.Rv  , "Rv");
+
+        for (const auto& prop : props) {
+            writeVector(prop.data, prop.name);
+        }
+    }
+} // namespace Anonymous
+
+int main(int argc, char* argv[])
+try {
+    const auto prm    = example::initParam(argc, argv);
+    const auto cellID = prm.getDefault("cell", 0);
+
+    const auto rset  = example::identifyResultSet(prm);
+    const auto init  = Opm::ECLInitFileData(rset.initFile());
+    const auto graph = Opm::ECLGraph::load(rset.gridFile(), init);
+    const auto pvtCC = Opm::ECLPVT::ECLPvtCurveCollection(graph, init);
+
+    const auto x = CellState{ graph, rset, cellID };
+
+    auto props = std::vector<Property>{};
+
+    for (const auto& prop : enumerateProperties()) {
+        if (prm.getDefault(prop.first, false)) {
+            props.push_back(Property{ prop.first, (*prop.second)(pvtCC, x) });
+        }
+    }
+
+    if (! props.empty()) {
+        std::cout.precision(16);
+        std::cout.setf(std::ios_base::scientific);
+
+        writeResults(x, props);
+    }
+}
+catch (const std::exception& e) {
+    std::cerr << "Caught Exception: " << e.what() << '\n';
+
+    return EXIT_FAILURE;
+}

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -179,6 +179,19 @@ namespace example {
 
 
 
+    inline double simulationTime(const Opm::ECLRestartData& rstrt)
+    {
+        if (! rstrt.haveKeywordData("DOUBHEAD")) {
+            return -1.0;
+        }
+
+        const auto& doubhead = rstrt.keywordData<double>("DOUBHEAD");
+
+        // First item (.front()) is simulation time in days
+        return doubhead.front();
+    }
+
+
 
     inline Opm::FlowDiagnostics::Toolbox
     initToolbox(const Opm::ECLGraph& G)

--- a/opm/utility/ECLPropertyUnitConversion.cpp
+++ b/opm/utility/ECLPropertyUnitConversion.cpp
@@ -1,0 +1,437 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/utility/ECLPropertyUnitConversion.hpp>
+
+#include <opm/utility/ECLResultData.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <ert/ecl/ecl_kw_magic.h>
+
+#include <exception>
+#include <stdexcept>
+
+namespace detail {
+    template <class ResultSet>
+    std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+    serialisedUnitConventions(const ResultSet& rset)
+    {
+        // Use INTEHEAD from Main grid.  Reasonably safe.
+        const auto& ih = rset.template keywordData<int>(INTEHEAD_KW);
+
+        return ::Opm::ECLUnits::createUnitSystem(ih[ INTEHEAD_UNIT_INDEX ]);
+    }
+
+    struct SIUnits : public ::Opm::ECLUnits::UnitSystem
+    {
+    public:
+        virtual std::unique_ptr<Opm::ECLUnits::UnitSystem>
+        clone() const override
+        {
+            return std::unique_ptr<Opm::ECLUnits::UnitSystem> {
+                new SIUnits(*this)
+            };
+        }
+
+        virtual double density() const override
+        {
+            return 1.0;
+        }
+
+        virtual double depth() const override
+        {
+            return 1.0;
+        }
+
+        virtual double pressure() const override
+        {
+            return 1.0;
+        }
+
+        virtual double reservoirRate() const override
+        {
+            return 1.0;
+        }
+
+        virtual double reservoirVolume() const override
+        {
+            return 1.0;
+        }
+
+        virtual double surfaceVolumeGas() const override
+        {
+            return 1.0;
+        }
+
+        virtual double surfaceVolumeLiquid() const override
+        {
+            return 1.0;
+        }
+
+        virtual double time() const override
+        {
+            return 1.0;
+        }
+
+        virtual double transmissibility() const override
+        {
+            return 1.0;
+        }
+
+        virtual double viscosity() const override
+        {
+            return 1.0;
+        }
+    };
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::serialisedUnitConventions(const ECLRestartData& rstrt)
+{
+    return detail::serialisedUnitConventions(rstrt);
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::serialisedUnitConventions(const ECLInitFileData& init)
+{
+    return detail::serialisedUnitConventions(init);
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::internalUnitConventions()
+{
+    using UPtr = std::unique_ptr<const UnitSystem>;
+
+    return UPtr{ new detail::SIUnits{} };
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::metricUnitConventions()
+{
+    return ::Opm::ECLUnits::createUnitSystem(1);
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::fieldUnitConventions()
+{
+    return ::Opm::ECLUnits::createUnitSystem(2);
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::labUnitConventions()
+{
+    return ::Opm::ECLUnits::createUnitSystem(3);
+}
+
+std::unique_ptr<const Opm::ECLUnits::UnitSystem>
+Opm::ECLUnits::pvtmUnitConventions()
+{
+    return ::Opm::ECLUnits::createUnitSystem(4);
+}
+
+// =====================================================================
+// Class Convert::PhysicalQuantity::Impl
+// =====================================================================
+
+namespace {
+    std::unique_ptr<Opm::ECLUnits::UnitSystem>
+    conditionalClone(const Opm::ECLUnits::UnitSystem* usys)
+    {
+        if (usys == nullptr) {
+            return std::unique_ptr<Opm::ECLUnits::UnitSystem>{};
+        }
+
+        return usys->clone();
+    }
+}
+
+class Opm::ECLUnits::Convert::PhysicalQuantity::Impl
+{
+public:
+    Impl() {}
+
+    Impl(const Impl& rhs)
+        : from_(conditionalClone(rhs.from_.get()))
+        , to_  (conditionalClone(rhs.to_  .get()))
+    {}
+
+    Impl(Impl&& rhs)
+        : from_(std::move(rhs.from_))
+        , to_  (std::move(rhs.to_))
+    {}
+
+    Impl& operator=(const Impl& rhs)
+    {
+        this->from_ = conditionalClone(rhs.from_.get());
+        this->to_   = conditionalClone(rhs.to_  .get());
+
+        return *this;
+    }
+
+    Impl& operator=(Impl&& rhs)
+    {
+        this->from_ = std::move(rhs.from_);
+        this->to_   = std::move(rhs.to_);
+
+        return *this;
+    }
+
+    void from(const UnitSystem& usys)
+    {
+        this->from_ = usys.clone();
+    }
+
+    void to(const UnitSystem& usys)
+    {
+        this->to_ = usys.clone();
+    }
+
+    const UnitSystem* from() const
+    {
+        return this->from_.get();
+    }
+
+    const UnitSystem* to() const
+    {
+        return this->to_.get();
+    }
+
+private:
+    std::unique_ptr<UnitSystem> from_{ nullptr };
+    std::unique_ptr<UnitSystem> to_  { nullptr };
+};
+
+// =====================================================================
+// Class Convert::PhysicalQuantity
+// =====================================================================
+
+Opm::ECLUnits::Convert::PhysicalQuantity::PhysicalQuantity()
+    : pImpl_(new Impl{})
+{}
+
+Opm::ECLUnits::Convert::PhysicalQuantity::~PhysicalQuantity()
+{}
+
+Opm::ECLUnits::Convert::PhysicalQuantity::
+PhysicalQuantity(const PhysicalQuantity& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::ECLUnits::Convert::PhysicalQuantity::
+PhysicalQuantity(PhysicalQuantity&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::ECLUnits::Convert::PhysicalQuantity&
+Opm::ECLUnits::Convert::PhysicalQuantity::operator=(const PhysicalQuantity& rhs)
+{
+    this->pImpl_.reset(new Impl(*rhs.pImpl_));
+
+    return *this;
+}
+
+Opm::ECLUnits::Convert::PhysicalQuantity&
+Opm::ECLUnits::Convert::PhysicalQuantity::operator=(PhysicalQuantity&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
+Opm::ECLUnits::Convert::PhysicalQuantity&
+Opm::ECLUnits::Convert::PhysicalQuantity::from(const UnitSystem& usys)
+{
+    this->pImpl_->from(usys);
+
+    return *this;
+}
+
+Opm::ECLUnits::Convert::PhysicalQuantity&
+Opm::ECLUnits::Convert::PhysicalQuantity::to(const UnitSystem& usys)
+{
+    this->pImpl_->to(usys);
+
+    return *this;
+}
+
+const Opm::ECLUnits::UnitSystem*
+Opm::ECLUnits::Convert::PhysicalQuantity::from() const
+{
+    return this->pImpl_->from();
+}
+
+const Opm::ECLUnits::UnitSystem*
+Opm::ECLUnits::Convert::PhysicalQuantity::to() const
+{
+    return this->pImpl_->to();
+}
+
+// =====================================================================
+
+namespace {
+    void rescaleVector(const double factor, std::vector<double>& x)
+    {
+        for (auto& xi : x) {
+            xi *= factor;
+        }
+    }
+
+    void validateUnitConventions(const std::string&               name,
+                                 const Opm::ECLUnits::UnitSystem* from,
+                                 const Opm::ECLUnits::UnitSystem* to)
+    {
+        if (from == nullptr) {
+            throw std::invalid_argument {
+                "Cannot Perform " + name + " Value Unit Conversion "
+                "Without Known 'From' Unit System Convention"
+            };
+        }
+
+        if (to == nullptr) {
+            throw std::invalid_argument {
+                "Cannot Perform " + name + " Value Unit Conversion "
+                "Without Known 'To' Unit System Convention"
+            };
+        }
+    }
+
+    double calculateScaleFactor(const double from, const double to)
+    {
+        using namespace ::Opm::unit;
+
+        // "return from / to", essentially.
+        return convert::to(convert::from(1.0, from), to);
+    }
+} // namespace Anonymous
+
+// =====================================================================
+// class Convert::Pressure
+// =====================================================================
+
+void
+Opm::ECLUnits::Convert::Pressure::appliedTo(std::vector<double>& press) const
+{
+    const auto* from = this->from();
+    const auto* to   = this->to();
+
+    validateUnitConventions("Pressure", from, to);
+
+    const auto scaling =
+        calculateScaleFactor(from->pressure(), to->pressure());
+
+    rescaleVector(scaling, press);
+}
+
+// =====================================================================
+// class Convert::Viscosity
+// =====================================================================
+
+void
+Opm::ECLUnits::Convert::Viscosity::appliedTo(std::vector<double>& mu) const
+{
+    const auto* from = this->from();
+    const auto* to   = this->to();
+
+    validateUnitConventions("Viscosity", from, to);
+
+    const auto scaling =
+        calculateScaleFactor(from->viscosity(), to->viscosity());
+
+    rescaleVector(scaling, mu);
+}
+
+// =====================================================================
+// class Convert::GasFVF
+// =====================================================================
+
+void
+Opm::ECLUnits::Convert::GasFVF::appliedTo(std::vector<double>& Bg) const
+{
+    const auto* from = this->from();
+    const auto* to   = this->to();
+
+    validateUnitConventions("GasFVF", from, to);
+
+    const auto scaling =
+        calculateScaleFactor(from->reservoirVolume() / from->surfaceVolumeGas(),
+                             to  ->reservoirVolume() / to  ->surfaceVolumeGas());
+
+    rescaleVector(scaling, Bg);
+}
+
+// =====================================================================
+// class Convert::OilFVF
+// =====================================================================
+
+void
+Opm::ECLUnits::Convert::OilFVF::appliedTo(std::vector<double>& Bo) const
+{
+    const auto* from = this->from();
+    const auto* to   = this->to();
+
+    validateUnitConventions("OilFVF", from, to);
+
+    const auto scaling =
+        calculateScaleFactor(from->reservoirVolume() / from->surfaceVolumeLiquid(),
+                             to  ->reservoirVolume() / to  ->surfaceVolumeLiquid());
+
+    rescaleVector(scaling, Bo);
+}
+
+// =====================================================================
+// class Convert::DissolvedGasOilRatio
+// =====================================================================
+
+void
+Opm::ECLUnits::Convert::DissolvedGasOilRatio::
+appliedTo(std::vector<double>& Rs) const
+{
+    const auto* from = this->from();
+    const auto* to   = this->to();
+
+    validateUnitConventions("DissolvedGasOilRatio", from, to);
+
+    const auto scaling =
+        calculateScaleFactor(from->dissolvedGasOilRat(),
+                             to  ->dissolvedGasOilRat());
+
+    rescaleVector(scaling, Rs);
+}
+
+// =====================================================================
+// class Convert::VaporisedOilGasRatio
+// =====================================================================
+
+void
+Opm::ECLUnits::Convert::VaporisedOilGasRatio::
+appliedTo(std::vector<double>& Rv) const
+{
+    const auto* from = this->from();
+    const auto* to   = this->to();
+
+    validateUnitConventions("VaporisedOilGasRatio", from, to);
+
+    const auto scaling =
+        calculateScaleFactor(from->vaporisedOilGasRat(),
+                             to  ->vaporisedOilGasRat());
+
+    rescaleVector(scaling, Rv);
+}

--- a/opm/utility/ECLPropertyUnitConversion.hpp
+++ b/opm/utility/ECLPropertyUnitConversion.hpp
@@ -1,0 +1,467 @@
+/*
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECLPROPERTYUNITCONVERSION_HEADER_INCLUDED
+#define OPM_ECLPROPERTYUNITCONVERSION_HEADER_INCLUDED
+
+#include <memory>
+#include <vector>
+
+namespace Opm {
+
+    class ECLRestartData;
+    class ECLInitFileData;
+
+    namespace ECLUnits {
+
+        struct UnitSystem;
+
+        /// Construct a Unit System object corresponding to the main grid's
+        /// unit convention of a Restart result set.
+        ///
+        /// \param[in] rstrt ECL Restart data set from which to extract unit
+        ///    system convention (e.g., METRIC or FIELD).
+        ///
+        /// \return Unit System object corresponding to the main grid's
+        ///    system convention of the currently selected restart step.
+        std::unique_ptr<const UnitSystem>
+        serialisedUnitConventions(const ECLRestartData& rstrt);
+
+        /// Construct a Unit System object corresponding to the main grid's
+        /// unit convention of an INIT file result set.
+        ///
+        /// \param[in] init ECL INIT file data set from which to extract
+        ///    unit system convention (e.g., METRIC or FIELD).
+        ///
+        /// \return Unit System object corresponding to the main grid's
+        ///    system convention of the INIT file result set.
+        std::unique_ptr<const UnitSystem>
+        serialisedUnitConventions(const ECLInitFileData& init);
+
+        /// Construct a Unit System object corresponding to the module's
+        /// internal unit system convention (strict SI).
+        ///
+        /// \return Unit System object corresponding to the module's
+        ///    internal unit system convention (i.e., strict SI).
+        std::unique_ptr<const UnitSystem> internalUnitConventions();
+
+        /// Construct a Unit System object corresponding to ECLIPSE's
+        /// "METRIC" unit system convention.
+        ///
+        /// \return Unit System object corresponding to ECLIPSE's
+        ///    "METRIC" unit system convention.
+        std::unique_ptr<const UnitSystem> metricUnitConventions();
+
+        /// Construct a Unit System object corresponding to ECLIPSE's
+        /// "FIELD" unit system convention.
+        ///
+        /// \return Unit System object corresponding to ECLIPSE's
+        ///    "FIELD" unit system convention.
+        std::unique_ptr<const UnitSystem> fieldUnitConventions();
+
+        /// Construct a Unit System object corresponding to ECLIPSE's
+        /// "LAB" unit system convention.
+        ///
+        /// \return Unit System object corresponding to ECLIPSE's
+        ///    "LAB" unit system convention.
+        std::unique_ptr<const UnitSystem> labUnitConventions();
+
+        /// Construct a Unit System object corresponding to ECLIPSE's
+        /// "PVT-M" unit system convention.
+        ///
+        /// \return Unit System object corresponding to ECLIPSE's
+        ///    "PVT-M" unit system convention.
+        std::unique_ptr<const UnitSystem> pvtmUnitConventions();
+
+        /// Facility for converting the units of measure of selected
+        /// physcial quanties between user-specified systems of unit
+        /// convention.
+        struct Convert
+        {
+            /// Representation of a physical quantity
+            ///
+            /// Base class.  Resource management and operations common to
+            /// all particular/specific physical quantities.
+            class PhysicalQuantity
+            {
+            public:
+                /// Default constructor.
+                PhysicalQuantity();
+
+                /// Destructor.
+                virtual ~PhysicalQuantity();
+
+                /// Copy constructor.
+                ///
+                /// \param[in] rhs Existing physical quantity.
+                PhysicalQuantity(const PhysicalQuantity& rhs);
+
+                /// Move constructor.
+                ///
+                /// Subsumes the implementation of an existing Physical
+                /// Quantity.
+                ///
+                /// \param[in] rhs Existing physical quantity.  Does not
+                ///    have a valid implementation when the constructor
+                ///    completes.
+                PhysicalQuantity(PhysicalQuantity&& rhs);
+
+                /// Assignment operator
+                ///
+                /// \param[in] rhs Existing Physical Quantity.
+                ///
+                /// \return \code *this \endcode.
+                PhysicalQuantity& operator=(const PhysicalQuantity& rhs);
+
+                /// Move assignment operator.
+                ///
+                /// Subsumes the implementation of an existing object.
+                ///
+                /// \param[in] rhs Existing Physical Quantity.  Does not
+                ///    have a valid implementation when the assignment
+                ///    completes.
+                ///
+                /// \return \code *this \endcode.
+                PhysicalQuantity& operator=(PhysicalQuantity&& rhs);
+
+                /// Specify collection of units of measure of the inputs.
+                ///
+                /// \param[in] usys Collection of units of measure of inputs.
+                ///
+                /// \return \code *this \endcode.
+                PhysicalQuantity& from(const UnitSystem& usys);
+
+                /// Specify collection of units of measure of the output.
+                ///
+                /// \param[in] usys Collection of units of measure of outputs.
+                ///
+                /// \return \code *this \endcode.
+                PhysicalQuantity& to(const UnitSystem& usys);
+
+                /// Convert a physical quantity from its input unit of
+                /// measure to its output unit of measure.
+                ///
+                /// Must be overridden in derived classes.
+                ///
+                /// \param[in,out] x On input, a sequence of values of a
+                ///    physical quantities assumed to be defined in the
+                ///    input unit specified through \code from(usys)
+                ///    \endcode.  On output, the same seqeuence of values
+                ///    converted to the output unit of measure specified
+                ///    through \code to(usys) \endcode.
+                virtual void appliedTo(std::vector<double>& x) const = 0;
+
+            protected:
+                /// Retrieve input unit system.
+                ///
+                /// Exists for the benefit of derived classes.
+                ///
+                /// \return Input unit system.  Null if not specified by
+                ///    caller.
+                const UnitSystem* from() const;
+
+                /// Retrieve output unit system.
+                ///
+                /// Exists for the benefit of derived classes.
+                ///
+                /// \return Output unit system.  Null if not specified by
+                ///    caller.
+                const UnitSystem* to() const;
+
+            private:
+                /// Implementation class.
+                class Impl;
+
+                /// Pointer to implementation.
+                std::unique_ptr<Impl> pImpl_;
+            };
+
+            /// Facility for converting pressure values between
+            /// user-selected units of measure.
+            class Pressure : public PhysicalQuantity {
+            public:
+                /// Convert a sequence of pressure values from its input
+                /// unit of measure to its output unit of measure.
+                ///
+                /// Will throw an exception of type \code
+                /// std::invalid_argument \endcode unless both of the input
+                /// and output unit system conventions have been previously
+                /// specified.
+                ///
+                /// Example: Convert LGR-1's oil pressure values on restart
+                ///    step 123 from serialised format on disk (unified
+                ///    restart) to internal units of measure (SI).
+                /// \code
+                ///   const auto rstrt  = ECLRestartData{ "Case.UNRST" };
+                ///   const auto native = serialisedUnitConventions(rstrt);
+                ///   const auto si     = internalUnitConvention();
+                ///
+                ///   rstrt.selectReportStep(123);
+                ///   auto press = rstrt.keywordData<double>("PRESSURE", "LGR-1");
+                ///   Convert::Pressure().from(*native).to(*si).appliedTo(press);
+                /// \endcode
+                ///
+                /// \param[in,out] press On input, a sequence of pressure
+                ///    values assumed to be defined in the input unit
+                ///    specified through \code from(usys) \endcode.  On
+                ///    output, the same seqeuence of pressure values
+                ///    converted to the output unit of measure specified
+                ///    through \code to(usys) \endcode.
+                void appliedTo(std::vector<double>& press) const override;
+            };
+
+            /// Facility for converting viscosity values between
+            /// user-selected units of measure.
+            class Viscosity : public PhysicalQuantity {
+            public:
+                /// Convert a sequence of fluid phase viscosity values from
+                /// its input unit of measure to its output unit of measure.
+                ///
+                /// Will throw an exception of type \code
+                /// std::invalid_argument \endcode unless both of the input
+                /// and output unit system conventions have been previously
+                /// specified.
+                ///
+                /// Example: Compute the dynamic gas viscosity value in cell
+                ///    27182 on restart step 10 and report it in LAB units.
+                /// \code
+                ///   const auto rset  = ResultSet("Case.EGRID");
+                ///   const auto init  = ECLInitFileData{ rset.initFile() };
+                ///   const auto G     = ECLGraph.load(rset.gridFile(), init);
+                ///   const auto rstrt = ECLRestartData{ rset.restartFile(10) };
+                ///   const auto si    = internalUnitConvention();
+                ///   const auto lab   = labUnitConvention();
+                ///
+                ///   rstrt.selectReportStep(10);
+                ///   const auto press = G.linearisedCellData<double>
+                ///       (rstrt, "PRESSURE", &UnitSystem::pressure);
+                ///
+                ///   const auto rv = G.linearisedCellData<double>
+                ///       (rstrt, "RV", &UnitSystem::vaporisedOilGasRat);
+                ///
+                ///   const auto pvtCC = ECLPvtCurveCollection(G, init);
+                ///
+                ///   auto mu = pvtCC.getDynamicProperty(RawCurve::Viscosity,
+                ///       ECLPhaseIndex::Vapour, 27182,
+                ///       std::vector<double>{ press[27182] },
+                ///       std::vector<double>{ rv.empty() ? 0.0 : rv[27182] });
+                ///
+                ///   Convert::Viscosity().to(*lab).from(*si).appliedTo(mu);
+                /// \endcode
+                ///
+                /// \param[in,out] mu On input, a sequence of viscosity
+                ///    values assumed to be defined in the input unit
+                ///    specified through \code from(usys) \endcode.  On
+                ///    output, the same seqeuence of viscosity values
+                ///    converted to the output unit of measure specified
+                ///    through \code to(usys) \endcode.
+                void appliedTo(std::vector<double>& mu) const override;
+            };
+
+            /// Facility for converting gas phase formation volume factor
+            /// values between user-selected units of measure.
+            class GasFVF : public PhysicalQuantity {
+            public:
+                /// Convert a sequence of formation volume factor values for
+                /// the gas/vapour phase from its input unit of measure to
+                /// its output unit of measure.
+                ///
+                /// Will throw an exception of type \code
+                /// std::invalid_argument \endcode unless both of the input
+                /// and output unit system conventions have been previously
+                /// specified.
+                ///
+                /// Example: Compute the dynamic gas formation volume factor
+                ///    value in cell 57721 on restart step 314 and report it
+                ///    in Field units.
+                /// \code
+                ///   const auto rset  = ResultSet("Case.EGRID");
+                ///   const auto init  = ECLInitFileData{ rset.initFile() };
+                ///   const auto G     = ECLGraph.load(rset.gridFile(), init);
+                ///   const auto rstrt = ECLRestartData{ rset.restartFile(10) };
+                ///   const auto si    = internalUnitConvention();
+                ///   const auto field = fieldUnitConvention();
+                ///
+                ///   rstrt.selectReportStep(314);
+                ///   const auto press = G.linearisedCellData<double>
+                ///       (rstrt, "PRESSURE", &UnitSystem::pressure);
+                ///
+                ///   const auto rv = G.linearisedCellData<double>
+                ///       (rstrt, "RV", &UnitSystem::vaporisedOilGasRat);
+                ///
+                ///   const auto pvtCC = ECLPvtCurveCollection(G, init);
+                ///
+                ///   auto Bg = pvtCC.getDynamicProperty(RawCurve::FVF,
+                ///       ECLPhaseIndex::Vapour, 57721,
+                ///       std::vector<double>{ press[57721] },
+                ///       std::vector<double>{ rv.empty() ? 0.0 : rv[57721] });
+                ///
+                ///   Convert::GasFVF().to(*field).from(*si).appliedTo(Bg);
+                /// \endcode
+                ///
+                /// \param[in,out] Bg On input, a sequence of formation
+                ///    volume factor values for the gas phase assumed to be
+                ///    defined in the input unit specified through \code
+                ///    from(usys) \endcode.  On output, the same seqeuence
+                ///    of gas FVF values converted to the output unit of
+                ///    measure specified through \code to(usys) \endcode.
+                void appliedTo(std::vector<double>& Bg) const override;
+            };
+
+            /// Facility for converting oil phase formation volume factor
+            /// values between user-selected units of measure.
+            class OilFVF : public PhysicalQuantity {
+            public:
+                /// Convert a sequence of formation volume factor values for
+                /// the oil/liquid phase from its input unit of measure to
+                /// its output unit of measure.
+                ///
+                /// Will throw an exception of type \code
+                /// std::invalid_argument \endcode unless both of the input
+                /// and output unit system conventions have been previously
+                /// specified.
+                ///
+                /// Example: Extract the dynamic oil formation volume factor
+                ///    curve in cell 355,113 in native units (convention of
+                ///    serialised result set).
+                /// \code
+                ///   const auto rset   = ResultSet("Case.EGRID");
+                ///   const auto init   = ECLInitFileData{ rset.initFile() };
+                ///   const auto G      = ECLGraph.load(rset.gridFile(), init);
+                ///   const auto si     = internalUnitConvention();
+                ///   const auto native = serialisedUnitConventions(init);
+                ///
+                ///   const auto pvtCC = ECLPvtCurveCollection(G, init);
+                ///
+                ///   auto BoCurves = pvtCC.getPvtCurve(RawCurve::FVF,
+                ///       ECLPhaseIndex::Liquid, 355113);
+                ///
+                ///   const auto cvrtPress =
+                ///       Convert::Pressure().to(*native).from(*si);
+                ///   const auto cvrtBo =
+                ///       Convert::OilFVF().to(*native).from(*si);
+                ///
+                ///   for (auto& curve : BoCurves) {
+                ///       cvrtPress.appliedTo(curve.first);
+                ///       cvrtBo   .appliedTo(curve.second);
+                ///   }
+                /// \endcode
+                ///
+                /// \param[in,out] Bo On input, a sequence of formation
+                ///    volume factor values for the oil phase assumed to be
+                ///    defined in the input unit specified through \code
+                ///    from(usys) \endcode.  On output, the same seqeuence
+                ///    of oil FVF values converted to the output unit of
+                ///    measure specified through \code to(usys) \endcode.
+                void appliedTo(std::vector<double>& Bo) const override;
+            };
+
+            /// Facility for converting dissolved gas/oil ratio (Rs) values
+            /// between user-selected units of measure.
+            class DissolvedGasOilRatio : public PhysicalQuantity {
+            public:
+                /// Convert a sequence of dissolved gas/oil ratio values
+                /// from its input unit of measure to its output unit of
+                /// measure.
+                ///
+                /// Will throw an exception of type \code
+                /// std::invalid_argument \endcode unless both of the input
+                /// and output unit system conventions have been previously
+                /// specified.
+                ///
+                /// Example: Extract the saturated state curve for oil in
+                ///    cell 14142 in PVT-M units.
+                /// \code
+                ///   const auto rset  = ResultSet("Case.EGRID");
+                ///   const auto init  = ECLInitFileData{ rset.initFile() };
+                ///   const auto G     = ECLGraph.load(rset.gridFile(), init);
+                ///   const auto si    = internalUnitConvention();
+                ///   const auto pvt_m = pvtmUnitConventions();
+                ///
+                ///   const auto pvtCC = ECLPvtCurveCollection(G, init);
+                ///
+                ///   const auto satState =
+                ///       pvtCC.getPvtCurve(RawCurve::SaturatedState,
+                ///           ECLPhaseIndex::Liquid, 14142);
+                ///
+                ///   Convert::DissolvedGasOilRatio().to(*pvt_m).from(*si)
+                ///       .appliedTo(satState.first);
+                ///
+                ///   Convert::Pressure().to(*pvt_m).from(*si)
+                ///       .appliedTo(satState.second);
+                /// \endcode
+                ///
+                /// \param[in,out] Rs On input, a sequence of dissolved
+                ///    gas/oil ratio values assumed to be defined in the
+                ///    input unit specified through \code from(usys)
+                ///    \endcode.  On output, the same seqeuence of oil Rs
+                ///    values converted to the output unit of measure
+                ///    specified through \code to(usys) \endcode.
+                void appliedTo(std::vector<double>& Rs) const override;
+            };
+
+            /// Facility for converting vaporised oil/gas ratio (Rv) values
+            /// between user-selected units of measure.
+            class VaporisedOilGasRatio : public PhysicalQuantity {
+            public:
+                /// Convert a sequence of vaporised oil/gas ratio values
+                /// from its input unit of measure to its output unit of
+                /// measure.
+                ///
+                /// Will throw an exception of type \code
+                /// std::invalid_argument \endcode unless both of the input
+                /// and output unit system conventions have been previously
+                /// specified.
+                ///
+                /// Example: Extract the saturated state curve for gas in
+                ///    cell 161803 in Metric units.
+                /// \code
+                ///   const auto rset   = ResultSet("Case.EGRID");
+                ///   const auto init   = ECLInitFileData{ rset.initFile() };
+                ///   const auto G      = ECLGraph.load(rset.gridFile(), init);
+                ///   const auto si     = internalUnitConvention();
+                ///   const auto metric = metricUnitConventions();
+                ///
+                ///   const auto pvtCC = ECLPvtCurveCollection(G, init);
+                ///
+                ///   const auto satState =
+                ///       pvtCC.getPvtCurve(RawCurve::SaturatedState,
+                ///           ECLPhaseIndex::Vapour, 161803);
+                ///
+                ///   Convert::Pressure().to(*metric).from(*si)
+                ///       .appliedTo(satState.first);
+                ///
+                ///   Convert::VaporisedOilGasRatio().to(*metric).from(*si)
+                ///       .appliedTo(satState.second);
+                /// \endcode
+                ///
+                /// \param[in,out] Rv On input, a sequence of vapourised
+                ///    oil/gas ratio values assumed to be defined in the
+                ///    input unit specified through \code from(usys)
+                ///    \endcode.  On output, the same seqeuence of gas Rv
+                ///    values converted to the output unit of measure
+                ///    specified through \code to(usys) \endcode.
+                void appliedTo(std::vector<double>& Rv) const override;
+            };
+        };
+
+    } // namespace ECLUnits
+} // namespace Opm
+
+#endif  // OPM_ECLPROPERTYUNITCONVERSION_HEADER_INCLUDED

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -265,6 +265,11 @@ Opm::ECLPVT::PVDx::viscosity(const std::vector<double>& p) const
 Opm::FlowDiagnostics::Graph
 Opm::ECLPVT::PVDx::getPvtCurve(const RawCurve curve) const
 {
+    if (curve == RawCurve::SaturatedState) {
+        // Not applicable to dry gas or dead oil.  Return empty.
+        return FlowDiagnostics::Graph{};
+    }
+
     return extractRawPVTCurve(this->interp_, curve);
 }
 

--- a/opm/utility/ECLPvtCommon.hpp
+++ b/opm/utility/ECLPvtCommon.hpp
@@ -669,28 +669,11 @@ namespace Opm { namespace ECLPVT {
         std::vector<FlowDiagnostics::Graph>
         getPvtCurve(const RawCurve curve) const
         {
-            auto ret = std::vector<FlowDiagnostics::Graph>{};
-            ret.reserve(this->propInterp_.size());
-
-            for (const auto& interp : this->propInterp_) {
-                ret.push_back(extractRawPVTCurve(interp, curve));
+            if (curve == RawCurve::SaturatedState) {
+                return this->saturatedStateCurve();
             }
 
-            return ret;
-        }
-
-        std::vector<double> getSaturatedPoints() const
-        {
-            auto y = std::vector<double>{};
-            y.reserve(this->propInterp_.size());
-
-            for (const auto& interp : this->propInterp_) {
-                const auto& yi = interp.independentVariable();
-
-                y.push_back(yi[0]);
-            }
-
-            return y;
+            return this->mainPvtCurve(curve);
         }
 
     private:
@@ -843,6 +826,37 @@ namespace Opm { namespace ECLPVT {
             }
 
             return result;
+        }
+
+        std::vector<FlowDiagnostics::Graph>
+        mainPvtCurve(const RawCurve curve) const
+        {
+            auto ret = std::vector<FlowDiagnostics::Graph>{};
+            ret.reserve(this->propInterp_.size());
+
+            for (const auto& interp : this->propInterp_) {
+                ret.push_back(extractRawPVTCurve(interp, curve));
+            }
+
+            return ret;
+        }
+
+        std::vector<FlowDiagnostics::Graph> saturatedStateCurve() const
+        {
+            auto y = std::vector<double>{};
+            y.reserve(this->propInterp_.size());
+
+            for (const auto& interp : this->propInterp_) {
+                const auto& yi = interp.independentVariable();
+
+                y.push_back(yi[0]);
+            }
+
+            return {
+                FlowDiagnostics::Graph {
+                    this->key_, std::move(y)
+                }
+            };
         }
     };
 

--- a/opm/utility/ECLPvtCurveCollection.cpp
+++ b/opm/utility/ECLPvtCurveCollection.cpp
@@ -19,13 +19,12 @@
 
 #include <opm/utility/ECLPvtCurveCollection.hpp>
 
+#include <opm/utility/ECLPropertyUnitConversion.hpp>
 #include <opm/utility/ECLResultData.hpp>
 
 #include <cassert>
 #include <initializer_list>
 #include <vector>
-
-#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <ert/ecl/ecl_kw_magic.h>
 
@@ -45,77 +44,59 @@ namespace {
         return pvtnum;
     }
 
-    std::unique_ptr<const Opm::ECLUnits::UnitSystem>
-    createUnitSystem(const ::Opm::ECLInitFileData& init)
-    {
-        const auto& ih = init.keywordData<int>(INTEHEAD_KW);
-
-        return ::Opm::ECLUnits::createUnitSystem(ih[ INTEHEAD_UNIT_INDEX ]);
-    }
-
     std::vector<Opm::FlowDiagnostics::Graph> emptyFDGraph()
     {
         return { Opm::FlowDiagnostics::Graph{} };
     }
 
-    template <class PvtPtr>
+    template <class PVTInterp>
     std::vector<Opm::FlowDiagnostics::Graph>
-    rawPvtCurve(PvtPtr&                          pvt, // ref to shared_ptr<>
-                const Opm::ECLPVT::RawCurve      curve,
-                const int                        regID,
-                const Opm::ECLUnits::UnitSystem& usys)
-    {
-        if (pvt != nullptr) {
-            return pvt->getPvtCurve(curve, regID, usys);
-        }
-
-        // Result set does not provide requisite tabulated properties.
-        // Return empty.
-        return emptyFDGraph();
-    }
-
-    std::vector<double>
-    fromSI(std::vector<double>&& x, const double x_scale)
-    {
-        for (auto& xi : x) {
-            xi = Opm::unit::convert::to(xi, x_scale);
-        }
-
-        return x;
-    }
-
-    template <class PVTInterp, class Pressure, class MixRatio>
-    std::vector<double>
-    formationVolumeFactor(const PVTInterp& pvt,
-                          const int        regID,
-                          const Pressure&  press,
-                          const MixRatio&  R,
-                          const double     fvfScale)
-    {
-        return fromSI(pvt.formationVolumeFactor(regID, R, press), fvfScale);
-    }
-
-    template <class PVTInterp, class Pressure, class MixRatio>
-    std::vector<double>
-    viscosity(const PVTInterp& pvt,
-              const int        regID,
-              const Pressure&  press,
-              const MixRatio&  R,
-              const double     muScale)
-    {
-        return fromSI(pvt.viscosity(regID, R, press), muScale);
-    }
-
-    std::vector<double>
-    gasProperty(const std::shared_ptr<Opm::ECLPVT::Gas>& pvt,
-                const Opm::ECLPVT::RawCurve              property,
-                const int                                regID,
-                const std::vector<double>&               Pg,
-                const std::vector<double>&               Rv,
-                const Opm::ECLUnits::UnitSystem&         usys)
+    rawPvtCurve(const PVTInterp*            pvt,
+                const Opm::ECLPVT::RawCurve curve,
+                const int                   regID)
     {
         if (pvt == nullptr) {
-            // Nu such property interpolant.  Return empty.
+            // Result set does not provide requisite tabulated properties.
+            // Return empty.
+            return emptyFDGraph();
+        }
+
+        return pvt->getPvtCurve(curve, regID);
+    }
+
+    template <class PVTInterp, class Pressure, class MixRatio>
+    std::vector<double>
+    formationVolumeFactor(const PVTInterp* pvt,
+                          const int        regID,
+                          const Pressure&  press,
+                          const MixRatio&  R)
+    {
+        assert (pvt != nullptr);
+
+        return pvt->formationVolumeFactor(regID, R, press);
+    }
+
+    template <class PVTInterp, class Pressure, class MixRatio>
+    std::vector<double>
+    viscosity(const PVTInterp* pvt,
+              const int        regID,
+              const Pressure&  press,
+              const MixRatio&  R)
+    {
+        assert (pvt != nullptr);
+
+        return pvt->viscosity(regID, R, press);
+    }
+
+    std::vector<double>
+    gasProperty(const Opm::ECLPVT::Gas*     pvt,
+                const Opm::ECLPVT::RawCurve property,
+                const int                   regID,
+                const std::vector<double>&  Pg,
+                const std::vector<double>&  Rv)
+    {
+        if (pvt == nullptr) {
+            // No such property interpolant.  Return empty.
             return {};
         }
 
@@ -129,25 +110,21 @@ namespace {
         }
 
         if (property == Opm::ECLPVT::RawCurve::FVF) {
-            const auto fvfScale = usys.reservoirVolume()
-                / usys.surfaceVolumeGas();
-
-            return formationVolumeFactor(*pvt, regID, pg, rv, fvfScale);
+            return formationVolumeFactor(pvt, regID, pg, rv);
         }
 
-        return viscosity(*pvt, regID, pg, rv, usys.viscosity());
+        return viscosity(pvt, regID, pg, rv);
     }
 
     std::vector<double>
-    oilProperty(const std::shared_ptr<Opm::ECLPVT::Oil>& pvt,
-                const Opm::ECLPVT::RawCurve              property,
-                const int                                regID,
-                const std::vector<double>&               Po,
-                const std::vector<double>&               Rs,
-                const Opm::ECLUnits::UnitSystem&         usys)
+    oilProperty(const Opm::ECLPVT::Oil*     pvt,
+                const Opm::ECLPVT::RawCurve property,
+                const int                   regID,
+                const std::vector<double>&  Po,
+                const std::vector<double>&  Rs)
     {
         if (pvt == nullptr) {
-            // Nu such property interpolant.  Return empty.
+            // No such property interpolant.  Return empty.
             return {};
         }
 
@@ -161,24 +138,148 @@ namespace {
         }
 
         if (property == Opm::ECLPVT::RawCurve::FVF) {
-            const auto fvfScale = usys.reservoirVolume()
-                / usys.surfaceVolumeLiquid();
-
-            return formationVolumeFactor(*pvt, regID, po, rs, fvfScale);
+            return formationVolumeFactor(pvt, regID, po, rs);
         }
 
-        return viscosity(*pvt, regID, po, rs, usys.viscosity());
+        return viscosity(pvt, regID, po, rs);
+    }
+
+    std::vector<Opm::FlowDiagnostics::Graph>
+    convertCurve(std::vector<Opm::FlowDiagnostics::Graph>&&      curves,
+                 const Opm::ECLUnits::Convert::PhysicalQuantity& cvrt_x,
+                 const Opm::ECLUnits::Convert::PhysicalQuantity& cvrt_y)
+    {
+        for (auto& curve : curves) {
+            cvrt_x.appliedTo(curve.first);
+            cvrt_y.appliedTo(curve.second);
+        }
+
+        return curves;
+    }
+
+    std::vector<Opm::FlowDiagnostics::Graph>
+    convertFvfCurve(std::vector<Opm::FlowDiagnostics::Graph>&& curve,
+                    const Opm::ECLPhaseIndex                   phase,
+                    const Opm::ECLUnits::UnitSystem&           usysFrom,
+                    const Opm::ECLUnits::UnitSystem&           usysTo)
+    {
+        assert ((phase == Opm::ECLPhaseIndex::Liquid) ||
+                (phase == Opm::ECLPhaseIndex::Vapour));
+
+        if (phase == Opm::ECLPhaseIndex::Liquid) {
+             // Oil FVF.  First column is pressure, second column is Bo.
+            const auto& cvrt_x = Opm::ECLUnits::Convert::Pressure()
+                .from(usysFrom).to(usysTo);
+
+            const auto& cvrt_y = Opm::ECLUnits::Convert::OilFVF()
+                .from(usysFrom).to(usysTo);
+
+            return convertCurve(std::move(curve), cvrt_x, cvrt_y);
+        }
+
+        // Gas FVF.  Need to distinguish miscible from immiscible cases.  In
+        // the former, the first column is Rv (vapourised oil/gas ratio) and
+        // in the second case the first column is the gas pressure.
+        //
+        // Immiscible case identified by curve.size() <= 1.
+
+        const auto& cvrt_y = Opm::ECLUnits::Convert::GasFVF()
+            .from(usysFrom).to(usysTo);
+
+        if (curve.size() <= 1) {
+            // Immiscible Gas FVF.  First column is Pg.
+            const auto& cvrt_x = Opm::ECLUnits::Convert::Pressure()
+                .from(usysFrom).to(usysTo);
+
+            return convertCurve(std::move(curve), cvrt_x, cvrt_y);
+        }
+
+        // Miscible Gas FVF.  First column is Rv.
+        const auto& cvrt_x = Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+            .from(usysFrom).to(usysTo);
+
+        return convertCurve(std::move(curve), cvrt_x, cvrt_y);
+    }
+
+    std::vector<Opm::FlowDiagnostics::Graph>
+    convertViscosityCurve(std::vector<Opm::FlowDiagnostics::Graph>&& curve,
+                          const Opm::ECLPhaseIndex                   phase,
+                          const Opm::ECLUnits::UnitSystem&           usysFrom,
+                          const Opm::ECLUnits::UnitSystem&           usysTo)
+    {
+        assert ((phase == Opm::ECLPhaseIndex::Liquid) ||
+                (phase == Opm::ECLPhaseIndex::Vapour));
+
+        // This is the viscosity curve.  Second column is always viscosity
+        // irrespective of phase or miscible/immiscible fluids.
+        const auto& cvrt_y = Opm::ECLUnits::Convert::Viscosity()
+            .from(usysFrom).to(usysTo);
+
+        if ((phase == Opm::ECLPhaseIndex::Liquid) || (curve.size() <= 1)) {
+             // Graph is oil viscosity or immiscible gas viscosity.  First
+             // column is pressure.
+            const auto& cvrt_x = Opm::ECLUnits::Convert::Pressure()
+                .from(usysFrom).to(usysTo);
+
+            return convertCurve(std::move(curve), cvrt_x, cvrt_y);
+        }
+
+        // Miscible Gas viscosity.  First column is Rv (vapourised oil/gas
+        // ratio).
+        const auto& cvrt_x = Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+            .from(usysFrom).to(usysTo);
+
+        return convertCurve(std::move(curve), cvrt_x, cvrt_y);
+    }
+
+    std::vector<Opm::FlowDiagnostics::Graph>
+    convertSatStateCurve(std::vector<Opm::FlowDiagnostics::Graph>&& curve,
+                         const Opm::ECLPhaseIndex                   phase,
+                         const Opm::ECLUnits::UnitSystem&           usysFrom,
+                         const Opm::ECLUnits::UnitSystem&           usysTo)
+    {
+        assert ((phase == Opm::ECLPhaseIndex::Liquid) ||
+                (phase == Opm::ECLPhaseIndex::Vapour));
+
+        // First column is pressure (Po or Pg).
+        const auto& cvrt_x = Opm::ECLUnits::Convert::Pressure()
+            .from(usysFrom).to(usysTo);
+
+        // Second column is Rs or Rv depending on 'phase'.
+        if (phase == Opm::ECLPhaseIndex::Liquid) {
+            // Saturated state curve for miscible oil.  Second column is Rs
+            // (dissolved gas/oil ratio).
+            const auto& cvrt_y = Opm::ECLUnits::Convert::
+                DissolvedGasOilRatio().from(usysFrom).to(usysTo);
+
+            return convertCurve(std::move(curve), cvrt_x, cvrt_y);
+        }
+
+        // Saturated state curve for miscible gas.  Second column is Rv
+        // (vapourised oil/gas ratio).
+        const auto& cvrt_y = Opm::ECLUnits::Convert::
+            VaporisedOilGasRatio().from(usysFrom).to(usysTo);
+
+        return convertCurve(std::move(curve), cvrt_x, cvrt_y);
     }
 }
 
 Opm::ECLPVT::ECLPvtCurveCollection::
 ECLPvtCurveCollection(const ECLGraph&        G,
                       const ECLInitFileData& init)
-    : pvtnum_(pvtnumVector(G, init))
-    , gas_   (CreateGasPVTInterpolant::fromECLOutput(init)) // u_p<> -> s_p<>
-    , oil_   (CreateOilPVTInterpolant::fromECLOutput(init)) // u_p<> -> s_p<>
-    , usys_  (createUnitSystem(init))                       // u_p<> -> s_p<>
+    : pvtnum_       (pvtnumVector(G, init))
+    , gas_          (CreateGasPVTInterpolant::fromECLOutput(init))
+    , oil_          (CreateOilPVTInterpolant::fromECLOutput(init))
+    , usys_native_  (ECLUnits::serialisedUnitConventions(init))
+    , usys_internal_(ECLUnits::internalUnitConventions())
 {}
+
+void
+Opm::ECLPVT::ECLPvtCurveCollection::
+setOutputUnits(std::unique_ptr<const ECLUnits::UnitSystem> usys)
+{
+    this->usys_output_ = std::move(usys);
+}
 
 std::vector<Opm::FlowDiagnostics::Graph>
 Opm::ECLPVT::ECLPvtCurveCollection::
@@ -186,16 +287,9 @@ getPvtCurve(const RawCurve      curve,
             const ECLPhaseIndex phase,
             const int           activeCell) const
 {
-    if (phase == ECLPhaseIndex::Aqua) {
-        // Not supported at this time.
-        // Return empty.
-        return emptyFDGraph();
-    }
-
-    if (static_cast<decltype(this->pvtnum_.size())>(activeCell)
-        >= this->pvtnum_.size())
-    {
-        // Active cell index out of bounds.  Return empty.
+    if (! this->isValidRequest(phase, activeCell)) {
+        // Not a supported phase or cell index out of bounds.  Not a valid
+        // request so return empty.
         return emptyFDGraph();
     }
 
@@ -205,36 +299,32 @@ getPvtCurve(const RawCurve      curve,
 
     if (phase == ECLPhaseIndex::Liquid) {
         // Caller requests oil properties.
-        return rawPvtCurve(this->oil_, curve, regID, *this->usys_);
+        return this->convertToOutputUnits(
+            rawPvtCurve(this->oil_.get(), curve, regID), curve, phase);
     }
 
-    // Call requests gas properties.
-    return rawPvtCurve(this->gas_, curve, regID, *this->usys_);
+    // Caller requests gas properties.
+    assert ((phase == ECLPhaseIndex::Vapour) &&
+            "Internal Logic Error Identifying Supported Phases");
+
+    return this->convertToOutputUnits(
+        rawPvtCurve(this->gas_.get(), curve, regID), curve, phase);
 }
 
 std::vector<double>
 Opm::ECLPVT::ECLPvtCurveCollection::
-getDynamicProperty(const RawCurve             property,
-                   const ECLPhaseIndex        phase,
-                   const int                  activeCell,
-                   const std::vector<double>& phasePress,
-                   const std::vector<double>& mixRatio) const
+getDynamicPropertySI(const RawCurve             property,
+                     const ECLPhaseIndex        phase,
+                     const int                  activeCell,
+                     const std::vector<double>& phasePress,
+                     const std::vector<double>& mixRatio) const
 {
-    if (phase == ECLPhaseIndex::Aqua) {
-        // Not supported at this time.
-        // Return empty.
-        return {};
-    }
-
-    if (property == RawCurve::SaturatedState) {
-        // Not a supported request.  Return empty.
-        return {};
-    }
-
-    if (static_cast<decltype(this->pvtnum_.size())>(activeCell)
-        >= this->pvtnum_.size())
+    if (! this->isValidRequest(phase, activeCell) ||
+        (property == RawCurve::SaturatedState))
     {
-        // Active cell index out of bounds.  Return empty.
+        // Not a supported phase, cell index out of bounds, or caller
+        // requests dynamically evaluating the saturated state curve.  Not a
+        // valid request so return empty.
         return {};
     }
 
@@ -244,11 +334,145 @@ getDynamicProperty(const RawCurve             property,
 
     if (phase == ECLPhaseIndex::Liquid) {
         // Caller requests oil properties.
-        return oilProperty(this->oil_, property, regID,
-                           phasePress, mixRatio, *this->usys_);
+        return oilProperty(this->oil_.get(), property,
+                           regID, phasePress, mixRatio);
     }
 
-    // Call requests gas properties.
-    return gasProperty(this->gas_, property, regID,
-                       phasePress, mixRatio, *this->usys_);
+    // Caller requests gas properties.
+    assert ((phase == ECLPhaseIndex::Vapour) &&
+            "Internal Logic Error Identifying Supported Phases");
+
+    return gasProperty(this->gas_.get(), property,
+                       regID, phasePress, mixRatio);
+}
+
+std::vector<double>
+Opm::ECLPVT::ECLPvtCurveCollection::
+getDynamicPropertyNative(const RawCurve      property,
+                         const ECLPhaseIndex phase,
+                         const int           activeCell,
+                         std::vector<double> phasePress,
+                         std::vector<double> mixRatio) const
+{
+    if (! this->isValidRequest(phase, activeCell) ||
+        (property == RawCurve::SaturatedState))
+    {
+        // Not a supported phase, cell index out of bounds, or caller
+        // requests dynamically evaluating the saturated state curve.  Not a
+        // valid request so return empty.
+        return {};
+    }
+
+    assert (this->usys_native_   != nullptr);
+    assert (this->usys_internal_ != nullptr);
+
+    // 1) Convert inputs from native to internal (SI) units of measurement.
+    ::Opm::ECLUnits::Convert::Pressure()
+          .from(*this->usys_native_)
+          .to  (*this->usys_internal_).appliedTo(phasePress);
+
+    if (phase == ECLPhaseIndex::Liquid) {
+        ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+              .from(*this->usys_native_)
+              .to  (*this->usys_internal_).appliedTo(mixRatio);
+    }
+    else {
+        assert (phase == ECLPhaseIndex::Vapour);
+
+        ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+              .from(*this->usys_native_)
+              .to  (*this->usys_internal_).appliedTo(mixRatio);
+    }
+
+    // 2) Evaluate requested property in strict SI units.
+    auto prop = this->getDynamicPropertySI(property, phase, activeCell,
+                                           phasePress, mixRatio);
+
+    // 3) Convert property values to user's requested system of units.
+
+    if (this->usys_output_ == nullptr) {
+        // No user-defined system of units for outputs.  Use PropertySI()
+        // directly.
+        return prop;
+    }
+
+    // Caller has defined a particular system of units for outputs.  Convert
+    // 'prop' accordingly.
+    if (property == RawCurve::Viscosity) {
+        // The 'prop' values represent viscosities.
+        ::Opm::ECLUnits::Convert::Viscosity()
+            .from(*this->usys_internal_)
+            .to  (*this->usys_output_).appliedTo(prop);
+    }
+    else {
+        assert (property == RawCurve::FVF);
+
+        if (phase == ECLPhaseIndex::Vapour) {
+            // The 'prop' values represent Bg.
+            ::Opm::ECLUnits::Convert::GasFVF()
+                .from(*this->usys_internal_)
+                .to  (*this->usys_output_).appliedTo(prop);
+        }
+        else {
+            assert (phase == ECLPhaseIndex::Liquid);
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                .from(*this->usys_internal_)
+                .to  (*this->usys_output_).appliedTo(prop);
+        }
+    }
+
+    return prop;
+}
+
+bool
+Opm::ECLPVT::ECLPvtCurveCollection::
+isValidRequest(const ECLPhaseIndex phase,
+               const int           activeCell) const
+{
+    if (! ((phase == ECLPhaseIndex::Liquid) ||
+           (phase == ECLPhaseIndex::Vapour)))
+    {
+        // We support "liquid" and "vapour" phase (oil/gas) properties only.
+        return false;
+    }
+
+    // Check if cell index is within bounds.
+    return static_cast<decltype(this->pvtnum_.size())>(activeCell)
+        <  this->pvtnum_.size();
+}
+
+std::vector<Opm::FlowDiagnostics::Graph>
+Opm::ECLPVT::ECLPvtCurveCollection::
+convertToOutputUnits(std::vector<FlowDiagnostics::Graph>&& graph,
+                     const RawCurve                        curve,
+                     const ECLPhaseIndex                   phase) const
+{
+    if (this->usys_output_ == nullptr) {
+        // No defined system of units for outputs.  Return unconverted (SI).
+        return graph;
+    }
+
+    assert ((phase == ECLPhaseIndex::Liquid) ||
+            (phase == ECLPhaseIndex::Vapour));
+
+    if (curve == RawCurve::FVF) {
+        return convertFvfCurve(std::move(graph), phase,
+                               *this->usys_internal_, // from
+                               *this->usys_output_);  // to
+    }
+
+    if (curve == RawCurve::Viscosity) {
+        return convertViscosityCurve(std::move(graph), phase,
+                                     *this->usys_internal_, // from
+                                     *this->usys_output_);  // to
+    }
+
+    if (curve == RawCurve::SaturatedState) {
+        return convertSatStateCurve(std::move(graph), phase,
+                                    *this->usys_internal_, // from
+                                    *this->usys_output_);  // to
+    }
+
+    throw std::invalid_argument { "Internal Logic Error" };
 }

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/utility/ECLGraph.hpp>
 #include <opm/utility/ECLPhaseIndex.hpp>
+#include <opm/utility/ECLPropertyUnitConversion.hpp>
 #include <opm/utility/ECLPvtCommon.hpp>
 #include <opm/utility/ECLPvtGas.hpp>
 #include <opm/utility/ECLPvtOil.hpp>
@@ -58,6 +59,20 @@ namespace Opm { namespace ECLPVT {
         ECLPvtCurveCollection(const ECLGraph&        G,
                               const ECLInitFileData& init);
 
+        /// Define a collection of units of measure for output purposes.
+        ///
+        /// PVT property curves will be reported in the appropriate units of
+        /// this system.  If this function is never called (or called with
+        /// null pointer), then the output units are implicitly set to the
+        /// flow-diagnostics module's internal units of measurement (meaning
+        /// all properties and curves will be reported in strict SI units).
+        ///
+        /// \param[in] usys Collection of units of measure for output
+        ///    purposes.  Typically the return value from one of the \code
+        ///    *UnitConvention() \endcode functions of the \code ECLUnits
+        ///    \endcode namespace.
+        void setOutputUnits(std::unique_ptr<const ECLUnits::UnitSystem> usys);
+
         /// Retrieve 2D graph representation of Phase PVT property function
         /// in a specific active cell.
         ///
@@ -73,7 +88,9 @@ namespace Opm { namespace ECLPVT {
         ///    \p activeCell.  One curve (vector element) for each tabulated
         ///    node of the primary look-up key.  Single curve (i.e., a
         ///    single element vector) in the case of dry gas (no vaporised
-        ///    oil) or dead oil (no dissolved gas).
+        ///    oil) or dead oil (no dissolved gas).  Return values provided
+        ///    in the system of units specified by setOutputUnits().  Strict
+        ///    SI if no output units have been defined.
         ///
         ///    No curves for water or dead oil with constant compressibility
         ///    (i.e., keyword 'PVCDO' in the input deck).
@@ -93,6 +110,10 @@ namespace Opm { namespace ECLPVT {
 
         /// Compute a single dynamic property in a single active cell for a
         /// collection of cell states.
+        ///
+        /// Note: Phase property inputs (phase pressure and mixing ratios)
+        ///    must be in strict SI units of measure (Pascal and sm^3/sm^3,
+        ///    respectively).
         ///
         /// \param[in] property Named property.  Must be one of \code
         ///    RawCurve::FVF \endcode or \code RawCurve::Viscosity \endcode.
@@ -121,14 +142,75 @@ namespace Opm { namespace ECLPVT {
         ///    requested property name of the identified phase in the
         ///    particular active cell.  Empty for invalid requests, number
         ///    of elements equal to \code phasePress.size() \endcode
-        ///    otherwise.
+        ///    otherwise.  Return values are in strict SI units of
+        ///    measure--i.e., rm^3/sm^3 for the formation volume factors and
+        ///    Pascal seconds for the viscosities.
         std::vector<double>
-        getDynamicProperty(const RawCurve             property,
-                           const ECLPhaseIndex        phase,
-                           const int                  activeCell,
-                           const std::vector<double>& phasePress,
-                           const std::vector<double>& mixRatio
-                               = std::vector<double>()) const;
+        getDynamicPropertySI(const RawCurve             property,
+                             const ECLPhaseIndex        phase,
+                             const int                  activeCell,
+                             const std::vector<double>& phasePress,
+                             const std::vector<double>& mixRatio
+                                 = std::vector<double>()) const;
+
+        /// Compute a single dynamic property in a single active cell for a
+        /// collection of cell states.
+        ///
+        /// This interface is intended for direct calculation based on raw
+        /// (unconverted) data vectors from an ECL result set.
+        /// Consequently, phase property inputs (phase pressure and mixing
+        /// ratios) must be in the result set's native/serialised collection
+        /// of units of measure (e.g., pressures in Atmospheres and mixing
+        /// ratios in scm^3/scm^3 for the "LAB" system of units).
+        ///
+        /// \param[in] property Named property.  Must be one of \code
+        ///    RawCurve::FVF \endcode or \code RawCurve::Viscosity \endcode.
+        ///    All other values return an empty result.
+        ///
+        /// \param[in] phase Phase for which to compute the property value.
+        ///    Must be \code ECLPhaseIndex::Vapour \endcode or \code
+        ///    ECLPhaseIndex::Liquid \endcode.  All other values return an
+        ///    empty result.
+        ///
+        /// \param[in] activeCell Index of particular active cell in model.
+        ///
+        /// \param[in] phasePress Sequence of phase pressure values
+        ///    pertaining to \p activeCell.  Could, for instance, be the
+        ///    entire time-series of oil pressure values in that cell.  Must
+        ///    be in the serialised system of units (i.e., Bars for METRIC,
+        ///    Psi for FIELD, and Atm for LAB and PVT-M).
+        ///
+        /// \param[in] mixRatio Sequence of phase mixing ratio values
+        ///    pertaining to \p activeCell.  Could, for instance, be the
+        ///    entire time-series of dissolved gas/oil ratio values in that
+        ///    cell.  Must be empty or match the size of \p phasePress.  If
+        ///    empty, treated as \code
+        ///    std::vector<double>(phasePress.size(), 0.0) \endcode which is
+        ///    typically appropriate only for dry gas or dead oil cases.
+        ///
+        ///    Must be in the serialised system of units.  In other words
+        ///    when the \p mixRatio represents the dissolved gas/oil ratio
+        ///    (Rs), then the input must be given in sm^3/sm^3 for METRIC,
+        ///    Mscf/stb for FIELD, scm^3/scm^3 for LAB and sm^3/sm^3 for
+        ///    PVT-M.  Similarly, when the \p mixRatio represents the
+        ///    vapourised oil/gas ratio (Rv), then the input must be given
+        ///    in sm^3/sm^3 for METRIC, stb/Mscf for FIELD, scm^3/scm^3 for
+        ///    LAB and sm^3/sm^3 for PVT-M).
+        ///
+        /// \return Sequence of dynamic property values corresponding to the
+        ///    requested property name of the identified phase in the
+        ///    particular active cell.  Empty for invalid requests, number
+        ///    of elements equal to \code phasePress.size() \endcode
+        ///    otherwise.  Return values provided in the system of units
+        ///    specified by setOutputUnits().  Strict SI if no output units
+        ///    have been defined.
+        std::vector<double>
+        getDynamicPropertyNative(const RawCurve      property,
+                                 const ECLPhaseIndex phase,
+                                 const int           activeCell,
+                                 std::vector<double> phasePress, // Mutable copy
+                                 std::vector<double> mixRatio    // Mutable copy
+                                 = std::vector<double>()) const;
 
     private:
         /// Forward map: Cell -> PVT Region ID
@@ -140,8 +222,44 @@ namespace Opm { namespace ECLPVT {
         /// Oil PVT property evaluator.
         std::shared_ptr<Oil> oil_;
 
-        /// Unit handling (SI -> result-set convention)
-        std::shared_ptr<const ECLUnits::UnitSystem> usys_;
+        /// Native unit system of INIT file.  Used in the implementation of
+        /// member function getDynamicPropertyNative().
+        std::shared_ptr<const ECLUnits::UnitSystem> usys_native_;
+
+        /// Explicit representation of internal system of units.  Strict SI.
+        /// Used in getDynamicPropertyNative().
+        std::shared_ptr<const ECLUnits::UnitSystem> usys_internal_;
+
+        /// User-specified system of units for output of properties.  Used
+        /// by getPvtCurve() and getDynamicPropertyNative().
+        std::shared_ptr<const ECLUnits::UnitSystem> usys_output_{nullptr};
+
+        /// Determine if a particular request can be met by the internal
+        /// implementation.
+        ///
+        /// \param[in] phase Phase for which to compute a property.
+        ///
+        /// \param[in] activeCell Index of particular active cell in model.
+        ///
+        /// \return True if \p phase is supported and \p activeCell is
+        ///    within range of the currently defined model.  False otherwise.
+        bool isValidRequest(const ECLPhaseIndex phase,
+                            const int           activeCell) const;
+
+        /// Convert a sequence of 2D graphs to user-defined system of units.
+        ///
+        /// \param[in] graph Sequence of 2D graphs corresponding to a
+        ///    particular curve request.
+        ///
+        /// \param[in] property Named property.
+        ///
+        /// \param[in] phase Phase for which to compute the property curve.
+        ///    Must be \code ECLPhaseIndex::Vapour \endcode or \code
+        ///    ECLPhaseIndex::Liquid \endcode.
+        std::vector<FlowDiagnostics::Graph>
+        convertToOutputUnits(std::vector<FlowDiagnostics::Graph>&& graph,
+                             const RawCurve                        curve,
+                             const ECLPhaseIndex                   phase) const;
     };
 
 }} // Opm::ECLPVT

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -66,7 +66,7 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] phase Phase for which to compute extract graph
         ///    representation of PVT property function.
         ///
-        /// \param[in] activeCell Index of particular active cell in model..
+        /// \param[in] activeCell Index of particular active cell in model.
         ///
         /// \return Collection of 2D graphs for PVT property curve
         ///    identified by requests represented by \p curve, \p phase and
@@ -90,6 +90,45 @@ namespace Opm { namespace ECLPVT {
         getPvtCurve(const RawCurve      curve,
                     const ECLPhaseIndex phase,
                     const int           activeCell) const;
+
+        /// Compute a single dynamic property in a single active cell for a
+        /// collection of cell states.
+        ///
+        /// \param[in] property Named property.  Must be one of \code
+        ///    RawCurve::FVF \endcode or \code RawCurve::Viscosity \endcode.
+        ///    All other values return an empty result.
+        ///
+        /// \param[in] phase Phase for which to compute the property value.
+        ///    Must be \code ECLPhaseIndex::Vapour \endcode or \code
+        ///    ECLPhaseIndex::Liquid \endcode.  All other values return an
+        ///    empty result.
+        ///
+        /// \param[in] activeCell Index of particular active cell in model.
+        ///
+        /// \param[in] phasePress Sequence of phase pressure values
+        ///    pertaining to \p activeCell.  Could, for instance, be the
+        ///    entire time-series of oil pressure values in that cell.
+        ///
+        /// \param[in] mixRatio Sequence of phase mixing ratio values
+        ///    pertaining to \p activeCell.  Could, for instance, be the
+        ///    entire time-series of dissolved gas/oil ratio values in that
+        ///    cell.  Must be empty or match the size of \p phasePress.  If
+        ///    empty, treated as \code
+        ///    std::vector<double>(phasePress.size(), 0.0) \endcode which is
+        ///    typically appropriate only for dry gas or dead oil cases.
+        ///
+        /// \return Sequence of dynamic property values corresponding to the
+        ///    requested property name of the identified phase in the
+        ///    particular active cell.  Empty for invalid requests, number
+        ///    of elements equal to \code phasePress.size() \endcode
+        ///    otherwise.
+        std::vector<double>
+        getDynamicProperty(const RawCurve             property,
+                           const ECLPhaseIndex        phase,
+                           const int                  activeCell,
+                           const std::vector<double>& phasePress,
+                           const std::vector<double>& mixRatio
+                               = std::vector<double>()) const;
 
     private:
         /// Forward map: Cell -> PVT Region ID

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -162,11 +162,6 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] region Region ID.  Non-negative integer typically
         ///    derived from the PVTNUM mapping vector.
         ///
-        /// \param[in] usys Unit system.  Collection of units to which the
-        ///    raw, tabulated PVT curve data will be converted.  Usually
-        ///    created by function \code ECLUnits::createUnitSystem()
-        ///    \endcode or a similar facility.
-        ///
         /// \return Collection of 2D graphs for PVT property curve
         ///    identified by requests represented by \p func and \p region.
         ///    One curve (vector element) for each pressure node.  Single
@@ -181,9 +176,8 @@ namespace Opm { namespace ECLPVT {
         ///           pvtGas.getPvtCurve(ECLPVT::RawCurve::FVF, 0);
         ///    \endcode
         std::vector<FlowDiagnostics::Graph>
-        getPvtCurve(const RawCurve              curve,
-                    const int                   region,
-                    const ECLUnits::UnitSystem& usys) const;
+        getPvtCurve(const RawCurve curve,
+                    const int      region) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -159,11 +159,6 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] region Region ID.  Non-negative integer typically
         ///    derived from the PVTNUM mapping vector.
         ///
-        /// \param[in] usys Unit system.  Collection of units to which the
-        ///    raw, tabulated PVT curve data will be converted.  Usually
-        ///    created by function \code ECLUnits::createUnitSystem()
-        ///    \endcode or a similar facility.
-        ///
         /// \return Collection of 2D graphs for PVT property curve
         ///    identified by requests represented by \p func and \p region.
         ///    One curve (vector element) for each dissolved gas/oil ratio
@@ -178,9 +173,8 @@ namespace Opm { namespace ECLPVT {
         ///           pvtOil.getPvtCurve(ECLPVT::RawCurve::Viscosity, 3);
         ///    \endcode
         std::vector<FlowDiagnostics::Graph>
-        getPvtCurve(const RawCurve              curve,
-                    const int                   region,
-                    const ECLUnits::UnitSystem& usys) const;
+        getPvtCurve(const RawCurve curve,
+                    const int      region) const;
 
     private:
         /// Implementation class.

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -42,6 +42,14 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_METRIC_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual std::unique_ptr<Opm::ECLUnits::UnitSystem>
+            clone() const override
+            {
+                return std::unique_ptr<Opm::ECLUnits::UnitSystem> {
+                    new USys<ECL_METRIC_UNITS>(*this)
+                };
+            }
+
             virtual double density() const override
             {
                 return Metric::Density;
@@ -97,6 +105,14 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_FIELD_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual std::unique_ptr<Opm::ECLUnits::UnitSystem>
+            clone() const override
+            {
+                return std::unique_ptr<Opm::ECLUnits::UnitSystem> {
+                    new USys<ECL_FIELD_UNITS>(*this)
+                };
+            }
+
             virtual double density() const override
             {
                 return Field::Density;
@@ -152,6 +168,14 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_LAB_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual std::unique_ptr<Opm::ECLUnits::UnitSystem>
+            clone() const override
+            {
+                return std::unique_ptr<Opm::ECLUnits::UnitSystem> {
+                    new USys<ECL_LAB_UNITS>(*this)
+                };
+            }
+
             virtual double density() const override
             {
                 return Lab::Density;
@@ -207,6 +231,14 @@ namespace Opm { namespace ECLUnits {
         class USys<ECL_PVT_M_UNITS> : public ::Opm::ECLUnits::UnitSystem
         {
         public:
+            virtual std::unique_ptr<Opm::ECLUnits::UnitSystem>
+            clone() const override
+            {
+                return std::unique_ptr<Opm::ECLUnits::UnitSystem> {
+                    new USys<ECL_PVT_M_UNITS>(*this)
+                };
+            }
+
             virtual double density() const override
             {
                 using namespace prefix;

--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -28,6 +28,8 @@ namespace Opm {
 
         struct UnitSystem
         {
+            virtual std::unique_ptr<UnitSystem> clone() const = 0;
+
             virtual double density()             const = 0;
             virtual double depth()               const = 0;
             virtual double pressure()            const = 0;

--- a/tests/test_eclpropertyunitconversion.cpp
+++ b/tests/test_eclpropertyunitconversion.cpp
@@ -1,0 +1,3766 @@
+/*
+  Copyright 2017 SINTEF ICT, Applied Mathematics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ECLPROPERTYUNITCONVERSION
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/utility/ECLPropertyUnitConversion.hpp>
+
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <exception>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+    std::vector<double> unity(const std::vector<double>::size_type n = 1)
+    {
+        return std::vector<double>(n, 1.0);
+    }
+
+    template <class Coll1, class Coll2>
+    void check_is_close(const Coll1& c1, const Coll2& c2)
+    {
+        BOOST_REQUIRE_EQUAL(c1.size(), c2.size());
+
+        for (auto b1 = std::begin(c1),
+                  e1 = std::end  (c1),
+                  b2 = std::begin(c2);
+             b1 != e1; ++b1, ++b2)
+        {
+            BOOST_CHECK_CLOSE(*b1, *b2, 1.0e-10);
+        }
+    }
+}
+
+struct UnitCollection
+{
+    using UPtr = std::unique_ptr<const Opm::ECLUnits::UnitSystem>;
+
+    UPtr metric { ::Opm::ECLUnits::metricUnitConventions() };
+    UPtr field  { ::Opm::ECLUnits::fieldUnitConventions()  };
+    UPtr lab    { ::Opm::ECLUnits::labUnitConventions()    };
+    UPtr pvt_m  { ::Opm::ECLUnits::pvtmUnitConventions()   };
+};
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (Pressure)
+
+BOOST_AUTO_TEST_CASE (Unspecified_Throws_Invalid)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Case 1: Pressure().to(si) (no .from() -> invalid)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto press = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::
+                          Pressure().to(*si).appliedTo(press),
+                          std::invalid_argument);
+    }
+
+    // Case 2: Pressure().from(field) (no .to() -> invalid)
+    {
+        auto press = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::Pressure()
+                          .from(*ucoll.field).appliedTo(press),
+                          std::invalid_argument);
+
+        check_is_close(press, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Same_to_same_NoChange)
+{
+    const auto ucoll = UnitCollection{};
+
+    // SI -> SI (Pascal -> Pascal)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto press = unity();
+
+        ::Opm::ECLUnits::Convert::Pressure()
+              .from(*si).to(*si).appliedTo(press);
+
+        check_is_close(press, unity());
+    }
+
+    // Metric -> Metric (Bar -> Bar)
+    {
+        auto press = unity();
+
+        ::Opm::ECLUnits::Convert::Pressure()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(press);
+
+        check_is_close(press, unity());
+    }
+
+    // Field -> Field (Psi -> Psi)
+    {
+        auto press = unity();
+
+        ::Opm::ECLUnits::Convert::Pressure()
+              .from(*ucoll.field).to(*ucoll.field).appliedTo(press);
+
+        check_is_close(press, unity());
+    }
+
+    // Lab -> Lab (Atm -> Atm)
+    {
+        auto press = unity();
+
+        ::Opm::ECLUnits::Convert::Pressure()
+              .from(*ucoll.lab).to(*ucoll.lab).appliedTo(press);
+
+        check_is_close(press, unity());
+    }
+
+    // PVT-M -> PVT-M (Atm -> Atm)
+    {
+        auto press = unity();
+
+        ::Opm::ECLUnits::Convert::Pressure()
+              .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(press);
+
+        check_is_close(press, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SI)
+{
+    const auto ucoll = UnitCollection{};
+    const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+    // SI -> Metric (Pascal -> Bar; /= 1.0e5)
+    {
+        const auto expect = std::vector<double>{ 1.0e-5 };
+
+        // Case 1: Pressure().from(metric).to(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*si).to(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(si).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.metric).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // SI -> Field (Pascal -> Psi; /= 6.894757293168360e+03)
+    {
+        const auto expect = std::vector<double>{ 1.450377377302092e-04 };
+
+        // Case 1: Pressure().from(si).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*si).to(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.field).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // SI -> Lab (Pascal -> Atm; /= 101325)
+    {
+        const auto expect = std::vector<double>{ 9.869232667160128e-06 };
+
+        // Case 1: Pressure().from(si).to(lab)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*si).to(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(lab).from(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.lab).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // SI -> PVT-M (Pascal -> Atm; /= 101325)
+    {
+        const auto expect = std::vector<double>{ 9.869232667160128e-06 };
+
+        // Case 1: Pressure().from(si).to(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*si).to(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(pvt_m).from(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.pvt_m).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Metric -> SI (Bar -> Pascal; *= 1.0e5)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0e5 };
+
+        // Case 1: Pressure().from(metric).to(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.metric).to(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(si).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*si).from(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Metric -> Field (Bar -> Psi; *= 14.50377377302092)
+    {
+        const auto expect = std::vector<double>{ 14.50377377302092 };
+
+        // Case 1: Pressure().from(metric).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.metric).to(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.field).from(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Metric -> Lab (Bar -> Atm; /= 1.01325)
+    {
+        const auto expect = std::vector<double>{ 9.869232667160128e-01 };
+
+        // Case 1: Pressure().from(metric).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.metric).to(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.lab).from(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Metric -> PVT-M (Bar -> Atm; /= 1.01325)
+    {
+        const auto expect = std::vector<double>{ 9.869232667160128e-01 };
+
+        // Case 1: Pressure().from(metric).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.metric).to(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.pvt_m).from(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Field -> SI (Psi -> Pascal; *= 6.894757293168360e+03)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 6.894757293168360e+03 };
+
+        // Case 1: Pressure().from(field).to(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.field).to(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(si).from(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*si).from(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Field -> Metric (Psi -> Bar; /= 14.50377377302092)
+    {
+        const auto expect = std::vector<double>{ 6.894757293168360e-02 };
+
+        // Case 1: Pressure().from(field).to(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.field).to(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(metric).from(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.metric).from(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Field -> Lab (Psi -> Atm; /= 14.69594877551345)
+    {
+        const auto expect = std::vector<double>{ 6.804596390987772e-02 };
+
+        // Case 1: Pressure().from(field).to(lab)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.field).to(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(lab).from(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.lab).from(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Field -> PVT-M (Psi -> Atm; /= 14.69594877551345)
+    {
+        const auto expect = std::vector<double>{ 6.804596390987772e-02 };
+
+        // Case 1: Pressure().from(field).to(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.field).to(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(pvt_m).from(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.pvt_m).from(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Lab -> SI (Atm -> Pascal; *= 1.01325e5)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.01325e5 };
+
+        // Case 1: Pressure().from(lab).to(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.lab).to(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(si).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*si).from(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Lab -> Metric (Atm -> Bar; *= 1.01325)
+    {
+        const auto expect = std::vector<double>{ 1.01325 };
+
+        // Case 1: Pressure().from(lab).to(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.lab).to(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.metric).from(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Lab -> Field (Atm -> Psi; *= 14.69594877551345)
+    {
+        const auto expect = std::vector<double>{ 14.69594877551345 };
+
+        // Case 1: Pressure().from(metric).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.lab).to(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(lab)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.field).from(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // Lab -> PVT-M (Atm -> Atm; unchanged)
+    {
+        // Case 1: Pressure().from(metric).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.lab).to(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, unity());
+        }
+
+        // Case 2: Pressure().to(field).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.pvt_m).from(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto ucoll = UnitCollection{};
+
+    // PVT-M -> SI (Atm -> Pascal; *= 1.01325e5)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.01325e5 };
+
+        // Case 1: Pressure().from(pvt_m).to(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.pvt_m).to(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(si).from(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*si).from(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // PVT-M -> Metric (Atm -> Bar; *= 1.01325)
+    {
+        const auto expect = std::vector<double>{ 1.01325 };
+
+        // Case 1: Pressure().from(pvt_m).to(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.pvt_m).to(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.metric).from(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // PVT-M -> Field (Atm -> Psi; *= 14.69594877551345)
+    {
+        const auto expect = std::vector<double>{ 14.69594877551345 };
+
+        // Case 1: Pressure().from(pvt_m).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.pvt_m).to(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Pressure().to(field).from(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.field).from(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // PVT-M -> Lab (Atm -> Atm; unchanged)
+    {
+        // Case 1: Pressure().from(pvt_m).to(lab)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, unity());
+        }
+
+        // Case 2: Pressure().to(lab).from(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Pressure()
+                  .to(*ucoll.pvt_m).from(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (Viscosity)
+
+BOOST_AUTO_TEST_CASE (Unspecified_Throws_Invalid)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Case 1: Viscosity().to(si) (no .from() -> invalid)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto visc = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::
+                          Viscosity().to(*si).appliedTo(visc),
+                          std::invalid_argument);
+    }
+
+    // Case 2: Viscosity().from(field) (no .to() -> invalid)
+    {
+        auto visc = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::Viscosity()
+                          .from(*ucoll.field).appliedTo(visc),
+                          std::invalid_argument);
+
+        check_is_close(visc, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Same_to_same_NoChange)
+{
+    const auto ucoll = UnitCollection{};
+
+    // SI -> SI (Pas -> Pas)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto visc = unity();
+
+        ::Opm::ECLUnits::Convert::Viscosity()
+              .from(*si).to(*si).appliedTo(visc);
+
+        check_is_close(visc, unity());
+    }
+
+    // Metric -> Metric (cP -> cP)
+    {
+        auto visc = unity();
+
+        ::Opm::ECLUnits::Convert::Viscosity()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(visc);
+
+        check_is_close(visc, unity());
+    }
+
+    // Field -> Field (cP -> cP)
+    {
+        auto visc = unity();
+
+        ::Opm::ECLUnits::Convert::Viscosity()
+              .from(*ucoll.field).to(*ucoll.field).appliedTo(visc);
+
+        check_is_close(visc, unity());
+    }
+
+    // Lab -> Lab (cP -> cP)
+    {
+        auto visc = unity();
+
+        ::Opm::ECLUnits::Convert::Viscosity()
+              .from(*ucoll.lab).to(*ucoll.lab).appliedTo(visc);
+
+        check_is_close(visc, unity());
+    }
+
+    // PVT-M -> PVT-M (cP -> cP)
+    {
+        auto visc = unity();
+
+        ::Opm::ECLUnits::Convert::Viscosity()
+              .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(visc);
+
+        check_is_close(visc, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SI)
+{
+    const auto ucoll = UnitCollection{};
+    const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+    // SI -> Metric (Pas -> cP; *= 1000)
+    {
+        const auto expect = std::vector<double>{ 1000.0 };
+
+        // Case 1: Viscosity().from(metric).to(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*si).to(*ucoll.metric).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Viscosity().to(si).from(metric)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.metric).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // SI -> Field (Pas -> cP; *= 1000)
+    {
+        const auto expect = std::vector<double>{ 1000.0 };
+
+        // Case 1: Viscosity().from(si).to(field)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*si).to(*ucoll.field).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Viscosity().to(field).from(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.field).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // SI -> Lab (Pas -> cP; *= 1000)
+    {
+        const auto expect = std::vector<double>{ 1000.0 };
+
+        // Case 1: Viscosity().from(si).to(lab)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*si).to(*ucoll.lab).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Viscosity().to(lab).from(si)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.lab).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+
+    // SI -> PVT-M (Pas -> cP; *= 1000)
+    {
+        const auto expect = std::vector<double>{ 1000.0 };
+
+        // Case 1: Viscosity().from(si).to(pvt_m)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*si).to(*ucoll.pvt_m).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+
+        // Case 2: Viscosity().to(pvt_m).from(lab)
+        {
+            auto press = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.pvt_m).from(*si).appliedTo(press);
+
+            check_is_close(press, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Metric -> SI (cP -> Pas; /= 1000)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0e-3 };
+
+        // Case 1: Viscosity().from(metric).to(si)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.metric).to(*si).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+
+        // Case 2: Viscosity().to(si).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*si).from(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+    }
+
+    // Metric -> Field (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(metric).to(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.metric).to(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.field).from(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // Metric -> Lab (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(metric).to(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.metric).to(*ucoll.lab).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.lab).from(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // Metric -> PVT-M (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(metric).to(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.metric).to(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.pvt_m).from(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Field -> SI (cP -> Pas; /= 1000)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0e-3 };
+
+        // Case 1: Viscosity().from(field).to(si)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.field).to(*si).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+
+        // Case 2: Viscosity().to(si).from(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*si).from(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+    }
+
+    // Field -> Metric (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(field).to(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.field).to(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(metric).from(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.metric).from(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // Field -> Lab (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(field).to(lab)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.field).to(*ucoll.lab).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(lab).from(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.lab).from(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // Field -> PVT-M (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(field).to(pvt_m)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.field).to(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(pvt_m).from(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.pvt_m).from(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Lab -> SI (cP -> Pas; /= 1000)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0e-3 };
+
+        // Case 1: Viscosity().from(lab).to(si)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.lab).to(*si).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+
+        // Case 2: Viscosity().to(si).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*si).from(*ucoll.lab).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+    }
+
+    // Lab -> Metric (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(lab).to(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.lab).to(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.metric).from(*ucoll.lab).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // Lab -> Field (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(metric).to(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.lab).to(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(lab)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.field).from(*ucoll.lab).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // Lab -> PVT-M (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(metric).to(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.lab).to(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.pvt_m).from(*ucoll.lab).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto ucoll = UnitCollection{};
+
+    // PVT-M -> SI (cP -> Pas; /= 1000)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0e-3 };
+
+        // Case 1: Viscosity().from(pvt_m).to(si)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.pvt_m).to(*si).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+
+        // Case 2: Viscosity().to(si).from(pvt_m)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*si).from(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, expect);
+        }
+    }
+
+    // PVT-M -> Metric (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(pvt_m).to(metric)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.pvt_m).to(*ucoll.metric).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(pvt_m)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.metric).from(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // PVT-M -> Field (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(pvt_m).to(field)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.pvt_m).to(*ucoll.field).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(field).from(pvt_m)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.field).from(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+
+    // PVT-M -> Lab (cP -> cP; Unchanged)
+    {
+        // Case 1: Viscosity().from(pvt_m).to(lab)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+
+        // Case 2: Viscosity().to(lab).from(pvt_m)
+        {
+            auto visc = unity();
+
+            ::Opm::ECLUnits::Convert::Viscosity()
+                  .to(*ucoll.pvt_m).from(*ucoll.pvt_m).appliedTo(visc);
+
+            check_is_close(visc, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (GasFVF)
+
+BOOST_AUTO_TEST_CASE (Unspecified_Throws_Invalid)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Case 1: GasFVF().to(si) (no .from() -> invalid)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Bg = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::
+                          GasFVF().to(*si).appliedTo(Bg),
+                          std::invalid_argument);
+    }
+
+    // Case 2: GasFVF().from(field) (no .to() -> invalid)
+    {
+        auto Bg = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::GasFVF()
+                          .from(*ucoll.field).appliedTo(Bg),
+                          std::invalid_argument);
+
+        check_is_close(Bg, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Same_to_same_NoChange)
+{
+    const auto ucoll = UnitCollection{};
+
+    // SI -> SI (rm^3/sm^3 -> rm^3/sm^3)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Bg = unity();
+
+        ::Opm::ECLUnits::Convert::GasFVF()
+              .from(*si).to(*si).appliedTo(Bg);
+
+        check_is_close(Bg, unity());
+    }
+
+    // Metric -> Metric (rm^3/sm^3 -> rm^3/sm^3)
+    {
+        auto Bg = unity();
+
+        ::Opm::ECLUnits::Convert::GasFVF()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Bg);
+
+        check_is_close(Bg, unity());
+    }
+
+    // Field -> Field (rb/Mscf -> rb/Mscf)
+    {
+        auto Bg = unity();
+
+        ::Opm::ECLUnits::Convert::GasFVF()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Bg);
+
+        check_is_close(Bg, unity());
+    }
+
+    // Lab -> Lab (rcm^3/scm^3 -> rcm^3/scm^3)
+    {
+        auto Bg = unity();
+
+        ::Opm::ECLUnits::Convert::GasFVF()
+              .from(*ucoll.lab).to(*ucoll.lab).appliedTo(Bg);
+
+        check_is_close(Bg, unity());
+    }
+
+    // PVT-M -> PVT-M (rm^3/sm^3 -> rm^3/sm^3)
+    {
+        auto Bg = unity();
+
+        ::Opm::ECLUnits::Convert::GasFVF()
+              .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Bg);
+
+        check_is_close(Bg, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SI)
+{
+    const auto ucoll = UnitCollection{};
+    const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+    // SI -> Metric (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(si).to(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*si).to(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(metric).from(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.metric).from(*si).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // SI -> Field (rm^3/sm^3 -> rb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: GasFVF().from(si).to(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*si).to(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(field).from(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.field).from(*si).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // SI -> Lab (rm^3/sm^3 -> rcm^3/scm^3; Unchanged)
+    {
+        // Case 1: GasFVF().from(si).to(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*si).to(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, unity());
+        }
+
+        // Case 2: GasFVF().to(lab).from(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.lab).from(*si).appliedTo(Bg);
+
+            check_is_close(Bg, unity());
+        }
+    }
+
+    // SI -> PVT-M (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        // Case 1: GasFVF().from(si).to(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*si).to(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, unity());
+        }
+
+        // Case 2: GasFVF().to(pvt_m).from(is)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.pvt_m).from(*si).appliedTo(Bg);
+
+            check_is_close(Bg, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Metric -> SI (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(metric).to(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.metric).to(*si).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(si).from(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*si).from(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Metric -> Field (rm^3/sm^3 -> rb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: GasFVF().from(metric).to(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.metric).to(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(field).from(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.field).from(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Metric -> Lab (rm^3/sm^3 -> rcm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(metric).to(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.metric).to(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(lab).from(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.lab).from(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Metric -> PVT-M (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(metric).to(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.metric).to(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(pvt_m).from(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Field -> SI (rb/Mscf -> rm^3/sm^3; /= 178.1076066790352)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: GasFVF().from(field).to(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.field).to(*si).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(si).from(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*si).from(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Field -> Metric (rb/Mscf -> rm^3/sm^3; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: GasFVF().from(field).to(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.field).to(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(metric).from(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.metric).from(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Field -> Lab (rb/Mscf -> rcm^3/scm^3; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: GasFVF().from(field).to(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.field).to(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(lab).from(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.lab).from(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Field -> PVT-M (rb/Mscf -> rm^3/sm^3; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: GasFVF().from(field).to(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.field).to(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(pvt_m).from(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Lab -> SI (rcm^3/scm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(lab).to(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.lab).to(*si).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(si).from(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*si).from(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Lab -> Metric (rcm^3/scm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(lab).to(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.lab).to(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(metric).from(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.metric).from(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Lab -> Field (rcm^3/scm^3 -> rb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: GasFVF().from(lab).to(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.lab).to(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(field).from(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.field).from(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // Lab -> PVT-M (rcm^3/scm^3 -> rm^3/sm^3; unchanged)
+    {
+        // Case 1: GasFVF().from(metric).to(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.lab).to(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, unity());
+        }
+
+        // Case 2: GasFVF().to(field).from(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.lab).appliedTo(Bg);
+
+            check_is_close(Bg, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto ucoll = UnitCollection{};
+
+    // PVT-M -> SI (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(pvt_m).to(si)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.pvt_m).to(*si).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(si).from(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*si).from(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // PVT-M -> Metric (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(pvt_m).to(metric)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.pvt_m).to(*ucoll.metric).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(field).from(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.metric).from(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // PVT-M -> Field (rm^3/sm^3 -> rb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: GasFVF().from(pvt_m).to(field)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.pvt_m).to(*ucoll.field).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(field).from(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.field).from(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+
+    // PVT-M -> Lab (rm^3/sm^3 -> rcm^3/scm^3; unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: GasFVF().from(pvt_m).to(lab)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+
+        // Case 2: GasFVF().to(lab).from(pvt_m)
+        {
+            auto Bg = unity();
+
+            ::Opm::ECLUnits::Convert::GasFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.pvt_m).appliedTo(Bg);
+
+            check_is_close(Bg, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (OilFVF)
+
+BOOST_AUTO_TEST_CASE (Unspecified_Throws_Invalid)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Case 1: OilFVF().to(si) (no .from() -> invalid)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Bo = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::
+                          OilFVF().to(*si).appliedTo(Bo),
+                          std::invalid_argument);
+    }
+
+    // Case 2: OilFVF().from(field) (no .to() -> invalid)
+    {
+        auto Bo = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::OilFVF()
+                          .from(*ucoll.field).appliedTo(Bo),
+                          std::invalid_argument);
+
+        check_is_close(Bo, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Same_to_same_NoChange)
+{
+    const auto ucoll = UnitCollection{};
+
+    // SI -> SI (rm^3/sm^3 -> rm^3/sm^3)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Bo = unity();
+
+        ::Opm::ECLUnits::Convert::OilFVF()
+              .from(*si).to(*si).appliedTo(Bo);
+
+        check_is_close(Bo, unity());
+    }
+
+    // Metric -> Metric (rm^3/sm^3 -> rm^3/sm^3)
+    {
+        auto Bo = unity();
+
+        ::Opm::ECLUnits::Convert::OilFVF()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Bo);
+
+        check_is_close(Bo, unity());
+    }
+
+    // Field -> Field (rb/stb -> rb/stb)
+    {
+        auto Bo = unity();
+
+        ::Opm::ECLUnits::Convert::OilFVF()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Bo);
+
+        check_is_close(Bo, unity());
+    }
+
+    // Lab -> Lab (rcm^3/scm^3 -> rcm^3/scm^3)
+    {
+        auto Bo = unity();
+
+        ::Opm::ECLUnits::Convert::OilFVF()
+              .from(*ucoll.lab).to(*ucoll.lab).appliedTo(Bo);
+
+        check_is_close(Bo, unity());
+    }
+
+    // PVT-M -> PVT-M (rm^3/sm^3 -> rm^3/sm^3)
+    {
+        auto Bo = unity();
+
+        ::Opm::ECLUnits::Convert::OilFVF()
+              .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Bo);
+
+        check_is_close(Bo, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SI)
+{
+    const auto ucoll = UnitCollection{};
+    const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+    // SI -> Metric (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(si).to(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*si).to(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(metric).from(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.metric).from(*si).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // SI -> Field (rm^3/sm^3 -> rb/stb; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(si).to(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*si).to(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(field).from(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.field).from(*si).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // SI -> Lab (rm^3/sm^3 -> rcm^3/scm^3; Unchanged)
+    {
+        // Case 1: OilFVF().from(si).to(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*si).to(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, unity());
+        }
+
+        // Case 2: OilFVF().to(lab).from(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.lab).from(*si).appliedTo(Bo);
+
+            check_is_close(Bo, unity());
+        }
+    }
+
+    // SI -> PVT-M (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        // Case 1: OilFVF().from(si).to(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*si).to(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, unity());
+        }
+
+        // Case 2: OilFVF().to(pvt_m).from(is)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.pvt_m).from(*si).appliedTo(Bo);
+
+            check_is_close(Bo, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Metric -> SI (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(metric).to(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.metric).to(*si).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(si).from(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*si).from(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Metric -> Field (rm^3/sm^3 -> rb/stb; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(metric).to(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.metric).to(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(field).from(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.field).from(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Metric -> Lab (rm^3/sm^3 -> rcm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(metric).to(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.metric).to(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(lab).from(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.lab).from(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Metric -> PVT-M (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(metric).to(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.metric).to(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(pvt_m).from(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Field -> SI (rb/stb -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(field).to(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.field).to(*si).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(si).from(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*si).from(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Field -> Metric (rb/stb -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(field).to(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.field).to(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(metric).from(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.metric).from(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Field -> Lab (rb/stb -> rcm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(field).to(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.field).to(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(lab).from(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.lab).from(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Field -> PVT-M (rb/stb -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(field).to(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.field).to(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(pvt_m).from(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Lab -> SI (rcm^3/scm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(lab).to(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.lab).to(*si).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(si).from(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*si).from(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Lab -> Metric (rcm^3/scm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(lab).to(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.lab).to(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(metric).from(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.metric).from(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Lab -> Field (rcm^3/scm^3 -> rb/stb; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(lab).to(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.lab).to(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(field).from(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.field).from(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // Lab -> PVT-M (rcm^3/scm^3 -> rm^3/sm^3; unchanged)
+    {
+        // Case 1: OilFVF().from(lab).to(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.lab).to(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, unity());
+        }
+
+        // Case 2: OilFVF().to(pvt_m).from(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.lab).appliedTo(Bo);
+
+            check_is_close(Bo, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto ucoll = UnitCollection{};
+
+    // PVT-M -> SI (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(pvt_m).to(si)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.pvt_m).to(*si).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(si).from(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*si).from(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // PVT-M -> Metric (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(pvt_m).to(metric)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.pvt_m).to(*ucoll.metric).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(field).from(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.metric).from(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // PVT-M -> Field (rm^3/sm^3 -> rb/stb; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(pvt_m).to(field)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.pvt_m).to(*ucoll.field).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(field).from(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.field).from(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+
+    // PVT-M -> Lab (rm^3/sm^3 -> rcm^3/scm^3; unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: OilFVF().from(pvt_m).to(lab)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+
+        // Case 2: OilFVF().to(lab).from(pvt_m)
+        {
+            auto Bo = unity();
+
+            ::Opm::ECLUnits::Convert::OilFVF()
+                  .to(*ucoll.pvt_m).from(*ucoll.pvt_m).appliedTo(Bo);
+
+            check_is_close(Bo, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (DissolvedGasOilRatio)
+
+BOOST_AUTO_TEST_CASE (Unspecified_Throws_Invalid)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Case 1: DissolvedGasOilRatio().to(si) (no .from() -> invalid)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Rs = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::
+                          DissolvedGasOilRatio().to(*si).appliedTo(Rs),
+                          std::invalid_argument);
+    }
+
+    // Case 2: DissolvedGasOilRatio().from(field) (no .to() -> invalid)
+    {
+        auto Rs = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                          .from(*ucoll.field).appliedTo(Rs),
+                          std::invalid_argument);
+
+        check_is_close(Rs, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Same_to_same_NoChange)
+{
+    const auto ucoll = UnitCollection{};
+
+    // SI -> SI (sm^3/sm^3 -> sm^3/sm^3)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Rs = unity();
+
+        ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+              .from(*si).to(*si).appliedTo(Rs);
+
+        check_is_close(Rs, unity());
+    }
+
+    // Metric -> Metric (sm^3/sm^3 -> sm^3/sm^3)
+    {
+        auto Rs = unity();
+
+        ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Rs);
+
+        check_is_close(Rs, unity());
+    }
+
+    // Field -> Field (Mscf/stb -> Mscf/stb)
+    {
+        auto Rs = unity();
+
+        ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Rs);
+
+        check_is_close(Rs, unity());
+    }
+
+    // Lab -> Lab (scm^3/scm^3 -> scm^3/scm^3)
+    {
+        auto Rs = unity();
+
+        ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+              .from(*ucoll.lab).to(*ucoll.lab).appliedTo(Rs);
+
+        check_is_close(Rs, unity());
+    }
+
+    // PVT-M -> PVT-M (sm^3/sm^3 -> sm^3/sm^3)
+    {
+        auto Rs = unity();
+
+        ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+              .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Rs);
+
+        check_is_close(Rs, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SI)
+{
+    const auto ucoll = UnitCollection{};
+    const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+    // SI -> Metric (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(si).to(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*si).to(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(metric).from(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.metric).from(*si).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // SI -> Field (sm^3/sm^3 -> Mscf/stb; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: DissolvedGasOilRatio().from(si).to(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*si).to(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(field).from(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.field).from(*si).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // SI -> Lab (sm^3/sm^3 -> scm^3/scm^3; Unchanged)
+    {
+        // Case 1: DissolvedGasOilRatio().from(si).to(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*si).to(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, unity());
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(lab).from(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.lab).from(*si).appliedTo(Rs);
+
+            check_is_close(Rs, unity());
+        }
+    }
+
+    // SI -> PVT-M (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        // Case 1: DissolvedGasOilRatio().from(si).to(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*si).to(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, unity());
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(pvt_m).from(is)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.pvt_m).from(*si).appliedTo(Rs);
+
+            check_is_close(Rs, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Metric -> SI (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(metric).to(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.metric).to(*si).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(si).from(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*si).from(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Metric -> Field (sm^3/sm^3 -> Mscf/stb; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: DissolvedGasOilRatio().from(metric).to(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.metric).to(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(field).from(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.field).from(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Metric -> Lab (sm^3/sm^3 -> scm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(metric).to(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.metric).to(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(lab).from(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.lab).from(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Metric -> PVT-M (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(metric).to(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.metric).to(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(pvt_m).from(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Field -> SI (Mscf/stb -> sm^3/sm^3; *= 178.1076066790352)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: DissolvedGasOilRatio().from(field).to(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.field).to(*si).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(si).from(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*si).from(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Field -> Metric (Mscf/stb -> sm^3/sm^3; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: DissolvedGasOilRatio().from(field).to(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.field).to(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(metric).from(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.metric).from(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Field -> Lab (Mscf/stb -> scm^3/scm^3; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: DissolvedGasOilRatio().from(field).to(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.field).to(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(lab).from(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.lab).from(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Field -> PVT-M (Mscf/stb -> sm^3/sm^3; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: DissolvedGasOilRatio().from(field).to(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.field).to(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(pvt_m).from(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Lab -> SI (scm^3/scm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(lab).to(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.lab).to(*si).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(si).from(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*si).from(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Lab -> Metric (scm^3/scm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(lab).to(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.lab).to(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(metric).from(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.metric).from(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Lab -> Field (scm^3/scm^3 -> Mscf/stb; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: DissolvedGasOilRatio().from(lab).to(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.lab).to(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(field).from(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.field).from(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // Lab -> PVT-M (scm^3/scm^3 -> sm^3/sm^3; Unchanged)
+    {
+        // Case 1: DissolvedGasOilRatio().from(lab).to(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.lab).to(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, unity());
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(pvt_m).from(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.lab).appliedTo(Rs);
+
+            check_is_close(Rs, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto ucoll = UnitCollection{};
+
+    // PVT-M -> SI (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(pvt_m).to(si)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.pvt_m).to(*si).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(si).from(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*si).from(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // PVT-M -> Metric (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(pvt_m).to(metric)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.pvt_m).to(*ucoll.metric).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(field).from(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.metric).from(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // PVT-M -> Field (sm^3/sm^3 -> Mscf/stb; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: DissolvedGasOilRatio().from(pvt_m).to(field)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.pvt_m).to(*ucoll.field).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(field).from(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.field).from(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+
+    // PVT-M -> Lab (sm^3/sm^3 -> scm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: DissolvedGasOilRatio().from(pvt_m).to(lab)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+
+        // Case 2: DissolvedGasOilRatio().to(lab).from(pvt_m)
+        {
+            auto Rs = unity();
+
+            ::Opm::ECLUnits::Convert::DissolvedGasOilRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.pvt_m).appliedTo(Rs);
+
+            check_is_close(Rs, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (VaporisedOilGasRatio)
+
+BOOST_AUTO_TEST_CASE (Unspecified_Throws_Invalid)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Case 1: VaporisedOilGasRatio().to(si) (no .from() -> invalid)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Rv = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::
+                          VaporisedOilGasRatio().to(*si).appliedTo(Rv),
+                          std::invalid_argument);
+    }
+
+    // Case 2: VaporisedOilGasRatio().from(field) (no .to() -> invalid)
+    {
+        auto Rv = unity();
+
+        BOOST_CHECK_THROW(::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                          .from(*ucoll.field).appliedTo(Rv),
+                          std::invalid_argument);
+
+        check_is_close(Rv, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Same_to_same_NoChange)
+{
+    const auto ucoll = UnitCollection{};
+
+    // SI -> SI (sm^3/sm^3 -> sm^3/sm^3)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        auto Rv = unity();
+
+        ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+              .from(*si).to(*si).appliedTo(Rv);
+
+        check_is_close(Rv, unity());
+    }
+
+    // Metric -> Metric (sm^3/sm^3 -> sm^3/sm^3)
+    {
+        auto Rv = unity();
+
+        ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Rv);
+
+        check_is_close(Rv, unity());
+    }
+
+    // Field -> Field (stb/Mscf -> stb/Mscf)
+    {
+        auto Rv = unity();
+
+        ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+              .from(*ucoll.metric).to(*ucoll.metric).appliedTo(Rv);
+
+        check_is_close(Rv, unity());
+    }
+
+    // Lab -> Lab (scm^3/scm^3 -> scm^3/scm^3)
+    {
+        auto Rv = unity();
+
+        ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+              .from(*ucoll.lab).to(*ucoll.lab).appliedTo(Rv);
+
+        check_is_close(Rv, unity());
+    }
+
+    // PVT-M -> PVT-M (sm^3/sm^3 -> sm^3/sm^3)
+    {
+        auto Rv = unity();
+
+        ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+              .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Rv);
+
+        check_is_close(Rv, unity());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (SI)
+{
+    const auto ucoll = UnitCollection{};
+    const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+    // SI -> Metric (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(si).to(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*si).to(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(metric).from(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.metric).from(*si).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // SI -> Field (sm^3/sm^3 -> stb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: VaporisedOilGasRatio().from(si).to(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*si).to(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(field).from(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.field).from(*si).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // SI -> Lab (sm^3/sm^3 -> scm^3/scm^3; Unchanged)
+    {
+        // Case 1: VaporisedOilGasRatio().from(si).to(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*si).to(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, unity());
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(lab).from(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.lab).from(*si).appliedTo(Rv);
+
+            check_is_close(Rv, unity());
+        }
+    }
+
+    // SI -> PVT-M (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        // Case 1: VaporisedOilGasRatio().from(si).to(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*si).to(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, unity());
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(pvt_m).from(is)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.pvt_m).from(*si).appliedTo(Rv);
+
+            check_is_close(Rv, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Metric)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Metric -> SI (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(metric).to(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.metric).to(*si).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(si).from(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*si).from(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Metric -> Field (sm^3/sm^3 -> stb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: VaporisedOilGasRatio().from(metric).to(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.metric).to(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(field).from(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.field).from(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Metric -> Lab (sm^3/sm^3 -> scm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(metric).to(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.metric).to(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(lab).from(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.lab).from(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Metric -> PVT-M (rm^3/sm^3 -> rm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(metric).to(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.metric).to(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(pvt_m).from(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Field)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Field -> SI (stb/Mscf -> sm^3/sm^3; /= 178.1076066790352)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: VaporisedOilGasRatio().from(field).to(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.field).to(*si).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(si).from(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*si).from(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Field -> Metric (stb/Mscf -> sm^3/sm^3; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: VaporisedOilGasRatio().from(field).to(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.field).to(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(metric).from(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.metric).from(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Field -> Lab (stb/Mscf -> scm^3/scm^3; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: VaporisedOilGasRatio().from(field).to(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.field).to(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(lab).from(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.lab).from(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Field -> PVT-M (stb/Mscf -> sm^3/sm^3; /= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 5.614583333333335e-03 };
+
+        // Case 1: VaporisedOilGasRatio().from(field).to(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.field).to(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(pvt_m).from(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Lab)
+{
+    const auto ucoll = UnitCollection{};
+
+    // Lab -> SI (scm^3/scm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(lab).to(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.lab).to(*si).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(si).from(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*si).from(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Lab -> Metric (scm^3/scm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(lab).to(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.lab).to(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(metric).from(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.metric).from(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Lab -> Field (scm^3/scm^3 -> stb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: VaporisedOilGasRatio().from(lab).to(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.lab).to(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(field).from(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.field).from(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // Lab -> PVT-M (scm^3/scm^3 -> sm^3/sm^3; Unchanged)
+    {
+        // Case 1: VaporisedOilGasRatio().from(lab).to(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.lab).to(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, unity());
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(pvt_m).from(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.lab).appliedTo(Rv);
+
+            check_is_close(Rv, unity());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (PVT_M)
+{
+    const auto ucoll = UnitCollection{};
+
+    // PVT-M -> SI (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto si = ::Opm::ECLUnits::internalUnitConventions();
+
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(pvt_m).to(si)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.pvt_m).to(*si).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(si).from(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*si).from(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // PVT-M -> Metric (sm^3/sm^3 -> sm^3/sm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(pvt_m).to(metric)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.pvt_m).to(*ucoll.metric).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(field).from(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.metric).from(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // PVT-M -> Field (sm^3/sm^3 -> stb/Mscf; *= 178.1076066790352)
+    {
+        const auto expect = std::vector<double>{ 178.1076066790352 };
+
+        // Case 1: VaporisedOilGasRatio().from(pvt_m).to(field)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.pvt_m).to(*ucoll.field).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(field).from(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.field).from(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+
+    // PVT-M -> Lab (sm^3/sm^3 -> scm^3/scm^3; Unchanged)
+    {
+        const auto expect = std::vector<double>{ 1.0 };
+
+        // Case 1: VaporisedOilGasRatio().from(pvt_m).to(lab)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .from(*ucoll.pvt_m).to(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+
+        // Case 2: VaporisedOilGasRatio().to(lab).from(pvt_m)
+        {
+            auto Rv = unity();
+
+            ::Opm::ECLUnits::Convert::VaporisedOilGasRatio()
+                  .to(*ucoll.pvt_m).from(*ucoll.pvt_m).appliedTo(Rv);
+
+            check_is_close(Rv, expect);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
This change-set adds a new member function,
```C++
void ECLPvtCurveCollection::getDynamicProperty(const RawCurve             property,
                                               const ECLPhaseIndex        phase,
                                               const int                  activeCell,
                                               const std::vector<double>& phasePress,
                                               const std::vector<double>& mixRatio)
```
that enables calculating principal dynamic properties like the phase formation volume factor or the phase viscosity in a single cell at a collection of cell states (phase pressure and mixing ratios).  One example of such related cell states would be the entire time series of an ECL result set.  We reuse the [`RawCurve`](https://github.com/OPM/opm-flowdiagnostics-applications/blob/master/opm/utility/ECLPvtCommon.hpp#L293-L302) description to identify which property to calculate and simply forward to the corresponding member functions of the fundamental Oil and Gas property interpolants.

We furthermore add a simple demonstration utility that enables calculating these properties as a function of simulated time in a single active cell and produce Octave/MATLAB-compatible output for easy loading into those environments.