### PR TITLE
Implement Proper Table Sizing for Wet Gas Tables (PVTG)

### DIFF
--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -785,10 +785,30 @@ fromECLOutput(const ECLInitFileData& init)
     const auto& tabdims = init.keywordData<int>("TABDIMS");
     const auto& tab     = init.keywordData<double>("TAB");
 
-    raw.numPrimary = tabdims[ TABDIMS_NRPVTO_ITEM ]; // #Rs nodes/full table
-    raw.numRows    = tabdims[ TABDIMS_NPPVTO_ITEM ]; // #Po nodes/sub-table
-    raw.numCols    = 5; // [ Po, 1/B, 1/(B*mu), d(1/B)/dPo, d(1/(B*mu))/dPo ]
-    raw.numTables  = tabdims[ TABDIMS_NTPVTO_ITEM ]; // # PVTO tables
+    const auto numRs = tabdims[ TABDIMS_NRPVTO_ITEM ]; // #Rs nodes/full table
+
+    // Inner dimension (number of rows per sub-table) is number of pressure
+    // nodes for both live oil and dead oil cases.
+    raw.numRows   = tabdims[ TABDIMS_NPPVTO_ITEM ]; // #Po nodes/sub-table
+    raw.numCols   = 5; // [ Po, 1/B, 1/(B*mu), d(1/B)/dPo, d(1/(B*mu))/dPo ]
+    raw.numTables = tabdims[ TABDIMS_NTPVTO_ITEM ]; // # PVTO tables
+
+    if (lh[ LOGIHEAD_RS_INDEX ]) {
+        // Dissolved gas flag set => Live Oil.
+        //
+        // Number of primary keys (outer dimension, number of sub-tables per
+        // PVTO table) is number of composition nodes.
+
+        raw.numPrimary = numRs;
+    }
+    else {
+        // Dissolved gas flag NOT set => Dead Oil.
+        //
+        // Number of primary keys (outer dimension, number of sub-tables per
+        // PVDO table) is one.
+
+        raw.numPrimary = 1;
+    }
 
     // Extract Primary Key (Rs)
     {


### PR DESCRIPTION
The initial implementation of this feature confused the roles of the number of composition nodes and the number of gas pressure nodes in defining the proper table dimensions.  This commit removes that confusion and ensures that in the case of Wet Gas (PVTG)

  * The inner dimension (number of rows per sub-table) is equal to the number of composition (i.e., Rv) nodes

  * The outer dimension (number of sub-tables per PVT region) is equal to the number of gas pressure nodes.

While here, also clarify this relationship for the Live Oil case (i.e., PVTO tables) to ensure that

  * The inner dimension (number of rows per sub-table) is equal to the number of oil pressure nodes.

  * The outer dimension (number of sub-tables per PVT region) is equal to the number of composition (i.e., Rs) nodes.