### PR TITLE
Fix Implementation of IgnorePoint Invalid EPS Run-time Policy

### DIFF
--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -28,6 +28,7 @@
 #include <opm/utility/ECLResultData.hpp>
 
 #include <cassert>
+#include <cmath>
 #include <exception>
 #include <initializer_list>
 #include <iterator>
@@ -241,8 +242,12 @@ handleInvalidEndpoint(const SaturationAssoc& sp,
         return;
     }
 
-    // Nothing to do for IgnorePoint.  In particular, we must not change the
-    // contents or the size of effsat.
+    if (this->handle_invalid_ == InvalidEndpointBehaviour::IgnorePoint) {
+        // User requests that invalid scaling be ignored.  Signal invalid
+        // scaled saturation to caller as NaN.
+        effsat.push_back(std::nan(""));
+        return;
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -408,8 +413,12 @@ handleInvalidEndpoint(const SaturationAssoc& sp,
         return;
     }
 
-    // Nothing to do for IgnorePoint.  In particular, we must not change the
-    // contents or the size of effsat.
+    if (this->handle_invalid_ == InvalidEndpointBehaviour::IgnorePoint) {
+        // User requests that invalid scaling be ignored.  Signal invalid
+        // scaled saturation to caller as NaN.
+        effsat.push_back(std::nan(""));
+        return;
+    }
 }
 
 // ---------------------------------------------------------------------

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -197,6 +197,12 @@ Impl::reverse(const TableEndPoints&   tep,
         const auto sLO = this->smin_[cell];
         const auto sHI = this->smax_[cell];
 
+        if (! validSaturations({ sLO, sHI })) {
+            this->handleInvalidEndpoint(eval_pt, unscaledsat);
+
+            continue;
+        }
+
         unscaledsat.push_back(0.0);
         auto& s_unsc = unscaledsat.back();
 
@@ -344,12 +350,18 @@ Impl::reverse(const TableEndPoints&   tep,
     for (const auto& eval_pt : sp) {
         const auto cell = eval_pt.cell;
 
-        unscaledsat.push_back(0.0);
-        auto& s_unsc = unscaledsat.back();
-
         const auto sLO = this->smin_ [cell];
         const auto sR  = this->sdisp_[cell];
         const auto sHI = this->smax_ [cell];
+
+        if (! validSaturations({ sLO, sR, sHI })) {
+            this->handleInvalidEndpoint(eval_pt, unscaledsat);
+
+            continue;
+        }
+
+        unscaledsat.push_back(0.0);
+        auto& s_unsc = unscaledsat.back();
 
         if (! (eval_pt.sat > tep.low)) {
             // s <= minimum tabulated saturation.

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -102,12 +102,12 @@ namespace Opm {
         ///    Default value (\c true) means that effects of EPS are
         ///    included if requisite data is present in the INIT result.
         ///
-        /// \param[in] invalidIsUnscaled Whether or not treat invalid scaled
-        ///    saturation end-points (e.g., SWL=-1.0E+20) as unscaled
-        ///    saturations.  True for "treat as unscaled", false for "
+        /// \param[in] handle_invalid Run-time policy for how to handle
+        ///    scaling requests relative to invalid scaled saturations
+        ///    (e.g., SWL = -1.0E+20).
         ///
-        ///    Default value (\c true) means that invalid scalings are
-        ///    treated as unscaled, false
+        ///    Default value (\c UseUnscaled) means that invalid scalings
+        ///    are treated as unscaled.
         ECLSaturationFunc(const ECLGraph&          G,
                           const ECLInitFileData&   init,
                           const bool               useEPS = true,


### PR DESCRIPTION
The introduction of the `InvalidEndpointBehaviour` run-time parameter to class ECLSaturationFunc (commit 829e90c, PR #73) failed to properly guard the reverse scaling direction in the same way as the forward direction.  We also didn't take into account that some of the internal interfaces in the implementation of the end-point scaling functionality were not properly prepared to handle the dichotomy of a saturation being present or not.

This change-set works around this problem by

1. Properly checking for invalid scaled saturations also in the reverse direction

2. Returning a sentinel, invalid scaled saturation (`std::nan("")`) when any of the scaled end-points are invalid.  These sentinel values are then filtered out in the [`uniqueReverseScaleSat()`](https://github.com/OPM/opm-flowdiagnostics-applications/blob/e81ac15d14e056dbab537da769139f66761362ea/opm/utility/ECLSaturationFunc.cpp#L1976-L1996) member function of class `ECLSaturationFunc::Impl`.  Curves for which all sample points have sentinel values are then returned as empty rather than as unscaled which would be the case in the previous implementation.

I am not entirely satisfied by this implementation.  The sentinel value is more of an expedient hack than a good solution.  This is a prime candidate for rethinking from the ground up in the future, but is nevertheless usable and fairly non-intrusive&mdash;apart from additional run-time checks.