### PR TITLE
Add Support for Vertical Scaling of Saturation Functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ include(OpmInit)
 macro (dir_hook)
 endmacro (dir_hook)
 
-# Look for the opm-data repository; if found the variable
-# HAVE_OPM_DATA will be set to true.
-include (Findopm-data)
+# Look for the "opm-tests" repository (OPM's Regression Test data
+# repository)--HAVE_OPM_TESTS true if found.
+include (Findopm-tests)
 
 # list of prerequisites for this particular project; this is in a
 # separate file (in cmake/Modules sub-directory) because it is shared
@@ -93,6 +93,7 @@ endmacro (install_hook)
 # all setup common to the OPM library modules is done here
 include (OpmLibMain)
 
-if (HAVE_OPM_DATA)
+if (HAVE_OPM_TESTS)
+  # Regression test data available.  Enable additional tests.
   include (${CMAKE_CURRENT_SOURCE_DIR}/AcceptanceTests.cmake)
 endif()

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-flowdiagnostics-applications
 Description: flow diagnostics applications and examples
-Version: 2018.04-pre
-Label: 2018.04-pre
+Version: 2018.10-pre
+Label: 2018.10-pre
 Maintainer: bard.skaflestad@sintef.no
 MaintainerName: Bård Skaflestad
 Url: http://opm-project.org

--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2018.10-pre
 Maintainer: bard.skaflestad@sintef.no
 MaintainerName: Bård Skaflestad
 Url: http://opm-project.org
-Depends: opm-common opm-flowdiagnostics opm-parser
+Depends: opm-common opm-flowdiagnostics

--- a/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/opm-flowdiagnostics-applications-prereqs.cmake
@@ -17,7 +17,6 @@ set (opm-flowdiagnostics-applications_DEPS
   # Prerequisite OPM modules
   #   common -> Parameter System
   #   fdiag  -> Solver
-  #   parser -> Unit Conversions
   "opm-common REQUIRED"
   "opm-flowdiagnostics REQUIRED"
   )

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -114,12 +114,11 @@ namespace {
 class Opm::SatFunc::TwoPointScaling::Impl
 {
 public:
-    Impl(std::vector<double>      smin,
-         std::vector<double>      smax,
-         InvalidEndpointBehaviour handle_invalid)
+    Impl(std::vector<double> smin,
+         std::vector<double> smax)
         : smin_          (std::move(smin))
         , smax_          (std::move(smax))
-        , handle_invalid_(handle_invalid)
+        , handle_invalid_(InvalidEndpointBehaviour::UseUnscaled)
     {
         if (this->smin_.size() != this->smax_.size()) {
             throw std::invalid_argument {
@@ -285,14 +284,13 @@ handleInvalidEndpoint(const SaturationAssoc& sp,
 class Opm::SatFunc::ThreePointScaling::Impl
 {
 public:
-    Impl(std::vector<double>      smin ,
-         std::vector<double>      sdisp,
-         std::vector<double>      smax ,
-         InvalidEndpointBehaviour handle_invalid)
+    Impl(std::vector<double> smin ,
+         std::vector<double> sdisp,
+         std::vector<double> smax )
         : smin_          (std::move(smin ))
         , sdisp_         (std::move(sdisp))
         , smax_          (std::move(smax ))
-        , handle_invalid_(handle_invalid)
+        , handle_invalid_(InvalidEndpointBehaviour::UseUnscaled)
     {
         if ((this->sdisp_.size() != this->smin_.size()) ||
             (this->sdisp_.size() != this->smax_.size()))
@@ -493,35 +491,29 @@ namespace Create {
         struct Kr {
             static EPSPtr
             G(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init,
-              const InvBeh                  handle_invalid);
+              const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             OG(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init,
-               const InvBeh                  handle_invalid);
+               const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             OW(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init,
-               const InvBeh                  handle_invalid);
+               const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             W(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init,
-              const InvBeh                  handle_invalid);
+              const ::Opm::ECLInitFileData& init);
         };
 
         struct Pc {
             static EPSPtr
             GO(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init,
-               const InvBeh                  handle_invalid);
+               const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             OW(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init,
-               const InvBeh                  handle_invalid);
+               const ::Opm::ECLInitFileData& init);
         };
 
         static EPSPtr
@@ -540,23 +532,19 @@ namespace Create {
         struct Kr {
             static EPSPtr
             G(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init,
-              const InvBeh                  handle_invalid);
+              const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             OG(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init,
-               const InvBeh                  handle_invalid);
+               const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             OW(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init,
-               const InvBeh                  handle_invalid);
+               const ::Opm::ECLInitFileData& init);
 
             static EPSPtr
             W(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init,
-              const InvBeh                  handle_invalid);
+              const ::Opm::ECLInitFileData& init);
         };
 
         static EPSPtr
@@ -573,8 +561,7 @@ namespace Create {
 // Implementation of Create::TwoPoint::scalingFunction()
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::G(const ::Opm::ECLGraph&        G,
-                        const ::Opm::ECLInitFileData& init,
-                        const InvBeh                  handle_invalid)
+                        const ::Opm::ECLInitFileData& init)
 {
     auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
     auto sgu  = G.rawLinearisedCellData<double>(init, "SGU");
@@ -589,16 +576,13 @@ Create::TwoPoint::Kr::G(const ::Opm::ECLGraph&        G,
     }
 
     return EPSPtr {
-        new EPS {
-            std::move(sgcr), std::move(sgu), handle_invalid
-        }
+        new EPS { std::move(sgcr), std::move(sgu) }
     };
 }
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::OG(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init,
-                         const InvBeh                  handle_invalid)
+                         const ::Opm::ECLInitFileData& init)
 {
     auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
 
@@ -645,16 +629,13 @@ Create::TwoPoint::Kr::OG(const ::Opm::ECLGraph&        G,
     }
 
     return EPSPtr {
-        new EPS {
-            std::move(sogcr), std::move(smax), handle_invalid
-        }
+        new EPS { std::move(sogcr), std::move(smax) }
     };
 }
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::OW(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init,
-                         const InvBeh                  handle_invalid)
+                         const ::Opm::ECLInitFileData& init)
 {
     auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
 
@@ -701,16 +682,13 @@ Create::TwoPoint::Kr::OW(const ::Opm::ECLGraph&        G,
     }
 
     return EPSPtr {
-        new EPS {
-            std::move(sowcr), std::move(smax), handle_invalid
-        }
+        new EPS { std::move(sowcr), std::move(smax) }
     };
 }
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::W(const ::Opm::ECLGraph&        G,
-                        const ::Opm::ECLInitFileData& init,
-                        const InvBeh                  handle_invalid)
+                        const ::Opm::ECLInitFileData& init)
 {
     auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
     auto swu  = G.rawLinearisedCellData<double>(init, "SWU");
@@ -722,16 +700,13 @@ Create::TwoPoint::Kr::W(const ::Opm::ECLGraph&        G,
     }
 
     return EPSPtr {
-        new EPS {
-            std::move(swcr), std::move(swu), handle_invalid
-        }
+        new EPS { std::move(swcr), std::move(swu) }
     };
 }
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Pc::GO(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init,
-                         const InvBeh                  handle_invalid)
+                         const ::Opm::ECLInitFileData& init)
 {
     // Try dedicated scaled Sg_conn for Pc first
     auto sgl = G.rawLinearisedCellData<double>(init, "SGLPC");
@@ -752,16 +727,13 @@ Create::TwoPoint::Pc::GO(const ::Opm::ECLGraph&        G,
     }
 
     return EPSPtr {
-        new EPS {
-            std::move(sgl), std::move(sgu), handle_invalid
-        }
+        new EPS { std::move(sgl), std::move(sgu) }
     };
 }
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Pc::OW(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init,
-                         const InvBeh                  handle_invalid)
+                         const ::Opm::ECLInitFileData& init)
 {
     // Try dedicated scaled Sw_conn for Pc first
     auto swl = G.rawLinearisedCellData<double>(init, "SWLPC");
@@ -782,9 +754,7 @@ Create::TwoPoint::Pc::OW(const ::Opm::ECLGraph&        G,
     }
 
     return EPSPtr {
-        new EPS {
-            std::move(swl), std::move(swu), handle_invalid
-        }
+        new EPS { std::move(swl), std::move(swu) }
     };
 }
 
@@ -811,10 +781,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
             }
 
             if (opt.thisPh == PhIdx::Aqua) {
-                return Create::TwoPoint::Kr::W(G, init, opt.handle_invalid);
+                return Create::TwoPoint::Kr::W(G, init);
             }
 
