### PR TITLE
Eliminate parser dep, complete boost::regex removal

### DIFF
--- a/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/opm-flowdiagnostics-applications-prereqs.cmake
@@ -20,7 +20,6 @@ set (opm-flowdiagnostics-applications_DEPS
   #   parser -> Unit Conversions
   "opm-common REQUIRED"
   "opm-flowdiagnostics REQUIRED"
-  "opm-parser REQUIRED"
   )
 
 find_package_deps(opm-flowdiagnostics-applications)

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -21,7 +21,7 @@
 #include <opm/utility/ECLPvtCommon.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 #include <opm/utility/ECLSaturationFunc.hpp>
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <algorithm>
 #include <exception>
@@ -90,7 +90,7 @@ namespace {
         const auto depthscale = usys->depth();
 
         for (auto& zi : depth) {
-            zi = ::Opm::unit::convert::from(zi, depthscale);
+            zi = ::ImportedOpm::unit::convert::from(zi, depthscale);
         }
 
         return depth;

--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -25,7 +25,7 @@
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <algorithm>
 #include <array>
@@ -604,7 +604,7 @@ ECL::getPVolVector(const ecl_grid_type*          G,
             getUnitSystem(init, gridID)->reservoirVolume();
 
         for (auto& pv : pvol) {
-            pv = ::Opm::unit::convert::from(pv, pvol_unit);
+            pv = ::ImportedOpm::unit::convert::from(pv, pvol_unit);
         }
     }
 
@@ -1157,7 +1157,7 @@ connectionData(const ::Opm::ECLRestartData&    rstrt,
             "Direction must be I, J, or K");
 
     for (const auto& cell : cells->second) {
-        x.push_back(::Opm::unit::convert::from(v[cell], unit));
+        x.push_back(::ImportedOpm::unit::convert::from(v[cell], unit));
     }
 }
 
