### PR TITLE
Update Build Prerequisites

### DIFF
--- a/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/opm-flowdiagnostics-applications-prereqs.cmake
@@ -9,10 +9,13 @@ set (opm-flowdiagnostics-applications_DEPS
   "Boost 1.44.0
     COMPONENTS filesystem regex system unit_test_framework REQUIRED"
   "ecl REQUIRED"
-  # prerequisite OPM modules
+  # Prerequisite OPM modules
+  #   common -> Parameter System
+  #   fdiag  -> Solver
+  #   parser -> Unit Conversions
   "opm-common REQUIRED"
   "opm-flowdiagnostics REQUIRED"
-  "opm-core REQUIRED"
+  "opm-parser REQUIRED"
   )
 
 find_package_deps(opm-flowdiagnostics-applications)

--- a/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/opm-flowdiagnostics-applications-prereqs.cmake
@@ -12,6 +12,7 @@ set (opm-flowdiagnostics-applications_DEPS
   #   filesystem::last_write_time()
   "Boost 1.44.0
     COMPONENTS filesystem system unit_test_framework REQUIRED"
+  # We need LibECL to handle ECL result sets.
   "ecl REQUIRED"
   # Prerequisite OPM modules
   #   common -> Parameter System

--- a/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/opm-flowdiagnostics-applications-prereqs.cmake
@@ -2,12 +2,16 @@
 set (opm-flowdiagnostics-applications_CONFIG_VAR
   )
 
-# dependencies
+# Build prerequisites
 set (opm-flowdiagnostics-applications_DEPS
-  # compile with C++0x/11 support if available
+  # This module requires C++11 support, including std::regex
   "CXX11Features REQUIRED"
+  # We need Boost.Filesystem for advanced file handling
+  #   filesystem::path
+  #   filesystem::directory_iterator
+  #   filesystem::last_write_time()
   "Boost 1.44.0
-    COMPONENTS filesystem regex system unit_test_framework REQUIRED"
+    COMPONENTS filesystem system unit_test_framework REQUIRED"
   "ecl REQUIRED"
   # Prerequisite OPM modules
   #   common -> Parameter System


### PR DESCRIPTION
We used to use opm-core for its parameter system (`ParameterGroup` and related features).  This system 
now resides in opm-common so we get it for free through the existing opm-common build prerequisite.  Retire opm-core as a prerequisite, but add opm-parser for its unit conversion system.  The parser module was previously added transitively as a prerequisite for opm-core.

While here, also note that we require C++11 support that includes a complete `<regex>` library (e.g., GCC >= 4.9 in C++11 mode) so there's no need to use or look for Boost.Regex.