-            return Create::TwoPoint::Kr::OW(G, init, opt.handle_invalid);
+            return Create::TwoPoint::Kr::OW(G, init);
         }
 
         if (opt.subSys == SSys::OilGas) {
@@ -826,10 +796,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
             }
 
             if (opt.thisPh == PhIdx::Vapour) {
-                return Create::TwoPoint::Kr::G(G, init, opt.handle_invalid);
+                return Create::TwoPoint::Kr::G(G, init);
             }
 
-            return Create::TwoPoint::Kr::OG(G, init, opt.handle_invalid);
+            return Create::TwoPoint::Kr::OG(G, init);
         }
     }
 
@@ -842,11 +812,11 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
         }
 
         if (opt.thisPh == PhIdx::Vapour) {
-            return Create::TwoPoint::Pc::GO(G, init, opt.handle_invalid);
+            return Create::TwoPoint::Pc::GO(G, init);
         }
 
         if (opt.thisPh == PhIdx::Aqua) {
-            return Create::TwoPoint::Pc::OW(G, init, opt.handle_invalid);
+            return Create::TwoPoint::Pc::OW(G, init);
         }
     }
 
@@ -931,8 +901,7 @@ Create::TwoPoint::unscaledEndPoints(const RTEP& ep, const EPSOpt& opt)
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::G(const ::Opm::ECLGraph&        G,
-                          const ::Opm::ECLInitFileData& init,
-                          const InvBeh                  handle_invalid)
+                          const ::Opm::ECLInitFileData& init)
 {
     auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
     auto sgu  = G.rawLinearisedCellData<double>(init, "SGU");
@@ -984,15 +953,14 @@ Create::ThreePoint::Kr::G(const ::Opm::ECLGraph&        G,
 
     return EPSPtr {
         new EPS {
-            std::move(sgcr), std::move(sr), std::move(sgu), handle_invalid
+            std::move(sgcr), std::move(sr), std::move(sgu)
         }
     };
 }
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::OG(const ::Opm::ECLGraph&        G,
-                           const ::Opm::ECLInitFileData& init,
-                           const InvBeh                  handle_invalid)
+                           const ::Opm::ECLInitFileData& init)
 {
     auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
 
@@ -1060,15 +1028,14 @@ Create::ThreePoint::Kr::OG(const ::Opm::ECLGraph&        G,
 
     return EPSPtr {
         new EPS {
-            std::move(sogcr), std::move(sdisp), std::move(smax), handle_invalid
+            std::move(sogcr), std::move(sdisp), std::move(smax)
         }
     };
 }
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::OW(const ::Opm::ECLGraph&        G,
-                           const ::Opm::ECLInitFileData& init,
-                           const InvBeh                  handle_invalid)
+                           const ::Opm::ECLInitFileData& init)
 {
     auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
 
@@ -1136,15 +1103,14 @@ Create::ThreePoint::Kr::OW(const ::Opm::ECLGraph&        G,
 
     return EPSPtr {
         new EPS {
-            std::move(sowcr), std::move(sdisp), std::move(smax), handle_invalid
+            std::move(sowcr), std::move(sdisp), std::move(smax)
         }
     };
 }
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::W(const ::Opm::ECLGraph&        G,
-                          const ::Opm::ECLInitFileData& init,
-                          const InvBeh                  handle_invalid)
+                          const ::Opm::ECLInitFileData& init)
 {
     auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
     auto swu  = G.rawLinearisedCellData<double>(init, "SWU");
@@ -1195,7 +1161,7 @@ Create::ThreePoint::Kr::W(const ::Opm::ECLGraph&        G,
 
     return EPSPtr {
         new EPS {
-            std::move(swcr), std::move(sdisp), std::move(swu), handle_invalid
+            std::move(swcr), std::move(sdisp), std::move(swu)
         }
     };
 }
@@ -1225,10 +1191,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
         }
 
         if (opt.thisPh == PhIdx::Aqua) {
-            return Create::ThreePoint::Kr::W(G, init, opt.handle_invalid);
+            return Create::ThreePoint::Kr::W(G, init);
         }
 