@@ -1208,7 +1208,7 @@ deriveNeighbours(const std::vector<std::size_t>& gcells,
 
     auto SI_trans = [trans_unit](const double trans)
     {
-        return ::Opm::unit::convert::from(trans, trans_unit);
+        return ::ImportedOpm::unit::convert::from(trans, trans_unit);
     };
 
     auto& ocell = this->outCell_[d];
@@ -1776,7 +1776,7 @@ NNC::add(const std::vector<ECL::CartesianGridData>& grid,
 
     // Capture transmissibility field to support on-demand flux calculations
     // if flux fields are not output to the on-disk result set.
-    this->trans_.push_back(unit::convert::from(nnc.trans, trans_unit));
+    this->trans_.push_back(ImportedOpm::unit::convert::from(nnc.trans, trans_unit));
 
     const auto cat = this->classifyConnection(nnc.grid_nr1, nnc.grid_nr2);
 
@@ -2211,7 +2211,7 @@ Opm::ECLGraph::Impl::linearisedCellData(const ECLRestartData& rstrt,
                        std::back_inserter(x),
             [vector_unit](const double value)
             {
-                return ::Opm::unit::convert::from(value, vector_unit);
+                return ::ImportedOpm::unit::convert::from(value, vector_unit);
             });
     }
 
@@ -2285,7 +2285,7 @@ Opm::ECLGraph::Impl::fluxNNC(const ECLRestartData& rstrt,
                 assert (ix.kwIdx    < q.size());
 
                 v[ix.neighIdx] =
-                    unit::convert::from(q[ix.kwIdx], flux_unit);
+                    ImportedOpm::unit::convert::from(q[ix.kwIdx], flux_unit);
 
                 assigned[ix.neighIdx] = true;
             }

--- a/opm/utility/ECLPropertyUnitConversion.cpp
+++ b/opm/utility/ECLPropertyUnitConversion.cpp
@@ -22,7 +22,7 @@
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <ert/ecl/ecl_kw_magic.h>
 
@@ -315,7 +315,7 @@ namespace {
 
     double calculateScaleFactor(const double from, const double to)
     {
-        using namespace ::Opm::unit;
+        using namespace ::ImportedOpm::unit;
 
         // "return from / to", essentially.
         return convert::to(convert::from(1.0, from), to);

--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -22,7 +22,7 @@
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <functional>
 #include <utility>
@@ -64,7 +64,7 @@ namespace {
         return ::Opm::ECLPVT::ConvertUnits::Converter {
             [uscale](const double q) -> double
             {
-                return ::Opm::unit::convert::from(q, uscale);
+                return ::ImportedOpm::unit::convert::from(q, uscale);
             }
         };
     }
@@ -326,7 +326,7 @@ Opm::ECLPVT::surfaceMassDensity(const ECLInitFileData& init,
     const auto dens_scale = u->density();
 
     for (auto& rho_i : rho) {
-        rho_i = unit::convert::from(rho_i, dens_scale);
+        rho_i = ImportedOpm::unit::convert::from(rho_i, dens_scale);
     }
 
     return rho;

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -25,7 +25,7 @@
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <cassert>
 #include <cmath>

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -24,7 +24,7 @@
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <cassert>
 #include <cmath>
@@ -48,7 +48,7 @@ namespace {
 
         return [scale](const double x) -> double
         {
-            return Opm::unit::convert::from(x, scale);
+            return ImportedOpm::unit::convert::from(x, scale);
         };
     }
 
@@ -59,7 +59,7 @@ namespace {
 
         return [scale](const double x) -> double
         {
-            return Opm::unit::convert::from(x, scale);
+            return ImportedOpm::unit::convert::from(x, scale);
         };
     }
 

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -31,7 +31,7 @@
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -589,7 +589,7 @@ Gas::Details::unitConverter(const int usys)
     const auto pscale = u->pressure();
 
     auto cvrt_press = [pscale](const double p) {
-        return ::Opm::unit::convert::from(p, pscale);
+        return ::ImportedOpm::unit::convert::from(p, pscale);
     };
 
     return CU {
@@ -680,7 +680,7 @@ Water::Details::unitConverter(const int usys)
     const auto pscale = u->pressure();
 
     auto cvrt_press = [pscale](const double p) {
-        return ::Opm::unit::convert::from(p, pscale);
+        return ::ImportedOpm::unit::convert::from(p, pscale);
     };
 
     return CU {

--- a/opm/utility/ECLUnitHandling.cpp
+++ b/opm/utility/ECLUnitHandling.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/utility/ECLUnitHandling.hpp>
 
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 
 #include <exception>
 #include <stdexcept>
@@ -37,6 +37,8 @@ namespace Opm { namespace ECLUnits {
 
         template <ert_ecl_unit_enum convention>
         class USys;
+
+        using namespace ImportedOpm;
 
         template <>
         class USys<ECL_METRIC_UNITS> : public ::Opm::ECLUnits::UnitSystem

--- a/opm/utility/ECLWellSolution.cpp
+++ b/opm/utility/ECLWellSolution.cpp
@@ -25,7 +25,7 @@
 #include <opm/utility/ECLWellSolution.hpp>
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLUnitHandling.hpp>
-#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/utility/imported/Units.hpp>
 #include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl_well/well_const.h>
 #include <cmath>
@@ -217,6 +217,7 @@ namespace Opm
         for (int well = 0; well < ih.nwell; ++well) {
             // Skip if total rate below threshold (for wells that are
             // shut or stopped for example).
+            using namespace ImportedOpm;
             const double well_reservoir_inflow_rate = -unit::convert::from(xwel[well * ih.nxwel + XWEL_RESV_INDEX], qr_unit);
             if (std::fabs(well_reservoir_inflow_rate) < rate_threshold_) {
                 continue;

--- a/opm/utility/imported/Units.hpp
+++ b/opm/utility/imported/Units.hpp
@@ -1,0 +1,367 @@
+//===========================================================================
+//
+// File: Units.hpp
+//
+// Created: Thu Jul  2 09:19:08 2009
+//
+// Author(s): Halvor M Nilsen <hnil@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010, 2011, 2012 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010, 2011, 2012 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef IMPORTED_OPM_UNITS_HEADER
+#define IMPORTED_OPM_UNITS_HEADER
+
+
+// WARNING!
+// This file is a modified duplicate, imported to make this module independent.
+// Modifications include file location, the header guard, and using the ImportedOpm namespace.
+
+
+/**
+   The unit sets emplyed in ECLIPSE, in particular the FIELD units,
+   are quite inconsistent. Ideally one should choose units for a set
+   of base quantities like Mass,Time and Length and then derive the
+   units for e.g. pressure and flowrate in a consisten manner. However
+   that is not the case; for instance in the metric system we have:
+
+      [Length] = meters
+      [time] = days
+      [mass] = kg
+
+   This should give:
+
+      [Pressure] = [mass] / ([length] * [time]^2) = kg / (m * days * days)
+
+   Instead pressure is given in Bars. When it comes to FIELD units the
+   number of such examples is long.
+*/
+namespace ImportedOpm {
+    namespace prefix
+    /// Conversion prefix for units.
+    {
+        constexpr const double micro = 1.0e-6;  /**< Unit prefix [\f$\mu\f$] */
+        constexpr const double milli = 1.0e-3;  /**< Unit prefix [m] */
+        constexpr const double centi = 1.0e-2;  /**< Non-standard unit prefix [c] */
+        constexpr const double deci  = 1.0e-1;  /**< Non-standard unit prefix [d] */
+        constexpr const double kilo  = 1.0e3;   /**< Unit prefix [k] */
+        constexpr const double mega  = 1.0e6;   /**< Unit prefix [M] */
+        constexpr const double giga  = 1.0e9;   /**< Unit prefix [G] */
+    } // namespace prefix
+
+    namespace unit
+    /// Definition of various units.
+    /// All the units are defined in terms of international standard
+    /// units (SI).  Example of use: We define a variable \c k which
+    /// gives a permeability. We want to set \c k to \f$1\,mD\f$.
+    /// \code
+    /// using namespace Opm::unit
+    /// double k = 0.001*darcy;
+    /// \endcode
+    /// We can also use one of the prefixes defined in Opm::prefix
+    /// \code
+    /// using namespace Opm::unit
+    /// using namespace Opm::prefix
+    /// double k = 1.0*milli*darcy;
+    /// \endcode
+    {
+        ///\name Common powers
+        /// @{
+        constexpr double square(double v) { return v * v;     }
+        constexpr double cubic (double v) { return v * v * v; }
+        /// @}
+
+        // --------------------------------------------------------------
+        // Basic (fundamental) units and conversions
+        // --------------------------------------------------------------
+
+        /// \name Length
+        /// @{
+        constexpr const double meter =  1;
+        constexpr const double inch  =  2.54 * prefix::centi*meter;
+        constexpr const double feet  = 12    * inch;
+        /// @}
+
+        /// \name Time
+        /// @{
+        constexpr const double second =   1;
+        constexpr const double minute =  60 * second;
+        constexpr const double hour   =  60 * minute;
+        constexpr const double day    =  24 * hour;
+        constexpr const double year   = 365 * day;
+        /// @}
+
+        /// \name Volume
+        /// @{
+        constexpr const double gallon = 231 * cubic(inch);
+        constexpr const double stb    =  42 * gallon;
+        constexpr const double liter  =   1 * cubic(prefix::deci*meter);
+        /// @}
+
+        /// \name Mass
+        /// @{
+        constexpr const double kilogram = 1;
+        constexpr const double gram     = 1.0e-3 * kilogram;
+        // http://en.wikipedia.org/wiki/Pound_(mass)#Avoirdupois_pound
+        constexpr const double pound    = 0.45359237 * kilogram;
+        /// @}
+
+        /// \name Energy
+        /// @{
+        constexpr const double joule = 1;
+        constexpr const double btu = 1054.3503*joule; // "british thermal units"
+        /// @}
+
+        // --------------------------------------------------------------
+        // Standardised constants
+        // --------------------------------------------------------------
+
+        /// \name Standardised constant
+        /// @{
+        constexpr const double gravity = 9.80665 * meter/square(second);
+        /// @}
+
+        // --------------------------------------------------------------
+        // Derived units and conversions
+        // --------------------------------------------------------------
+
+        /// \name Force
+        /// @{
+        constexpr const double Newton = kilogram*meter / square(second); // == 1
+        constexpr const double dyne   = 1e-5*Newton;
+        constexpr const double lbf    = pound * gravity; // Pound-force
+        /// @}
+
+        /// \name Pressure
+        /// @{
+        constexpr const double Pascal = Newton / square(meter); // == 1
+        constexpr const double barsa  = 100000 * Pascal;
+        constexpr const double atm    = 101325 * Pascal;
+        constexpr const double psia   = lbf / square(inch);
+        /// @}
+
+        /// \name Temperature. This one is more complicated
+        /// because the unit systems used by Eclipse (i.e. degrees
+        /// Celsius and degrees Fahrenheit require to add or
+        /// subtract an offset for the conversion between from/to
+        /// Kelvin
+        /// @{
+        constexpr const double degCelsius = 1.0; // scaling factor °C -> K
+        constexpr const double degCelsiusOffset = 273.15; // offset for the °C -> K conversion
+
+        constexpr const double degFahrenheit = 5.0/9; // scaling factor °F -> K
+        constexpr const double degFahrenheitOffset = 255.37; // offset for the °C -> K conversion
+        /// @}
+
+        /// \name Viscosity
+        /// @{
+        constexpr const double Pas   = Pascal * second; // == 1
+        constexpr const double Poise = prefix::deci*Pas;
+        /// @}
+
+        namespace perm_details {
+            constexpr const double p_grad   = atm / (prefix::centi*meter);
+            constexpr const double area     = square(prefix::centi*meter);
+            constexpr const double flux     = cubic (prefix::centi*meter) / second;
+            constexpr const double velocity = flux / area;
+            constexpr const double visc     = prefix::centi*Poise;
+            constexpr const double darcy    = (velocity * visc) / p_grad;
+            //                    == 1e-7 [m^2] / 101325
+            //                    == 9.869232667160130e-13 [m^2]
+        }
+        /// \name Permeability
+        /// @{
+        ///
+        /// A porous medium with a permeability of 1 darcy permits a flow (flux)
+        /// of \f$1\,\mathit{cm}^3/s\f$ of a fluid with viscosity
+        /// \f$1\,\mathit{cP}\f$ (\f$1\,mPa\cdot s\f$) under a pressure gradient
+        /// of \f$1\,\mathit{atm}/\mathit{cm}\f$ acting across an area of
+        /// \f$1\,\mathit{cm}^2\f$.
+        ///
+        constexpr const double darcy = perm_details::darcy;
+        /// @}
+
+        /**
+         * Unit conversion routines.
+         */
+        namespace convert {
+            /**
+             * Convert from external units of measurements to equivalent
+             * internal units of measurements.  Note: The internal units of
+             * measurements are *ALWAYS*, and exclusively, SI.
+             *
+             * Example: Convert a double @c kx, containing a permeability value
+             * in units of milli-darcy (mD) to the equivalent value in SI units
+             * (i.e., \f$m^2\f$).
+             * \code
+             *    using namespace Opm::unit;
+             *    using namespace Opm::prefix;
+             *    convert::from(kx, milli*darcy);
+             * \endcode
+             *
+             * @param[in] q    Physical quantity.
+             * @param[in] unit Physical unit of measurement.
+             * @return Value of @c q in equivalent SI units of measurements.
+             */
+            constexpr double from(const double q, const double unit)
+            {
+                return q * unit;
+            }
+
+            /**
+             * Convert from internal units of measurements to equivalent
+             * external units of measurements.  Note: The internal units of
+             * measurements are *ALWAYS*, and exclusively, SI.
+             *
+             * Example: Convert a <CODE>std::vector<double> p</CODE>, containing
+             * pressure values in the SI unit Pascal (i.e., unit::Pascal) to the
+             * equivalent values in Psi (unit::psia).
+             * \code
+             *    using namespace Opm::unit;
+             *    std::transform(p.begin(), p.end(), p.begin(),
+             *                   boost::bind(convert::to, _1, psia));
+             * \endcode
+             *
+             * @param[in] q    Physical quantity, measured in SI units.
+             * @param[in] unit Physical unit of measurement.
+             * @return Value of @c q in unit <CODE>unit</CODE>.
+             */
+            constexpr double to(const double q, const double unit)
+            {
+                return q / unit;
+            }
+        } // namespace convert
+    }
+
+    namespace Metric {
+        using namespace prefix;
+        using namespace unit;
+        constexpr const double Pressure             = barsa;
+        constexpr const double Temperature          = degCelsius;
+        constexpr const double TemperatureOffset    = degCelsiusOffset;
+        constexpr const double AbsoluteTemperature  = degCelsius; // actually [K], but the these two are identical
+        constexpr const double Length               = meter;
+        constexpr const double Time                 = day;
+        constexpr const double Mass                 = kilogram;
+        constexpr const double Permeability         = milli*darcy;
+        constexpr const double Transmissibility     = centi*Poise*cubic(meter)/(day*barsa);
+        constexpr const double LiquidSurfaceVolume  = cubic(meter);
+        constexpr const double GasSurfaceVolume     = cubic(meter);
+        constexpr const double ReservoirVolume      = cubic(meter);
+        constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
+        constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr const double Density              = kilogram/cubic(meter);
+        constexpr const double PolymerDensity       = kilogram/cubic(meter);
+        constexpr const double Salinity             = kilogram/cubic(meter);
+        constexpr const double Viscosity            = centi*Poise;
+        constexpr const double Timestep             = day;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
+        constexpr const double Energy               = kilo*joule;
+    }
+
+
+    namespace Field {
+        using namespace prefix;
+        using namespace unit;
+        constexpr const double Pressure             = psia;
+        constexpr const double Temperature          = degFahrenheit;
+        constexpr const double TemperatureOffset    = degFahrenheitOffset;
+        constexpr const double AbsoluteTemperature  = degFahrenheit; // actually [°R], but the these two are identical
+        constexpr const double Length               = feet;
+        constexpr const double Time                 = day;
+        constexpr const double Mass                 = pound;
+        constexpr const double Permeability = milli*darcy;
+        constexpr const double Transmissibility = centi*Poise*stb/(day*psia);
+        constexpr const double LiquidSurfaceVolume  = stb;
+        constexpr const double GasSurfaceVolume     = 1000*cubic(feet);
+        constexpr const double ReservoirVolume      = stb;
+        constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
+        constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr const double Density              = pound/cubic(feet);
+        constexpr const double PolymerDensity       = pound/stb;
+        constexpr const double Salinity             = pound/stb;
+        constexpr const double Viscosity            = centi*Poise;
+        constexpr const double Timestep             = day;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
+        constexpr const double Energy               = btu;
+    }
+
+
+    namespace Lab {
+        using namespace prefix;
+        using namespace unit;
+        constexpr const double Pressure             = atm;
+        constexpr const double Temperature          = degCelsius;
+        constexpr const double TemperatureOffset    = degCelsiusOffset;
+        constexpr const double AbsoluteTemperature  = degCelsius; // actually [K], but the these two are identical
+        constexpr const double Length               = centi*meter;
+        constexpr const double Time                 = hour;
+        constexpr const double Mass                 = gram;
+        constexpr const double Permeability         = milli*darcy;
+        constexpr const double Transmissibility     = centi*Poise*cubic(centi*meter)/(hour*atm);
+        constexpr const double LiquidSurfaceVolume  = cubic(centi*meter);
+        constexpr const double GasSurfaceVolume     = cubic(centi*meter);
+        constexpr const double ReservoirVolume      = cubic(centi*meter);
+        constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
+        constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr const double Density              = gram/cubic(centi*meter);
+        constexpr const double PolymerDensity       = gram/cubic(centi*meter);
+        constexpr const double Salinity             = gram/cubic(centi*meter);
+        constexpr const double Viscosity            = centi*Poise;
+        constexpr const double Timestep             = hour;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
+        constexpr const double Energy               = joule;
+    }
+
+
+    namespace PVT_M {
+        using namespace prefix;
+        using namespace unit;
+        constexpr const double Pressure             = atm;
+        constexpr const double Temperature          = degCelsius;
+        constexpr const double TemperatureOffset    = degCelsiusOffset;
+        constexpr const double AbsoluteTemperature  = degCelsius; // actually [K], but the these two are identical
+        constexpr const double Length               = meter;
+        constexpr const double Time                 = day;
+        constexpr const double Mass                 = kilogram;
+        constexpr const double Permeability         = milli*darcy;
+        constexpr const double Transmissibility     = centi*Poise*cubic(meter)/(day*atm);
+        constexpr const double LiquidSurfaceVolume  = cubic(meter);
+        constexpr const double GasSurfaceVolume     = cubic(meter);
+        constexpr const double ReservoirVolume      = cubic(meter);
+        constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
+        constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr const double Density              = kilogram/cubic(meter);
+        constexpr const double PolymerDensity       = kilogram/cubic(meter);
+        constexpr const double Salinity             = kilogram/cubic(meter);
+        constexpr const double Viscosity            = centi*Poise;
+        constexpr const double Timestep             = day;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
+        constexpr const double Energy               = kilo*joule;
+    }
+}
+
+#endif // IMPORTED_OPM_UNITS_HEADER

--- a/tests/runLinearisedCellDataTest.cpp
+++ b/tests/runLinearisedCellDataTest.cpp
@@ -44,7 +44,7 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_file_kw.h>
@@ -58,11 +58,11 @@ namespace StringUtils {
         std::string trim(const std::string& s)
         {
             const auto anchor_ws =
-                boost::regex(R"~~(^\s+([^\s]+)\s+$)~~");
+                std::regex(R"~~(^\s+([^\s]+)\s+$)~~");
 
-            auto m = boost::smatch{};
+            auto m = std::smatch{};
 
-            if (boost::regex_match(s, m, anchor_ws)) {
+            if (std::regex_match(s, m, anchor_ws)) {
                 return m[1];
             }
 
@@ -77,9 +77,9 @@ namespace StringUtils {
                 return { "" };
             }
 
-            const auto sep = boost::regex(R"~~([\s,;.|]+)~~");
+            const auto sep = std::regex(R"~~([\s,;.|]+)~~");
 
-            using TI = boost::sregex_token_iterator;
+            using TI = std::sregex_token_iterator;
 
             // vector<string>(begin, end)
             //


### PR DESCRIPTION
This follows #79 by removing the minor opm-parser dependency and removing the last use of boost::regex.

The dependency is eliminated by importing the Units.hpp file in a way that should do no harm even if combined with the original: the duplicated code resides in the ImportedOpm namespace, and it is only included from .cpp files, and therefore not installed.

With this, the *library* here (which is also used by ResInsight) only depends on opm-flowdiagnostics and libecl. The remainder (tests and examples) require opm-common and parts of boost, but that is of no consequence for ResInsight.

I will self-merge this now.