### PR TITLE
PVT Curves: Always Expand Primary Key for Miscible Curves

### DIFF
--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -64,6 +64,34 @@ namespace {
         os.precision(oprec);
     }
 
+    template <class OStream>
+    void printGraph(OStream&                                  os,
+                    const std::string&                        name,
+                    const std::vector<Opm::ECLPVT::PVTGraph>& graphs)
+    {
+        const auto oprec  = os.precision(16);
+        const auto oflags = os.setf(std::ios_base::scientific);
+
+        auto k = 1;
+        for (const auto& graph : graphs) {
+            const auto& p = graph.press;
+            const auto& R = graph.mixRat;
+            const auto& f = graph.value;
+
+            os << name << '{' << k << "} = [\n";
+
+            for (auto n = p.size(), i = 0*n; i < n; ++i) {
+                os << p[i] << ' ' << R[i] << ' ' << f[i] << '\n';
+            }
+
+            os << "];\n\n";
+            k += 1;
+        }
+
+        os.setf(oflags);
+        os.precision(oprec);
+    }
+
     // -----------------------------------------------------------------
     // Relative permeability
 

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -103,7 +103,7 @@ namespace Opm { namespace ECLPVT {
         ///           pvtCC.getPvtCurve(ECLPVT::RawCurve::Viscosity,
         ///                             ECLPhaseIndex::Vapour, 31415);
         ///    \endcode
-        std::vector<FlowDiagnostics::Graph>
+        std::vector<PVTGraph>
         getPvtCurve(const RawCurve      curve,
                     const ECLPhaseIndex phase,
                     const int           activeCell) const;
@@ -256,10 +256,10 @@ namespace Opm { namespace ECLPVT {
         /// \param[in] phase Phase for which to compute the property curve.
         ///    Must be \code ECLPhaseIndex::Vapour \endcode or \code
         ///    ECLPhaseIndex::Liquid \endcode.
-        std::vector<FlowDiagnostics::Graph>
-        convertToOutputUnits(std::vector<FlowDiagnostics::Graph>&& graph,
-                             const RawCurve                        curve,
-                             const ECLPhaseIndex                   phase) const;
+        std::vector<PVTGraph>
+        convertToOutputUnits(std::vector<PVTGraph>&& graph,
+                             const RawCurve          curve,
+                             const ECLPhaseIndex     phase) const;
     };
 
 }} // Opm::ECLPVT

--- a/opm/utility/ECLPvtGas.hpp
+++ b/opm/utility/ECLPvtGas.hpp
@@ -175,7 +175,7 @@ namespace Opm { namespace ECLPVT {
         ///       const auto graph =
         ///           pvtGas.getPvtCurve(ECLPVT::RawCurve::FVF, 0);
         ///    \endcode
-        std::vector<FlowDiagnostics::Graph>
+        std::vector<PVTGraph>
         getPvtCurve(const RawCurve curve,
                     const int      region) const;
 

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -95,7 +95,7 @@ public:
     viscosity(const std::vector<double>& rs,
               const std::vector<double>& po) const = 0;
 
-    virtual std::vector<Opm::FlowDiagnostics::Graph>
+    virtual std::vector<Opm::ECLPVT::PVTGraph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const = 0;
 
     virtual std::unique_ptr<PVxOBase> clone() const = 0;
@@ -130,7 +130,7 @@ public:
         return this->interpolant_.viscosity(po);
     }
 
-    virtual std::vector<Opm::FlowDiagnostics::Graph>
+    virtual std::vector<Opm::ECLPVT::PVTGraph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const override
     {
         return { this->interpolant_.getPvtCurve(curve) };
@@ -187,7 +187,7 @@ public:
         return this->interp_.viscosity(key, x);
     }
 
-    virtual std::vector<Opm::FlowDiagnostics::Graph>
+    virtual std::vector<Opm::ECLPVT::PVTGraph>
     getPvtCurve(const Opm::ECLPVT::RawCurve curve) const override
     {
         return this->interp_.getPvtCurve(curve);
@@ -406,7 +406,7 @@ public:
         return this->rhoS_[region];
     }
 
-    std::vector<FlowDiagnostics::Graph>
+    std::vector<PVTGraph>
     getPvtCurve(const RegIdx   region,
                 const RawCurve curve) const;
 
@@ -475,7 +475,7 @@ viscosity(const RegIdx               region,
     return this->eval_[region]->viscosity(rs, po);
 }
 
-std::vector<Opm::FlowDiagnostics::Graph>
+std::vector<Opm::ECLPVT::PVTGraph>
 Opm::ECLPVT::Oil::Impl::
 getPvtCurve(const RegIdx   region,
             const RawCurve curve) const
@@ -558,7 +558,7 @@ double Opm::ECLPVT::Oil::surfaceMassDensity(const int region) const
     return this->pImpl_->surfaceMassDensity(region);
 }
 
-std::vector<Opm::FlowDiagnostics::Graph>
+std::vector<Opm::ECLPVT::PVTGraph>
 Opm::ECLPVT::Oil::
 getPvtCurve(const RawCurve curve,
             const int      region) const

--- a/opm/utility/ECLPvtOil.hpp
+++ b/opm/utility/ECLPvtOil.hpp
@@ -172,7 +172,7 @@ namespace Opm { namespace ECLPVT {
         ///       const auto graph =
         ///           pvtOil.getPvtCurve(ECLPVT::RawCurve::Viscosity, 3);
         ///    \endcode
-        std::vector<FlowDiagnostics::Graph>
+        std::vector<PVTGraph>
         getPvtCurve(const RawCurve curve,
                     const int      region) const;
 


### PR DESCRIPTION
This guarantees that clients can choose whether to plot the function versus phase pressure or versus mixing ratio.