-        return Create::ThreePoint::Kr::OW(G, init, opt.handle_invalid);
+        return Create::ThreePoint::Kr::OW(G, init);
     }
 
     if (opt.subSys == SSys::OilGas) {
@@ -1240,10 +1206,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
         }
 
         if (opt.thisPh == PhIdx::Vapour) {
-            return Create::ThreePoint::Kr::G(G, init, opt.handle_invalid);
+            return Create::ThreePoint::Kr::G(G, init);
         }
 
-        return Create::ThreePoint::Kr::OG(G, init, opt.handle_invalid);
+        return Create::ThreePoint::Kr::OG(G, init);
     }
 
     // Invalid.
@@ -1341,10 +1307,9 @@ Opm::SatFunc::EPSEvalInterface::~EPSEvalInterface()
 
 // Class Opm::SatFunc::TwoPointScaling
 Opm::SatFunc::TwoPointScaling::
-TwoPointScaling(std::vector<double>      smin,
-                std::vector<double>      smax,
-                InvalidEndpointBehaviour handle_invalid)
-    : pImpl_(new Impl(std::move(smin), std::move(smax), handle_invalid))
+TwoPointScaling(std::vector<double> smin,
+                std::vector<double> smax)
+    : pImpl_(new Impl(std::move(smin), std::move(smax)))
 {}
 
 Opm::SatFunc::TwoPointScaling::~TwoPointScaling()
@@ -1400,14 +1365,10 @@ Opm::SatFunc::TwoPointScaling::clone() const
 
 // Class Opm::SatFunc::ThreePointScaling
 Opm::SatFunc::ThreePointScaling::
-ThreePointScaling(std::vector<double>      smin,
-                  std::vector<double>      sdisp,
-                  std::vector<double>      smax,
-                  InvalidEndpointBehaviour handle_invalid)
-    : pImpl_(new Impl(std::move(smin) ,
-                      std::move(sdisp),
-                      std::move(smax) ,
-                      handle_invalid))
+ThreePointScaling(std::vector<double> smin,
+                  std::vector<double> sdisp,
+                  std::vector<double> smax)
+    : pImpl_(new Impl(std::move(smin), std::move(sdisp), std::move(smax)))
 {}
 
 Opm::SatFunc::ThreePointScaling::~ThreePointScaling()

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -1459,10 +1459,10 @@ Opm::SatFunc::ThreePointScaling::clone() const
 }
 
 // ---------------------------------------------------------------------
-// Factory function Opm::SatFunc::CreateEPS::fromECLOutput()
+// Factory function Opm::SatFunc::CreateEPS::Horizontal::fromECLOutput()
 
 std::unique_ptr<Opm::SatFunc::EPSEvalInterface>
-Opm::SatFunc::CreateEPS::
+Opm::SatFunc::CreateEPS::Horizontal::
 fromECLOutput(const ECLGraph&        G,
               const ECLInitFileData& init,
               const EPSOptions&      opt)
@@ -1483,10 +1483,10 @@ fromECLOutput(const ECLGraph&        G,
 }
 
 // ---------------------------------------------------------------------
-// Factory function Opm::SatFunc::CreateEPS::unscaledEndPoints()
+// Factory function Opm::SatFunc::CreateEPS::Horizontal::unscaledEndPoints()
 
 std::vector<Opm::SatFunc::EPSEvalInterface::TableEndPoints>
