### PR TITLE
Endpoint Scaling: Guard Against Nonsensical Scaled Saturations

### DIFF
--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -67,6 +67,19 @@ namespace Opm { namespace SatFunc {
             double sat;
         };
 
+        /// Policy for how to handle an invalid end-point scaling (e.g., if
+        /// lower and/or upper scaled saturations have nonsensical values
+        /// like -1.0E+20).
+        enum class InvalidEndpointBehaviour {
+            /// Use the unscaled value for this point.
+            UseUnscaled,
+
+            /// Ignore this scaling request (e.g., produce no graphical
+            /// output for a scaled saturation function when the scaled
+            /// end-points are meaningless).
+            IgnorePoint,
+        };
+
         /// Convenience type alias.
         using SaturationPoints = std::vector<SaturationAssoc>;
 
@@ -128,8 +141,19 @@ namespace Opm { namespace SatFunc {
         /// \param[in] smin Left end points for a set of cells.
         ///
         /// \param[in] smax Right end points for a set of cells.
-        TwoPointScaling(std::vector<double> smin,
-                        std::vector<double> smax);
+        ///
+        /// \param[in] handle_invalid How to treat scaling requests with
+        ///    invalid scaled saturations.  This can, for instance, happen
+        ///    if the scaled saturations are present in the result set but
+        ///    some (or all) cells have irreconcilable values (e.g., minimum
+        ///    saturation greater than maximum saturation, smin < -1E+20,
+        ///    smax < -1E+20).
+        ///
+        ///    Default behaviour: Use unscaled saturation if this happens.
+        TwoPointScaling(std::vector<double>            smin,
+                        std::vector<double>            smax,
+                        const InvalidEndpointBehaviour handle_invalid
+                        = InvalidEndpointBehaviour::UseUnscaled);
 
         /// Destructor.
         ~TwoPointScaling();
@@ -237,9 +261,20 @@ namespace Opm { namespace SatFunc {
         ///    for a set of cells.
         ///
         /// \param[in] smax Right end points for a set of cells.
-        ThreePointScaling(std::vector<double> smin,
-                          std::vector<double> sdisp,
-                          std::vector<double> smax);
+        ///
+        /// \param[in] handle_invalid How to treat scaling requests with
+        ///    invalid scaled saturations.  This can, for instance, happen
+        ///    if the scaled saturations are present in the result set but
+        ///    some (or all) cells have irreconcilable values (e.g., minimum
+        ///    saturation greater than maximum saturation, smin < -1E+20,
+        ///    smax < -1E+20).
+        ///
+        ///    Default behaviour: Use unscaled saturation if this happens.
+        ThreePointScaling(std::vector<double>            smin,
+                          std::vector<double>            sdisp,
+                          std::vector<double>            smax,
+                          const InvalidEndpointBehaviour handle_invalid
+                          = InvalidEndpointBehaviour::UseUnscaled);
 
         /// Destructor.
         ~ThreePointScaling();
@@ -385,6 +420,13 @@ namespace Opm { namespace SatFunc {
             ///   auto eps = CreateEPS::fromECLOutput(G, init, opt);
             /// \endcode
             ::Opm::ECLPhaseIndex thisPh;
+
+            /// How to handle an invalid end-point scaling (e.g., if lower
+            /// and/or upper scaled saturations have nonsensical values like
+            /// -1.0E+20).
+            EPSEvalInterface::InvalidEndpointBehaviour handle_invalid {
+                EPSEvalInterface::InvalidEndpointBehaviour::UseUnscaled
+            };
         };
 
         /// Collection of raw saturation table end points.

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -21,6 +21,7 @@
 #define OPM_ECLSATURATIONFUNC_HEADER_INCLUDED
 
 #include <opm/flowdiagnostics/DerivedQuantities.hpp>
+#include <opm/utility/ECLEndPointScaling.hpp>
 #include <opm/utility/ECLPhaseIndex.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
@@ -78,6 +79,9 @@ namespace Opm {
             ECLPhaseIndex thisPh;
         };
 
+        using InvalidEPBehaviour = ::Opm::SatFunc::
+            EPSEvalInterface::InvalidEndpointBehaviour;
+
         /// Constructor
         ///
         /// \param[in] G Connected topology of current model's active cells.
@@ -97,9 +101,18 @@ namespace Opm {
         ///
         ///    Default value (\c true) means that effects of EPS are
         ///    included if requisite data is present in the INIT result.
-        ECLSaturationFunc(const ECLGraph&        G,
-                          const ECLInitFileData& init,
-                          const bool             useEPS = true);
+        ///
+        /// \param[in] invalidIsUnscaled Whether or not treat invalid scaled
+        ///    saturation end-points (e.g., SWL=-1.0E+20) as unscaled
+        ///    saturations.  True for "treat as unscaled", false for "
+        ///
+        ///    Default value (\c true) means that invalid scalings are
+        ///    treated as unscaled, false
+        ECLSaturationFunc(const ECLGraph&          G,
+                          const ECLInitFileData&   init,
+                          const bool               useEPS = true,
+                          const InvalidEPBehaviour handle_invalid
+                          = InvalidEPBehaviour::UseUnscaled);
 
         /// Destructor.
         ~ECLSaturationFunc();


### PR DESCRIPTION
Real-life testing has demonstrated that values of scaled endpoints need not always have reasonable values (i.e., in the range [0, 1]). One particular case has scaled saturations of -1.0E+20 which lead to
very peculiar values--for instance in a graphical representation.

This commit introduces a user-configurable run-time policy, implemented as a constructor argument to the EPS classes, called
```
EPSEvalInterface::InvalidEndpointBehaviour
```
with possible values `UseUnscaled` and `IgnorePoint`.  The former policy means that invalid scaled saturations get translated to the unscaled saturation while the latter means that cells with invalid scaled saturations are ignored.  The first of these is the default setting and is typically appropriate for simulation applications while the latter may be useful for graphical output of saturation function curves.