-Opm::SatFunc::CreateEPS::
+Opm::SatFunc::CreateEPS::Horizontal::
 unscaledEndPoints(const RawTableEndPoints& ep,
                   const EPSOptions&        opt)
 {

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -494,46 +494,54 @@ namespace Opm { namespace SatFunc {
             Maximum smax;
         };
 
-        /// Construct an EPS evaluator from a particular ECL result set.
-        ///
-        /// \param[in] G Connected topology of current model's active cells.
-        ///    Needed to linearise table end-points that may be distributed
-        ///    on local grids to all of the model's active cells (\code
-        ///    member function G.rawLinearisedCellData() \endcode).
-        ///
-        /// \param[in] init Container of tabulated saturation functions and
-        ///    saturation table end points for all active cells.
-        ///
-        /// \param[in] opt Options that identify a particular end-point
-        ///    scaling behaviour of a particular saturation function curve.
-        ///
-        /// \return EPS evaluator for the particular curve defined by the
-        ///    input options.
-        static std::unique_ptr<EPSEvalInterface>
-        fromECLOutput(const ECLGraph&        G,
-                      const ECLInitFileData& init,
-                      const EPSOptions&      opt);
+        /// Named constructors for horizontal (saturation) end-point scaling
+        /// of saturation functions.
+        struct Horizontal {
+            /// Construct a horizontal EPS evaluator from a particular ECL
+            /// result set.
+            ///
+            /// \param[in] G Connected topology of current model's active
+            ///    cells.  Needed to linearise table end-points that may be
+            ///    distributed on local grids to all of the model's active
+            ///    cells (\code member function G.rawLinearisedCellData()
+            ///    \endcode).
+            ///
+            /// \param[in] init Container of tabulated saturation functions
+            ///    and saturation table end points for all active cells.
+            ///
+            /// \param[in] opt Options that identify a particular end-point
+            ///    scaling behaviour of a particular saturation function
+            ///    curve.
+            ///
+            /// \return EPS evaluator for the particular curve defined by
+            ///    the input options.
+            static std::unique_ptr<EPSEvalInterface>
+            fromECLOutput(const ECLGraph&        G,
+                          const ECLInitFileData& init,
+                          const EPSOptions&      opt);
 
-        /// Extract table end points relevant to a particular EPS evaluator
-        /// from raw tabulated saturation functions.
-        ///
-        /// \param[in] ep Collection of all raw table saturation end points
-        ///    for all tabulated saturation functions.  Typically computed
-        ///    by direct calls to the \code connateSat() \endcode, \code
-        ///    criticalSat() \endcode, and \code maximumSat() \endcode of
-        ///    the currently active \code Opm::SatFuncInterpolant \code
-        ///    objects.
-        ///
-        /// \param[in] opt Options that identify a particular end-point
-        ///    scaling behaviour of a particular saturation function curve.
-        ///
-        /// \return Subset of the input end points in a format intended for
-        ///    passing as the first argument of member function \code eval()
-        ///    \endcode of the \code EPSEvalInterface \endcode that
-        ///    corresponds to the input options.
-        static std::vector<EPSEvalInterface::TableEndPoints>
-        unscaledEndPoints(const RawTableEndPoints& ep,
-                          const EPSOptions&        opt);
+            /// Extract table end points relevant to a particular horizontal
+            /// EPS evaluator from raw tabulated saturation functions.
+            ///
+            /// \param[in] ep Collection of all raw table saturation end
+            ///    points for all tabulated saturation functions.  Typically
+            ///    computed by direct calls to the \code connateSat()
+            ///    \endcode, \code criticalSat() \endcode, and \code
+            ///    maximumSat() \endcode of the currently active \code
+            ///    Opm::SatFuncInterpolant \code objects.
+            ///
+            /// \param[in] opt Options that identify a particular end-point
+            ///    scaling behaviour of a particular saturation function
+            ///    curve.
+            ///
+            /// \return Subset of the input end points in a format intended
+            ///    for passing as the first argument of member function
+            ///    \code eval() \endcode of the \code EPSEvalInterface
+            ///    \endcode that corresponds to the input options.
+            static std::vector<EPSEvalInterface::TableEndPoints>
+            unscaledEndPoints(const RawTableEndPoints& ep,
+                              const EPSOptions&        opt);
+        };
     };
 }} // namespace Opm::SatFunc
 

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -141,19 +141,8 @@ namespace Opm { namespace SatFunc {
         /// \param[in] smin Left end points for a set of cells.
         ///
         /// \param[in] smax Right end points for a set of cells.
-        ///
-        /// \param[in] handle_invalid How to treat scaling requests with
-        ///    invalid scaled saturations.  This can, for instance, happen
-        ///    if the scaled saturations are present in the result set but
-        ///    some (or all) cells have irreconcilable values (e.g., minimum
-        ///    saturation greater than maximum saturation, smin < -1E+20,
-        ///    smax < -1E+20).
-        ///
-        ///    Default behaviour: Use unscaled saturation if this happens.
-        TwoPointScaling(std::vector<double>            smin,
-                        std::vector<double>            smax,
-                        const InvalidEndpointBehaviour handle_invalid
-                        = InvalidEndpointBehaviour::UseUnscaled);
+        TwoPointScaling(std::vector<double> smin,
+                        std::vector<double> smax);
 
         /// Destructor.
         ~TwoPointScaling();
@@ -261,20 +250,9 @@ namespace Opm { namespace SatFunc {
         ///    for a set of cells.
         ///
         /// \param[in] smax Right end points for a set of cells.
-        ///
-        /// \param[in] handle_invalid How to treat scaling requests with
-        ///    invalid scaled saturations.  This can, for instance, happen
-        ///    if the scaled saturations are present in the result set but
-        ///    some (or all) cells have irreconcilable values (e.g., minimum
-        ///    saturation greater than maximum saturation, smin < -1E+20,
-        ///    smax < -1E+20).
-        ///
-        ///    Default behaviour: Use unscaled saturation if this happens.
-        ThreePointScaling(std::vector<double>            smin,
-                          std::vector<double>            sdisp,
-                          std::vector<double>            smax,
-                          const InvalidEndpointBehaviour handle_invalid
-                          = InvalidEndpointBehaviour::UseUnscaled);
+        ThreePointScaling(std::vector<double> smin,
+                          std::vector<double> sdisp,
+                          std::vector<double> smax);
 
         /// Destructor.
         ~ThreePointScaling();

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -699,6 +699,10 @@ namespace Opm { namespace SatFunc {
         /// Named constructors for vertical (value) scaling of saturation
         /// functions.
         struct Vertical {
+            using SatFuncEvaluator = std::function<double(int, double)>;
+            using FuncValVector    = std::vector<
+                VerticalScalingInterface::FunctionValues>;
+
             /// Construct a vertical saturation function value scaling from
             /// a particular ECL result set.
             ///
@@ -715,17 +719,25 @@ namespace Opm { namespace SatFunc {
             ///    scaling behaviour of a particular saturation function
             ///    curve.
             ///
+            /// \param[in] tep Table end-points.  Used to define critical
+            ///    saturations of displacing phase for vertical scaling at
+            ///    displacing saturation.  Otherwise unused.
+            ///
+            /// \param[in] fvals Function values at selected saturation
+            ///    points.  Typically constructed by means of function
+            ///    unscaledFunctionValues().
+            ///
             /// \return Vertical scaling operator for the particular curve
             ///    defined by the input options.
             static std::unique_ptr<VerticalScalingInterface>
-            fromECLOutput(const ECLGraph&        G,
-                          const ECLInitFileData& init,
-                          const EPSOptions&      opt);
+            fromECLOutput(const ECLGraph&          G,
+                          const ECLInitFileData&   init,
+                          const EPSOptions&        opt,
+                          const RawTableEndPoints& tep,
+                          const FuncValVector&     fvals);
 
-            using SatFuncEvaluator = std::function<double(int, double)>;
-
-            /// Extract table end points relevant to a particular horizontal
-            /// EPS evaluator from raw tabulated saturation functions.
+            /// Extract table end points relevant to a particular vertical
+            /// scaling evaluator from raw tabulated saturation functions.
             ///
             /// \param[in] ep Collection of all raw table saturation end
             ///    points for all tabulated saturation functions.  Typically
@@ -743,7 +755,9 @@ namespace Opm { namespace SatFunc {
             ///    \code eval() \endcode of the \code EPSEvalInterface
             ///    \endcode that corresponds to the input options.
             static std::vector<VerticalScalingInterface::FunctionValues>
-            unscaledFunctionValues(const RawTableEndPoints& ep,
+            unscaledFunctionValues(const ECLGraph&          G,
+                                   const ECLInitFileData&   init,
+                                   const RawTableEndPoints& ep,
                                    const EPSOptions&        opt,
                                    const SatFuncEvaluator&  evalSF);
         };

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -183,9 +183,9 @@ namespace Opm
     ECLFluxCalc::ECLFluxCalc(const ECLGraph&        graph,
                              const ECLInitFileData& init,
                              const double           grav,
-                             const bool             useEPS)
+                             const bool             /* useEPS */)
         : graph_(graph)
-        , satfunc_(graph, init, useEPS)
+        , satfunc_(graph, init)
         , rmap_(pvtnumVector(graph, init))
         , neighbours_(graph.neighbours())
         , transmissibility_(graph.transmissibility())

--- a/opm/utility/ECLGraph.hpp
+++ b/opm/utility/ECLGraph.hpp
@@ -111,10 +111,13 @@ namespace Opm {
         ///     outside valid range or if the specific cell identified by \p
         ///     ijk and \p gridID is not actually active.
         int activeCell(const std::array<int,3>& ijk,
-                       const std::string&       gridID = 0) const;
+                       const std::string&       gridID = "") const;
 
         /// Retrieve number of active cells in graph.
         std::size_t numCells() const;
+
+        /// Retrieve number of active cells in particular subgrid.
+        std::size_t numCells(const std::string& gridID) const;
 
         /// Retrieve number of connections in graph.
         std::size_t numConnections() const;
@@ -182,6 +185,24 @@ namespace Opm {
         std::vector<T>
         rawLinearisedCellData(const ResultSet&   rset,
                               const std::string& vector) const;
+
+        /// Retrieve result set vector from current view (e.g., particular
+        /// report step) linearised on active cells of a particular sub-grid.
+        ///
+        /// \tparam T Element type of result set vector.
+        ///
+        /// \param[in] vector Name of result set vector.
+        ///
+        /// \param[in] gridID Identity of specific grid to which to relate
+        ///    the requested vector.  Use empty for main grid and names for
+        ///    any LGRs.
+        ///
+        /// \return Result set vector linearised on active cells of sub-grid.
+        template <typename T, class ResultSet>
+        std::vector<T>
+        rawLinearisedCellData(const ResultSet&   rset,
+                              const std::string& vector,
+                              const std::string& gridID) const;
 
         /// Convenience type alias for \c UnitSystem PMFs (pointer to member
         /// function).

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -1013,8 +1013,8 @@ private:
             if (active.gas) {
                 opt.subSys = SSys::OilGas;
 
-                this->oil_in_og_.scaling =
-                    Create::fromECLOutput(G, init, opt);
+                this->oil_in_og_.scaling = Create::Horizontal::
+                    fromECLOutput(G, init, opt);
 
                 this->oil_in_og_.tep = this->endPoints(ep, opt);
             }
@@ -1022,8 +1022,8 @@ private:
             if (active.wat) {
                 opt.subSys = SSys::OilWater;
 
-                this->oil_in_ow_.scaling =
-                    Create::fromECLOutput(G, init, opt);
+                this->oil_in_ow_.scaling = Create::Horizontal::
+                    fromECLOutput(G, init, opt);
 
                 this->oil_in_ow_.tep = this->endPoints(ep, opt);
             }
@@ -1041,8 +1041,8 @@ private:
             {
                 opt.curve = FCat::Relperm;
 
-                this->gas_.kr.scaling =
-                    Create::fromECLOutput(G, init, opt);
+                this->gas_.kr.scaling = Create::Horizontal::
+                    fromECLOutput(G, init, opt);
 
                 this->gas_.kr.tep = this->endPoints(ep, opt);
             }
@@ -1056,8 +1056,8 @@ private:
 
                 opt.curve = FCat::CapPress;
 
-                this->gas_.pc.scaling =
-                    Create::fromECLOutput(G, init, opt);
+                this->gas_.pc.scaling = Create::Horizontal::
+                    fromECLOutput(G, init, opt);
 
                 this->gas_.pc.tep = this->endPoints(ep, opt);
 
@@ -1078,8 +1078,8 @@ private:
             {
                 opt.curve = FCat::Relperm;
 
-                this->wat_.kr.scaling =
-                    Create::fromECLOutput(G, init, opt);
+                this->wat_.kr.scaling = Create::Horizontal::
+                    fromECLOutput(G, init, opt);
 
                 this->wat_.kr.tep = this->endPoints(ep, opt);
             }
@@ -1093,8 +1093,8 @@ private:
 
                 opt.curve = FCat::CapPress;
 
-                this->wat_.pc.scaling =
-                    Create::fromECLOutput(G, init, opt);
+                this->wat_.pc.scaling = Create::Horizontal::
+                    fromECLOutput(G, init, opt);
 
                 this->wat_.pc.tep = this->endPoints(ep, opt);
 
@@ -1108,7 +1108,7 @@ private:
         endPoints(const RawTEP& ep, const Create::EPSOptions& opt)
         {
             return EndPtsPtr {
-                new EPSEndPtVec(Create::unscaledEndPoints(ep, opt))
+                new EPSEndPtVec(Create::Horizontal::unscaledEndPoints(ep, opt))
             };
         }
     };

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -32,6 +32,7 @@
 #include <opm/utility/ECLEndPointScaling.hpp>
 
 #include <exception>
+#include <initializer_list>
 #include <stdexcept>
 #include <vector>
 
@@ -67,6 +68,116 @@ namespace {
         }
 
         return sp;
+    }
+
+    std::vector<double> sw_core1d_example()
+    {
+        return {
+            1.700000000000000e-01,
+            1.861700000000000e-01,
+            2.023400000000000e-01,
+            2.185110000000000e-01,
+            2.346810000000000e-01,
+            2.508510000000000e-01,
+            2.670210000000000e-01,
+            2.831910000000000e-01,
+            2.993620000000000e-01,
+            3.155320000000000e-01,
+            3.317020000000000e-01,
+            3.478720000000000e-01,
+            3.640430000000000e-01,
+            3.802130000000000e-01,
+            3.963830000000000e-01,
+            4.125530000000000e-01,
+            4.287230000000000e-01,
+            4.448940000000000e-01,
+            4.610640000000000e-01,
+            4.772340000000000e-01,
+            4.934040000000000e-01,
+            5.095740000000000e-01,
+            5.257450000000000e-01,
+            5.419150000000000e-01,
+            5.580850000000001e-01,
+            5.742550000000000e-01,
+            5.904260000000000e-01,
+            6.065960000000000e-01,
+            6.227660000000000e-01,
+            6.389359999999999e-01,
+            6.551060000000000e-01,
+            6.712770000000000e-01,
+            6.874470000000000e-01,
+            7.036170000000000e-01,
+            7.197870000000000e-01,
+            7.359570000000000e-01,
+            7.521280000000000e-01,
+            7.682980000000000e-01,
+            7.844680000000001e-01,
+            8.006380000000000e-01,
+            8.168090000000000e-01,
+            8.329790000000000e-01,
+            8.491490000000000e-01,
+            8.653189999999999e-01,
+            8.814890000000000e-01,
+            8.976600000000000e-01,
+            9.138300000000000e-01,
+            9.300000000000000e-01,
+            1.000000000000000e+00,
+        };
+    }
+
+    std::vector<double> krw_core1d_example()
+    {
+        return {
+            0,
+            4.526940000000000e-04,
+            1.810770000000000e-03,
+            4.074240000000000e-03,
+            7.243100000000000e-03,
+            1.131730000000000e-02,
+            1.629700000000000e-02,
+            2.218200000000000e-02,
+            2.897240000000000e-02,
+            3.666820000000000e-02,
+            4.526940000000000e-02,
+            5.477590000000000e-02,
+            6.518789999999999e-02,
+            7.650520000000000e-02,
+            8.872790000000000e-02,
+            1.018560000000000e-01,
+            1.158900000000000e-01,
+            1.308280000000000e-01,
+            1.466730000000000e-01,
+            1.634220000000000e-01,
+            1.810770000000000e-01,
+            1.996380000000000e-01,
+            2.191040000000000e-01,
+            2.394750000000000e-01,
+            2.607510000000000e-01,
+            2.829330000000000e-01,
+            3.060210000000000e-01,
+            3.300140000000000e-01,
+            3.549120000000000e-01,
+            3.807150000000000e-01,
+            4.074240000000000e-01,
+            4.350380000000000e-01,
+            4.635580000000000e-01,
+            4.929830000000000e-01,
+            5.233139999999999e-01,
+            5.545500000000000e-01,
+            5.866910000000000e-01,
+            6.197370000000000e-01,
+            6.536890000000000e-01,
+            6.885470000000000e-01,
+            7.243100000000000e-01,
+            7.609780000000000e-01,
+            7.985510000000000e-01,
+            8.370300000000001e-01,
+            8.764150000000001e-01,
+            9.167040000000000e-01,
+            9.579000000000000e-01,
+            1.000000000000000e+00,
+            1.000000000000000e+00,
+        };
     }
 } // Namespace Anonymous
 
@@ -624,6 +735,333 @@ BOOST_AUTO_TEST_CASE (ScaledConnate)
 
         check_is_close(s_inp, s_inp_expect);
     }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Pure vertical scaling of SF values.
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (PureVerticalScaling_SFValues)
+
+BOOST_AUTO_TEST_CASE (Parabola_ScaledCell)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    // val = linspace(0, 1, 11) .^ 2
+    const auto val = std::vector<double> {
+        0,
+        1.0e-02,
+        4.0e-02,
+        9.0e-02,
+        1.6e-01,
+        2.5e-01,
+        3.6e-01,
+        4.9e-01,
+        6.4e-01,
+        8.1e-01,
+        1.0e+00,
+    };
+
+    // Maximum value in cell is 0.5.
+    const auto scaler = Opm::SatFunc::PureVerticalScaling({ 0.5 });
+
+    // This is a lie.  We do however not actually use the sp[i].sat values
+    // in *this particular application (pure v-scaling)* though--we only
+    // care about sp[i].cell--so we can get away with pretending that the
+    // function values (val) are saturations.
+    const auto sp = associate(val);
+
+    const auto f = SFVal{
+        SFPt{ 0.0, 0.0 }, // Displacement
+        SFPt{ 1.0, 1.0 }, // Maximum
+    };
+
+    const auto y = scaler.vertScale(f, sp, val);
+
+    // expect = 0.5 * val
+    const auto expect = std::vector<double> {
+        0,
+        5.00e-03,
+        2.00e-02,
+        4.50e-02,
+        8.00e-02,
+        1.25e-01,
+        1.80e-01,
+        2.45e-01,
+        3.20e-01,
+        4.05e-01,
+        5.00e-01,
+    };
+
+    check_is_close(y, expect);
+}
+
+BOOST_AUTO_TEST_CASE (Parabola_ScaledFunc)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    // val = linspace(0, 1, 11) .^ 2
+    const auto val = std::vector<double> {
+        0,
+        1.0e-02,
+        4.0e-02,
+        9.0e-02,
+        1.6e-01,
+        2.5e-01,
+        3.6e-01,
+        4.9e-01,
+        6.4e-01,
+        8.1e-01,
+        1.0e+00,
+    };
+
+    // Maximum value in cell is 1.
+    const auto scaler = Opm::SatFunc::PureVerticalScaling({ 1.0 });
+
+    // This is a lie.  We do however not actually use the sp[i].sat values
+    // in *this particular application (pure v-scaling)* though--we only
+    // care about sp[i].cell--so we can get away with pretending that the
+    // function values (val) are saturations.
+    const auto sp = associate(val);
+
+    const auto f = SFVal{
+        SFPt{ 0.0, 0.0 }, // Displacement
+        SFPt{ 1.0, 2.0 }, // Maximum
+    };
+
+    const auto y = scaler.vertScale(f, sp, val);
+
+    // expect = val / 2
+    const auto expect = std::vector<double> {
+        0,
+        5.00e-03,
+        2.00e-02,
+        4.50e-02,
+        8.00e-02,
+        1.25e-01,
+        1.80e-01,
+        2.45e-01,
+        3.20e-01,
+        4.05e-01,
+        5.00e-01,
+    };
+
+    check_is_close(y, expect);
+}
+
+BOOST_AUTO_TEST_CASE (Parabola_ScaledBoth)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    // val = linspace(0, 1, 11) .^ 2
+    const auto val = std::vector<double> {
+        0,
+        1.0e-02,
+        4.0e-02,
+        9.0e-02,
+        1.6e-01,
+        2.5e-01,
+        3.6e-01,
+        4.9e-01,
+        6.4e-01,
+        8.1e-01,
+        1.0e+00,
+    };
+
+    // Maximum value in cell is 1.5.
+    const auto scaler = Opm::SatFunc::PureVerticalScaling({ 1.5 });
+
+    // This is a lie.  We do however not actually use the sp[i].sat values
+    // in *this particular application (pure v-scaling)* though--we only
+    // care about sp[i].cell--so we can get away with pretending that the
+    // function values (val) are saturations.
+    const auto sp = associate(val);
+
+    const auto f = SFVal{
+        SFPt{ 0.0, 0.0 }, // Displacement
+        SFPt{ 1.0, 2.0 }, // Maximum
+    };
+
+    const auto y = scaler.vertScale(f, sp, val);
+
+    // expect = val * 0.75
+    const auto expect = std::vector<double> {
+        0,
+        7.500e-03,
+        3.000e-02,
+        6.750e-02,
+        1.200e-01,
+        1.875e-01,
+        2.700e-01,
+        3.675e-01,
+        4.800e-01,
+        6.075e-01,
+        7.500e-01,
+    };
+
+    check_is_close(y, expect);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+// Critical saturation vertical scaling of SF values.
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (CritSatVScale_SFValues)
+
+/*
+  sw = 0.1 : 0.05 : 0.9;
+  kr = sw .^ 2;
+
+  [sdisp, fdisp, fmax] = deal(0.7, 0.6, 0.7);
+
+  i = ~ (sw > sdisp);
+  y = 0 * kr;
+  y( i) = kr(i) .* fdisp./sdisp^2;
+  y(~i) = fdisp + (kr(~i) - sdisp^2)./(kr(end) - sdisp^2) .* (fmax - fdisp);
+
+  figure, plot(sw, [kr; y], '.-')
+  legend('Unscaled', 'Vert. Scaled', 'Location', 'Best')
+*/
+BOOST_AUTO_TEST_CASE (Sw2_Regular)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    const auto sw = associate({
+        1.0e-01, 1.5e-01, 2.0e-01, 2.5e-01,
+        3.0e-01, 3.5e-01, 4.0e-01, 4.5e-01,
+        5.0e-01, 5.5e-01, 6.0e-01, 6.5e-01,
+        7.0e-01, 7.5e-01, 8.0e-01, 8.5e-01,
+        9.0e-01,
+    });
+
+    const auto kr = std::vector<double> { // sw^2
+        1.000e-02, 2.250e-02, 4.000e-02, 6.250e-02, //  0 ..  3
+        9.000e-02, 1.225e-01, 1.600e-01, 2.025e-01, //  4 ..  7
+        2.500e-01, 3.025e-01, 3.600e-01, 4.225e-01, //  8 .. 11
+        4.900e-01, 5.625e-01, 6.400e-01, 7.225e-01, // 12 .. 15
+        8.100e-01,                                  // 16
+    };
+
+    const auto f = SFVal{
+        SFPt{ 0.7, 0.49 }, // Displacement
+        SFPt{ 0.9, 0.81 }, // Maximum
+    };
+
+    // Scaled residual displacement sat: 0.7
+    // Scaled Kr at Scaled Sr (KRxR):    0.6
+    // Scaled Kr at Smax:     (KRx)      0.7
+    const auto scaler = Opm::SatFunc::
+        CritSatVerticalScaling({ 0.71 }, { 0.6 }, { 0.7 });
+
+    const auto y = scaler.vertScale(f, sw, kr);
+
+    // expect = kr .* (KRxR/0.49), S \le Sr
+    //          KRxR + (kr - 0.49)/(0.81 - 0.49)*(KRx - KRxR), Sr < S
+    const auto expect = std::vector<double> {
+        1.224489795918368e-02,  //  0
+        2.755102040816328e-02,  //  1
+        4.897959183673471e-02,  //  2
+        7.653061224489796e-02,  //  3
+        1.102040816326531e-01,  //  4
+        1.500000000000000e-01,  //  5
+        1.959183673469388e-01,  //  6
+        2.479591836734695e-01,  //  7
+        3.061224489795918e-01,  //  8
+        3.704081632653062e-01,  //  9
+        4.408163265306123e-01,  // 10
+        5.173469387755103e-01,  // 11
+
+        // ------- Sr -------
+
+        6.000000000000000e-01,  // 12
+        6.226562500000000e-01,  // 13
+        6.468750000000000e-01,  // 14
+        6.726562500000000e-01,  // 15
+        7.000000000000000e-01,  // 16
+    };
+
+    check_is_close(y, expect);
+}
+
+BOOST_AUTO_TEST_CASE (Core1D_Coincident_FVal)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    const auto s  = associate(sw_core1d_example());
+    const auto kr = krw_core1d_example();
+
+    const auto f = SFVal{
+        SFPt{ 0.93, 1.0 }, // Displacement
+        SFPt{ 1.0 , 1.0 }, // Maximum
+    };
+
+    const auto scaler = Opm::SatFunc::
+        CritSatVerticalScaling({ 0.93 }, { 0.9 }, { 1.0 });
+
+    const auto y = scaler.vertScale(f, s, kr);
+
+    const auto expect = std::vector<double> {
+        0,
+        4.074246000000000e-04,
+        1.629693000000000e-03,
+        3.666816000000000e-03,
+        6.518790000000000e-03,
+        1.018557000000000e-02,
+        1.466730000000000e-02,
+        1.996380000000000e-02,
+        2.607516000000000e-02,
+        3.300138000000000e-02,
+        4.074246000000000e-02,
+        4.929831000000000e-02,
+        5.866911000000000e-02,
+        6.885468000000000e-02,
+        7.985511000000001e-02,
+        9.167040000000000e-02,
+        1.043010000000000e-01,
+        1.177452000000000e-01,
+        1.320057000000000e-01,
+        1.470798000000000e-01,
+        1.629693000000000e-01,
+        1.796742000000000e-01,
+        1.971936000000000e-01,
+        2.155275000000000e-01,
+        2.346759000000000e-01,
+        2.546397000000000e-01,
+        2.754189000000000e-01,
+        2.970126000000000e-01,
+        3.194208000000000e-01,
+        3.426435000000000e-01,
+        3.666816000000000e-01,
+        3.915342000000000e-01,
+        4.172022000000000e-01,
+        4.436847000000000e-01,
+        4.709826000000000e-01,
+        4.990950000000000e-01,
+        5.280218999999999e-01,
+        5.577633000000000e-01,
+        5.883201000000000e-01,
+        6.196923000000001e-01,
+        6.518790000000000e-01,
+        6.848802000000001e-01,
+        7.186959000000001e-01,
+        7.533270000000001e-01,
+        7.887735000000000e-01,
+        8.250336000000000e-01,
+        8.621100000000000e-01,
+        9.000000000000000e-01,
+        1.000000000000000e+00,
+    };
+
+    check_is_close(y, expect);
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -21,10 +21,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_ECLENDPOINTSCALING

--- a/tests/test_eclpropertyunitconversion.cpp
+++ b/tests/test_eclpropertyunitconversion.cpp
@@ -22,10 +22,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_ECLPROPERTYUNITCONVERSION

--- a/tests/test_eclproptable.cpp
+++ b/tests/test_eclproptable.cpp
@@ -21,10 +21,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_ECLPROPTABLE

--- a/tests/test_eclpvtcommon.cpp
+++ b/tests/test_eclpvtcommon.cpp
@@ -22,10 +22,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_ECLPVTCOMMON_UNITCONV

--- a/tests/test_eclregionmapping.cpp
+++ b/tests/test_eclregionmapping.cpp
@@ -22,10 +22,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_REGION_MAPPING

--- a/tests/test_eclsimple1dinterpolant.cpp
+++ b/tests/test_eclsimple1dinterpolant.cpp
@@ -21,10 +21,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_ECL1DINTERPOLATION

--- a/tests/test_eclunithandling.cpp
+++ b/tests/test_eclunithandling.cpp
@@ -22,10 +22,6 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_UNIT_HANDLING


### PR DESCRIPTION
This change-set introduces support for vertical scaling of saturation function values.  It is a partial answer to the needs of ResInsight's [Issue 2401](https://github.com/OPM/ResInsight/issues/2401).

We support both a simple option, `PureVerticalScaling`, which multiplies function values with location-dependent factor--usually derived from input vectors such as `KR{G,O,W}` or `PC{G,W}` and maximum values from saturation function input tables.  The other option is `CritSatVerticalScaling` which additionally scales relative permeability (only) at the critical saturation of the displacing phase.

The vertical scaling feature is currently limited to the system that extracts curves for visual representation only.  We do not yet include the feature in the flux calculation that is a fall-back for missing flux data (vectors `FLR{GAS,OIL,WAT}+`) in an ECL result set.  We expose the new feature through a new overload of member function
```
Opm::ECLSaturationFunc::getSatFuncCurve()
```
which enables selectively turning horizontal and vertical scaling on or off individually.  For reasons of backwards compatibility with out-of-tree callers&mdash;especially ResInsight&mdash;we maintain the original overload with an optional `bool` parameter that turns scaling on or off.  In this case, the setting applies to both horizontal and vertical scaling as a single entity.

---

The picture below was created using a combination of the [`extractPropCurves`](https://github.com/bska/opm-flowdiagnostics-applications/blob/add-vertscale-support/examples/extractPropCurves.cpp) example utility and MATLAB for plotting:
```
extractPropCurves case=CORE-1D.DATA krw=true > unscaled.m
extractPropCurves case=CORE-1D.DATA krw=true useEPS=horizontal,vertical > scaled.m
```

```matlab
run unscaled, us = krw{1};  run scaled, sc = krw{1};
figure, plot(us(:,1), us(:,2), 'x-', sc(:,1), sc(:,2), 'd-')
legend('Unscaled', 'Scaled (KRWR)', 'Location', 'Best')
xlabel('S_w'), title('Kr_w [Core-1D]')
```

![krw-core1d](https://user-images.githubusercontent.com/1871438/39507247-b8949b9c-4da2-11e8-9504-a625928660ce.png)
