### PR TITLE
Vertical Scaling: Use Correct Scaled Displacement Saturation for Sr in All Cases

### DIFF
--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -87,6 +87,19 @@ namespace {
         return tep;
     }
 
+    bool haveKeywordData(const ::Opm::ECLGraph&        G,
+                         const ::Opm::ECLInitFileData& init,
+                         const std::string&            vector)
+    {
+        const auto& grids = G.activeGrids();
+
+        return std::any_of(std::begin(grids), std::end(grids),
+            [&init, &vector](const std::string& gridID)
+        {
+            return init.haveKeywordData(vector, gridID);
+        });
+    }
+
     template <class CvrtVal>
     std::vector<double>
     gridDefaultedVector(const ::Opm::ECLGraph&        G,
@@ -120,6 +133,80 @@ namespace {
         return ret;
     }
 
+    std::vector<double>
+    sgCrit(const ::Opm::ECLGraph&                              G,
+           const ::Opm::ECLInitFileData&                       init,
+           const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        return gridDefaultedVector(G, init, "SGCR", tep.crit.gas,
+                                   [](const double s) { return s; });
+    }
+
+    std::vector<double>
+    sogCrit(const ::Opm::ECLGraph&                              G,
+            const ::Opm::ECLInitFileData&                       init,
+            const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        return gridDefaultedVector(G, init, "SOGCR", tep.crit.oil_in_gas,
+                                   [](const double s) { return s; });
+    }
+
+    std::vector<double>
+    sowCrit(const ::Opm::ECLGraph&                              G,
+            const ::Opm::ECLInitFileData&                       init,
+            const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        return gridDefaultedVector(G, init, "SOWCR", tep.crit.oil_in_water,
+                                   [](const double s) { return s; });
+    }
+
+    std::vector<double>
+    swCrit(const ::Opm::ECLGraph&                              G,
+           const ::Opm::ECLInitFileData&                       init,
+           const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        return gridDefaultedVector(G, init, "SWCR", tep.crit.water,
+                                   [](const double s) { return s; });
+    }
+
+    std::vector<double>
+    sgMax(const ::Opm::ECLGraph&                              G,
+          const ::Opm::ECLInitFileData&                       init,
+          const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        return gridDefaultedVector(G, init, "SGU", tep.smax.gas,
+                                   [](const double s) { return s; });
+    }
+
+    std::vector<double>
+    soMax(const ::Opm::ECLGraph&                              G,
+          const ::Opm::ECLInitFileData&                       init,
+          const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        auto smax = std::vector<double>(G.numCells());
+
+        const auto sgl = ::Opm::SatFunc::scaledConnateGas  (G, init, tep);
+        const auto swl = ::Opm::SatFunc::scaledConnateWater(G, init, tep);
+
+        std::transform(std::begin(sgl), std::end(sgl), std::begin(swl),
+                       std::begin(smax),
+            [](const double sg, const double sw) -> double
+        {
+            return 1.0 - (sg + sw);
+        });
+
+        return smax;
+    }
+
+    std::vector<double>
+    swMax(const ::Opm::ECLGraph&                              G,
+          const ::Opm::ECLInitFileData&                       init,
+          const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        return gridDefaultedVector(G, init, "SWU", tep.smax.water,
+                                   [](const double s) { return s; });
+    }
+
     double defaultedScaledSaturation(const double s, const double dflt)
     {
         // Use input scaled saturation ('s') if not defaulted (|s| < 1e20),
@@ -143,6 +230,27 @@ namespace {
         {
             return result && validSaturation(s);
         });
+    }
+
+    bool
+    haveScaledRelPermAtCritSat(const ::Opm::ECLGraph&                       G,
+                               const ::Opm::ECLInitFileData&                init,
+                               const ::Opm::SatFunc::CreateEPS::EPSOptions& opt)
+    {
+        switch (opt.thisPh) {
+        case ::Opm::ECLPhaseIndex::Aqua:
+            return haveKeywordData(G, init, "KRWR");
+
+        case ::Opm::ECLPhaseIndex::Liquid:
+            return (opt.subSys == ::Opm::SatFunc::CreateEPS::SubSystem::OilGas)
+                ? haveKeywordData(G, init, "KRORG")
+                : haveKeywordData(G, init, "KRORW");
+
+        case ::Opm::ECLPhaseIndex::Vapour:
+            return haveKeywordData(G, init, "KRGR");
+        }
+
+        return false;
     }
 }
 
@@ -364,9 +472,11 @@ class Opm::SatFunc::CritSatVerticalScaling::Impl
 public:
     explicit Impl(std::vector<double> sdisp,
                   std::vector<double> fdisp,
+                  std::vector<double> smax,
                   std::vector<double> fmax)
         : sdisp_(std::move(sdisp))
         , fdisp_(std::move(fdisp))
+        , smax_ (std::move(smax))
         , fmax_ (std::move(fmax))
     {}
 
@@ -378,6 +488,7 @@ public:
 private:
     std::vector<double> sdisp_;
     std::vector<double> fdisp_;
+    std::vector<double> smax_;
     std::vector<double> fmax_;
 };
 
@@ -393,9 +504,9 @@ vertScale(const FunctionValues&   f,
 
     auto ret = std::move(val);
 
-    const auto fdisp = f.disp.val;   const auto sdisp = f.disp.sat;
-    const auto fmax  = f.max .val;   const auto smax  = f.max .sat;
-    const auto sepfv = fmax > fdisp; const auto sep_s = sdisp > smax;
+    const auto fdisp = f.disp.val;
+    const auto fmax  = f.max .val;
+    const auto sepfv = fmax > fdisp;
 
     for (auto n = sp.size(), i = 0*n; i < n; ++i) {
         auto& y = ret[i];
@@ -404,6 +515,7 @@ vertScale(const FunctionValues&   f,
         const auto s  = sp[i].sat;
         const auto sr = this->sdisp_[c];
         const auto fr = this->fdisp_[c];
+        const auto sm = this->smax_ [c];
         const auto fm = this->fmax_ [c];
 
         if (! (s > sr)) {
@@ -411,20 +523,20 @@ vertScale(const FunctionValues&   f,
             y *= fr / fdisp;
         }
         else if (sepfv) {
-            // Normal case: Kr(Smax) > Kr(Sr)
+            // s > sr; normal case: Kr(Smax) > Kr(Sr)
             const auto t = (y - fdisp) / (fmax - fdisp);
 
             y = fr + t*(fm - fr);
         }
-        else if (sep_s) {
-            // Special case: Kr(Smax) == Kr(Sr).  Use linear function from
-            // saturations.
-            const auto t = (s - sdisp) / (smax - sdisp);
+        else if (s < sm) {
+            // s > sr; special case: Kr(Smax) == Kr(Sr) in table.  Use
+            // linear function between (sr,fr) and (sm,fm).
+            const auto t = (s - sr) / (sm - sr);
 
             y = fr + t*(fm - fr);
         }
         else {
-            // Smax == Sr; Almost arbitrarily pick fmax_[c].
+            // sm == sr (pure scaling).  Almost arbitrarily pick fmax_[c].
             y = fm;
         }
     }
@@ -633,42 +745,6 @@ handleInvalidEndpoint(const SaturationAssoc& sp,
 // EPS factory functions for two-point and three-point scaling options
 // ---------------------------------------------------------------------
 
-namespace {
-    bool haveScaledRelPermAtCritSatKeyword(const ::Opm::ECLGraph&        G,
-                                           const ::Opm::ECLInitFileData& init,
-                                           const std::string&            kw)
-    {
-        auto haveKW = false;
-
-        for (const auto& grid : G.activeGrids()) {
-            haveKW = haveKW || init.haveKeywordData(kw, grid);
-        }
-
-        return haveKW;
-    }
-
-    bool haveScaledRelPermAtCritSat(const ::Opm::ECLGraph&                     G,
-                                    const ::Opm::ECLInitFileData&              init,
-                                    const ::Opm::ECLPhaseIndex                 phase,
-                                    const ::Opm::SatFunc::CreateEPS::SubSystem subSys)
-    {
-        switch (phase) {
-        case ::Opm::ECLPhaseIndex::Aqua:
-            return haveScaledRelPermAtCritSatKeyword(G, init, "KRWR");
-
-        case ::Opm::ECLPhaseIndex::Liquid:
-            return (subSys == ::Opm::SatFunc::CreateEPS::SubSystem::OilGas)
-                ? haveScaledRelPermAtCritSatKeyword(G, init, "KROGR")
-                : haveScaledRelPermAtCritSatKeyword(G, init, "KROWR");
-
-        case ::Opm::ECLPhaseIndex::Vapour:
-            return haveScaledRelPermAtCritSatKeyword(G, init, "KRGR");
-        }
-
-        return false;
-    }
-} // namespace Anonymous
-
 namespace Create {
     using EPSOpt = ::Opm::SatFunc::CreateEPS::EPSOptions;
     using RTEP   = ::Opm::SatFunc::CreateEPS::RawTableEndPoints;
@@ -682,35 +758,42 @@ namespace Create {
         struct Kr {
             static EPSPtr
             G(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init);
+              const ::Opm::ECLInitFileData& init,
+              const RTEP&                   tep);
 
             static EPSPtr
             OG(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init);
+               const ::Opm::ECLInitFileData& init,
+               const RTEP&                   tep);
 
             static EPSPtr
             OW(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init);
+               const ::Opm::ECLInitFileData& init,
+               const RTEP&                   tep);
 
             static EPSPtr
             W(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init);
+              const ::Opm::ECLInitFileData& init,
+              const RTEP&                   tep);
         };
 
         struct Pc {
             static EPSPtr
             GO(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init);
+               const ::Opm::ECLInitFileData& init,
+               const RTEP&                   tep);
 
             static EPSPtr
             OW(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init);
+               const ::Opm::ECLInitFileData& init,
+               const RTEP&                   tep);
         };
 
         static EPSPtr
         scalingFunction(const ::Opm::ECLGraph&        G,
                         const ::Opm::ECLInitFileData& init,
-                        const EPSOpt&                 opt);
+                        const EPSOpt&                 opt,
+                        const RTEP&                   tep);
 
         static std::vector<TEP>
         unscaledEndPoints(const RTEP& ep, const EPSOpt& opt);
@@ -723,25 +806,30 @@ namespace Create {
         struct Kr {
             static EPSPtr
             G(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init);
+              const ::Opm::ECLInitFileData& init,
+              const RTEP&                   tep);
 
             static EPSPtr
             OG(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init);
+               const ::Opm::ECLInitFileData& init,
+               const RTEP&                   tep);
 
             static EPSPtr
             OW(const ::Opm::ECLGraph&        G,
-               const ::Opm::ECLInitFileData& init);
+               const ::Opm::ECLInitFileData& init,
+               const RTEP&                   tep);
 
             static EPSPtr
             W(const ::Opm::ECLGraph&        G,
-              const ::Opm::ECLInitFileData& init);
+              const ::Opm::ECLInitFileData& init,
+              const RTEP&                   tep);
         };
 
         static EPSPtr
-        scalingFunction(const ::Opm::ECLGraph&                       G,
-                        const ::Opm::ECLInitFileData&                init,
-                        const ::Opm::SatFunc::CreateEPS::EPSOptions& opt);
+        scalingFunction(const ::Opm::ECLGraph&        G,
+                        const ::Opm::ECLInitFileData& init,
+                        const EPSOpt&                 opt,
+                        const RTEP&                   tep);
 
         static std::vector<TEP>
         unscaledEndPoints(const RTEP& ep, const EPSOpt& opt);
@@ -795,29 +883,94 @@ namespace Create {
         using FValVec = ::Opm::SatFunc::CreateEPS::Vertical::FuncValVector;
         using ScalPtr = std::unique_ptr<Scaling>;
 
+        namespace CritDispSat {
+            struct KrG {
+                static std::vector<double>
+                twoPointMethod(const ::Opm::ECLGraph&        G,
+                               const ::Opm::ECLInitFileData& init,
+                               const RTEP&                   tep,
+                               const bool                    activeOil);
+
+                static std::vector<double>
+                alternateMethod(const ::Opm::ECLGraph&        G,
+                                const ::Opm::ECLInitFileData& init,
+                                const RTEP&                   tep,
+                                const bool                    activeOil);
+            };
+
+            struct KrGO {
+                static std::vector<double>
+                twoPointMethod(const ::Opm::ECLGraph&        G,
+                               const ::Opm::ECLInitFileData& init,
+                               const RTEP&                   tep);
+
+                static std::vector<double>
+                alternateMethod(const ::Opm::ECLGraph&        G,
+                                const ::Opm::ECLInitFileData& init,
+                                const RTEP&                   tep);
+            };
+
+            struct KrOW {
+                static std::vector<double>
+                twoPointMethod(const ::Opm::ECLGraph&        G,
+                               const ::Opm::ECLInitFileData& init,
+                               const RTEP&                   tep);
+
+                static std::vector<double>
+                alternateMethod(const ::Opm::ECLGraph&        G,
+                                const ::Opm::ECLInitFileData& init,
+                                const RTEP&                   tep);
+            };
+
+            struct KrW {
+                static std::vector<double>
+                twoPointMethod(const ::Opm::ECLGraph&        G,
+                               const ::Opm::ECLInitFileData& init,
+                               const RTEP&                   tep,
+                               const bool                    activeOil);
+
+                static std::vector<double>
+                alternateMethod(const ::Opm::ECLGraph&        G,
+                                const ::Opm::ECLInitFileData& init,
+                                const RTEP&                   tep,
+                                const bool                    activeOil);
+            };
+
+            std::vector<double>
+            transformedCritSat(const ::Opm::ECLGraph&        G,
+                               const ::Opm::ECLInitFileData& init,
+                               const std::vector<double>&    t,
+                               const std::vector<double>&    left,
+                               const std::vector<double>&    right);
+        } // namespace CritDispSat
+
         struct Kr {
             static ScalPtr
             G(const ::Opm::ECLGraph&        G,
               const ::Opm::ECLInitFileData& init,
-              const RTEP&                   tep,
+              std::vector<double>&&         sdisp,
+              std::vector<double>&&         smax,
               const FValVec&                fval);
 
             static ScalPtr
             GO(const ::Opm::ECLGraph&        G,
                const ::Opm::ECLInitFileData& init,
-               const RTEP&                   tep,
+               std::vector<double>&&         sdisp,
+               std::vector<double>&&         smax,
                const FValVec&                fval);
 
             static ScalPtr
             OW(const ::Opm::ECLGraph&        G,
                const ::Opm::ECLInitFileData& init,
-               const RTEP&                   tep,
+               std::vector<double>&&         sdisp,
+               std::vector<double>&&         smax,
                const FValVec&                fval);
 
             static ScalPtr
             W(const ::Opm::ECLGraph&        G,
               const ::Opm::ECLInitFileData& init,
-              const RTEP&                   tep,
+              std::vector<double>&&         sdisp,
+              std::vector<double>&&         smax,
               const FValVec&                fval);
         };
 
@@ -834,10 +987,11 @@ namespace Create {
 // Implementation of Create::TwoPoint::scalingFunction()
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::G(const ::Opm::ECLGraph&        G,
-                        const ::Opm::ECLInitFileData& init)
+                        const ::Opm::ECLInitFileData& init,
+                        const RTEP&                   tep)
 {
-    auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
-    auto sgu  = G.rawLinearisedCellData<double>(init, "SGU");
+    auto sgcr = sgCrit(G, init, tep);
+    auto sgu  = sgMax (G, init, tep);
 
     if ((sgcr.size() != sgu.size()) ||
         (sgcr.size() != G.numCells()))
@@ -855,9 +1009,10 @@ Create::TwoPoint::Kr::G(const ::Opm::ECLGraph&        G,
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::OG(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init)
+                         const ::Opm::ECLInitFileData& init,
+                         const RTEP&                   tep)
 {
-    auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
+    auto sogcr = sogCrit(G, init, tep);
 
     if (sogcr.size() != G.numCells()) {
         throw std::invalid_argument {
@@ -866,40 +1021,7 @@ Create::TwoPoint::Kr::OG(const ::Opm::ECLGraph&        G,
         };
     }
 
-    auto smax = std::vector<double>(sogcr.size(), 1.0);
-
-    // Adjust maximum S_o for scaled connate gas saturations.
-    {
-        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
-
-        if (sgl.size() != sogcr.size()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Connate Gas "
-                "Saturation in Oil/Gas System"
-            };
-        }
-
-        for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
-            smax[i] -= sgl[i];
-        }
-    }
-
-    // Adjust maximum S_o for scaled connate water saturations (if relevant).
-    {
-        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
-
-        if (swl.size() == sogcr.size()) {
-            for (auto n = swl.size(), i = 0*n; i < n; ++i) {
-                smax[i] -= swl[i];
-            }
-        }
-        else if (! swl.empty()) {
-            throw std::invalid_argument {
-                "Mismatching Connate Water "
-                "Saturation in Oil/Gas System"
-            };
-        }
-    }
+    auto smax = soMax(G, init, tep);
 
     return EPSPtr {
         new EPS { std::move(sogcr), std::move(smax) }
@@ -908,9 +1030,10 @@ Create::TwoPoint::Kr::OG(const ::Opm::ECLGraph&        G,
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::OW(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init)
+                         const ::Opm::ECLInitFileData& init,
+                         const RTEP&                   tep)
 {
-    auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
+    auto sowcr = sowCrit(G, init, tep);
 
     if (sowcr.size() != G.numCells()) {
         throw std::invalid_argument {
@@ -919,40 +1042,7 @@ Create::TwoPoint::Kr::OW(const ::Opm::ECLGraph&        G,
         };
     }
 
-    auto smax = std::vector<double>(sowcr.size(), 1.0);
-
-    // Adjust maximum S_o for scaled connate water saturations.
-    {
-        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
-
-        if (swl.size() != sowcr.size()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Connate Water "
-                "Saturation in Oil/Water System"
-            };
-        }
-
-        for (auto n = swl.size(), i = 0*n; i < n; ++i) {
-            smax[i] -= swl[i];
-        }
-    }
-
-    // Adjust maximum S_o for scaled connate gas saturations (if relevant).
-    {
-        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
-
-        if (sgl.size() == sowcr.size()) {
-            for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
-                smax[i] -= sgl[i];
-            }
-        }
-        else if (! sgl.empty()) {
-            throw std::invalid_argument {
-                "Mismatching Connate Gas "
-                "Saturation in Oil/Water System"
-            };
-        }
-    }
+    auto smax = soMax(G, init, tep);
 
     return EPSPtr {
         new EPS { std::move(sowcr), std::move(smax) }
@@ -961,10 +1051,11 @@ Create::TwoPoint::Kr::OW(const ::Opm::ECLGraph&        G,
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Kr::W(const ::Opm::ECLGraph&        G,
-                        const ::Opm::ECLInitFileData& init)
+                        const ::Opm::ECLInitFileData& init,
+                        const RTEP&                   tep)
 {
-    auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
-    auto swu  = G.rawLinearisedCellData<double>(init, "SWU");
+    auto swcr = swCrit(G, init, tep);
+    auto swu  = swMax (G, init, tep);
 
     if (swcr.empty() || swu.empty()) {
         throw std::invalid_argument {
@@ -979,16 +1070,18 @@ Create::TwoPoint::Kr::W(const ::Opm::ECLGraph&        G,
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Pc::GO(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init)
+                         const ::Opm::ECLInitFileData& init,
+                         const RTEP&                   tep)
 {
-    // Try dedicated scaled Sg_conn for Pc first
-    auto sgl = G.rawLinearisedCellData<double>(init, "SGLPC");
-    if (sgl.empty()) {
-        // Fall back to general scaled Sg_conn if not available.
-        sgl = G.rawLinearisedCellData<double>(init, "SGL");
-    }
+    // Use dedicated scaled Sg_conn for Pc if defined in at least one
+    // subgrid.  Use SGL otherwise.  Same default value (i.e., table's
+    // connate gas saturation) for both vectors.
+    auto sgl = haveKeywordData(G, init, "SGLPC")
+        ? gridDefaultedVector(G, init, "SGLPC", tep.conn.gas,
+                              [](const double s) { return s; })
+        : ::Opm::SatFunc::scaledConnateGas(G, init, tep);
 
-    auto sgu = G.rawLinearisedCellData<double>(init, "SGU");
+    auto sgu = sgMax(G, init, tep);
 
     if ((sgl.size() != sgu.size()) ||
         (sgl.size() != G.numCells()))
@@ -1006,16 +1099,18 @@ Create::TwoPoint::Pc::GO(const ::Opm::ECLGraph&        G,
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::Pc::OW(const ::Opm::ECLGraph&        G,
-                         const ::Opm::ECLInitFileData& init)
+                         const ::Opm::ECLInitFileData& init,
+                         const RTEP&                   tep)
 {
-    // Try dedicated scaled Sw_conn for Pc first
-    auto swl = G.rawLinearisedCellData<double>(init, "SWLPC");
-    if (swl.empty()) {
-        // Fall back to general scaled Sw_conn if not available.
-        swl = G.rawLinearisedCellData<double>(init, "SWL");
-    }
+    // Use dedicated scaled Sw_conn for Pc if defined in at least one
+    // subgrid.  Use SWL otherwise.  Same default value (i.e., table's
+    // connate water saturation) for both vectors.
+    auto swl = haveKeywordData(G, init, "SWLPC")
+        ? gridDefaultedVector(G, init, "SWLPC", tep.conn.water,
+                              [](const double s) { return s; })
+        : ::Opm::SatFunc::scaledConnateWater(G, init, tep);
 
-    auto swu = G.rawLinearisedCellData<double>(init, "SWU");
+    auto swu = swMax(G, init, tep);
 
     if ((swl.size() != swu.size()) ||
         (swl.size() != G.numCells()))
@@ -1033,9 +1128,10 @@ Create::TwoPoint::Pc::OW(const ::Opm::ECLGraph&        G,
 
 Create::TwoPoint::EPSPtr
 Create::TwoPoint::
-scalingFunction(const ::Opm::ECLGraph&                       G,
-                const ::Opm::ECLInitFileData&                init,
-                const ::Opm::SatFunc::CreateEPS::EPSOptions& opt)
+scalingFunction(const ::Opm::ECLGraph&        G,
+                const ::Opm::ECLInitFileData& init,
+                const EPSOpt&                 opt,
+                const RTEP&                   tep)
 {
     using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
     using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
@@ -1054,10 +1150,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
             }
 
             if (opt.thisPh == PhIdx::Aqua) {
-                return Create::TwoPoint::Kr::W(G, init);
+                return Create::TwoPoint::Kr::W(G, init, tep);
             }
 
-            return Create::TwoPoint::Kr::OW(G, init);
+            return Create::TwoPoint::Kr::OW(G, init, tep);
         }
 
         if (opt.subSys == SSys::OilGas) {
@@ -1069,10 +1165,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
             }
 
             if (opt.thisPh == PhIdx::Vapour) {
-                return Create::TwoPoint::Kr::G(G, init);
+                return Create::TwoPoint::Kr::G(G, init, tep);
             }
 
-            return Create::TwoPoint::Kr::OG(G, init);
+            return Create::TwoPoint::Kr::OG(G, init, tep);
         }
     }
 
@@ -1085,11 +1181,11 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
         }
 
         if (opt.thisPh == PhIdx::Vapour) {
-            return Create::TwoPoint::Pc::GO(G, init);
+            return Create::TwoPoint::Pc::GO(G, init, tep);
         }
 
         if (opt.thisPh == PhIdx::Aqua) {
-            return Create::TwoPoint::Pc::OW(G, init);
+            return Create::TwoPoint::Pc::OW(G, init, tep);
         }
     }
 
@@ -1174,10 +1270,11 @@ Create::TwoPoint::unscaledEndPoints(const RTEP& ep, const EPSOpt& opt)
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::G(const ::Opm::ECLGraph&        G,
-                          const ::Opm::ECLInitFileData& init)
+                          const ::Opm::ECLInitFileData& init,
+                          const RTEP&                   tep)
 {
-    auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
-    auto sgu  = G.rawLinearisedCellData<double>(init, "SGU");
+    auto sgcr = sgCrit(G, init, tep);
+    auto sgu  = sgMax (G, init, tep);
 
     if ((sgcr.size() != sgu.size()) ||
         (sgcr.size() != G.numCells()))
@@ -1188,54 +1285,22 @@ Create::ThreePoint::Kr::G(const ::Opm::ECLGraph&        G,
         };
     }
 
-    auto sr = std::vector<double>(G.numCells(), 1.0);
-
-    // Adjust displacing saturation for connate water.
-    {
-        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
-
-        if (swl.size() == sgcr.size()) {
-            for (auto n = swl.size(), i = 0*n; i < n; ++i) {
-                sr[i] -= swl[i];
-            }
-        }
-        else if (! swl.empty()) {
-            throw std::invalid_argument {
-                "Connate Water Saturation Array Mismatch "
-                "in Three-Point Scaling Option"
-            };
-        }
-    }
-
-    // Adjust displacing saturation for critical S_o in O/G system.
-    {
-        const auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
-
-        if (sogcr.size() == sgcr.size()) {
-            for (auto n = sogcr.size(), i = 0*n; i < n; ++i) {
-                sr[i] -= sogcr[i];
-            }
-        }
-        else if (! sogcr.empty()) {
-            throw std::invalid_argument {
-                "Critical Oil Saturation (O/G System) Array "
-                "Size Mismatch in Three-Point Scaling Option"
-            };
-        }
-    }
+    auto sdisp = CritSatVertical::CritDispSat::
+        KrG::alternateMethod(G, init, tep, true);
 
     return EPSPtr {
         new EPS {
-            std::move(sgcr), std::move(sr), std::move(sgu)
+            std::move(sgcr), std::move(sdisp), std::move(sgu)
         }
     };
 }
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::OG(const ::Opm::ECLGraph&        G,
-                           const ::Opm::ECLInitFileData& init)
+                           const ::Opm::ECLInitFileData& init,
+                           const RTEP&                   tep)
 {
-    auto sogcr = G.rawLinearisedCellData<double>(init, "SOGCR");
+    auto sogcr = sogCrit(G, init, tep);
 
     if (sogcr.size() != G.numCells()) {
         throw std::invalid_argument {
@@ -1244,60 +1309,10 @@ Create::ThreePoint::Kr::OG(const ::Opm::ECLGraph&        G,
         };
     }
 
-    auto smax = std::vector<double>(sogcr.size(), 1.0);
+    auto sdisp = CritSatVertical::CritDispSat::
+        KrGO::alternateMethod(G, init, tep);
 
-    // Adjust maximum S_o for scaled connate gas saturations.
-    {
-        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
-
-        if (sgl.size() != sogcr.size()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Connate Gas "
-                "Saturation in Oil/Gas System"
-            };
-        }
-
-        for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
-            smax[i] -= sgl[i];
-        }
-    }
-
-    auto sdisp = std::vector<double>(sogcr.size(), 1.0);
-
-    // Adjust displacing S_o for scaled critical gas saturation.
-    {
-        const auto sgcr = G.rawLinearisedCellData<double>(init, "SGCR");
-
-        if (sgcr.size() != sogcr.size()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Scaled Critical Gas "
-                "Saturation in Oil/Gas System"
-            };
-        }
-
-        for (auto n = sgcr.size(), i = 0*n; i < n; ++i) {
-            sdisp[i] -= sgcr[i];
-        }
-    }
-
-    // Adjust displacing and maximum S_o for scaled connate water
-    // saturations (if relevant).
-    {
-        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
-
-        if (swl.size() == sogcr.size()) {
-            for (auto n = swl.size(), i = 0*n; i < n; ++i) {
-                sdisp[i] -= swl[i];
-                smax [i] -= swl[i];
-            }
-        }
-        else if (! swl.empty()) {
-            throw std::invalid_argument {
-                "Mismatching Scaled Connate Water "
-                "Saturation in Oil/Gas System"
-            };
-        }
-    }
+    auto smax = soMax(G, init, tep);
 
     return EPSPtr {
         new EPS {
@@ -1308,9 +1323,10 @@ Create::ThreePoint::Kr::OG(const ::Opm::ECLGraph&        G,
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::OW(const ::Opm::ECLGraph&        G,
-                           const ::Opm::ECLInitFileData& init)
+                           const ::Opm::ECLInitFileData& init,
+                           const RTEP&                   tep)
 {
-    auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
+    auto sowcr = sowCrit(G, init, tep);
 
     if (sowcr.size() != G.numCells()) {
         throw std::invalid_argument {
@@ -1319,60 +1335,10 @@ Create::ThreePoint::Kr::OW(const ::Opm::ECLGraph&        G,
         };
     }
 
-    auto smax = std::vector<double>(sowcr.size(), 1.0);
+    auto sdisp = CritSatVertical::CritDispSat::
+        KrOW::alternateMethod(G, init, tep);
 
-    // Adjust maximum S_o for scaled connate water saturations.
-    {
-        const auto swl = G.rawLinearisedCellData<double>(init, "SWL");
-
-        if (swl.size() != sowcr.size()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Connate Water "
-                "Saturation in Oil/Water System"
-            };
-        }
-
-        for (auto n = swl.size(), i = 0*n; i < n; ++i) {
-            smax[i] -= swl[i];
-        }
-    }
-
-    auto sdisp = std::vector<double>(sowcr.size(), 1.0);
-
-    // Adjust displacing S_o for scaled critical water saturations.
-    {
-        const auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
-
-        if (swcr.size() != sowcr.size()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Scaled Critical Water "
-                "Saturation in Oil/Water System"
-            };
-        }
-
-        for (auto n = swcr.size(), i = 0*n; i < n; ++i) {
-            sdisp[i] -= swcr[i];
-        }
-    }
-
-    // Adjust displacing and maximum S_o for scaled connate gas saturations
-    // (if relevant).
-    {
-        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
-
-        if (sgl.size() == sowcr.size()) {
-            for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
-                sdisp[i] -= sgl[i];
-                smax [i] -= sgl[i];
-            }
-        }
-        else if (! sgl.empty()) {
-            throw std::invalid_argument {
-                "Mismatching Connate Gas "
-                "Saturation in Oil/Water System"
-            };
-        }
-    }
+    auto smax = soMax(G, init, tep);
 
     return EPSPtr {
         new EPS {
@@ -1383,10 +1349,11 @@ Create::ThreePoint::Kr::OW(const ::Opm::ECLGraph&        G,
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::Kr::W(const ::Opm::ECLGraph&        G,
-                          const ::Opm::ECLInitFileData& init)
+                          const ::Opm::ECLInitFileData& init,
+                          const RTEP&                   tep)
 {
-    auto swcr = G.rawLinearisedCellData<double>(init, "SWCR");
-    auto swu  = G.rawLinearisedCellData<double>(init, "SWU");
+    auto swcr = swCrit(G, init, tep);
+    auto swu  = swMax (G, init, tep);
 
     if ((swcr.size() != G.numCells()) ||
         (swcr.size() != swu.size()))
@@ -1396,41 +1363,8 @@ Create::ThreePoint::Kr::W(const ::Opm::ECLGraph&        G,
         };
     }
 
-    auto sdisp = std::vector<double>(swcr.size(), 1.0);
-
-    // Adjust displacing S_w for scaled critical oil saturation.
-    {
-        const auto sowcr = G.rawLinearisedCellData<double>(init, "SOWCR");
-
-        if (sowcr.size() == swcr.size()) {
-            for (auto n = sowcr.size(), i = 0*n; i < n; ++i) {
-                sdisp[i] -= sowcr[i];
-            }
-        }
-        else if (! sowcr.empty()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Scaled Critical "
-                "Oil Saturation in Oil/Water System"
-            };
-        }
-    }
-
-    // Adjust displacing S_w for scaled connate gas saturation.
-    {
-        const auto sgl = G.rawLinearisedCellData<double>(init, "SGL");
-
-        if (sgl.size() == swcr.size()) {
-            for (auto n = sgl.size(), i = 0*n; i < n; ++i) {
-                sdisp[i] -= sgl[i];
-            }
-        }
-        else if (! sgl.empty()) {
-            throw std::invalid_argument {
-                "Missing or Mismatching Scaled Connate "
-                "Gas Saturation in Oil/Water System"
-            };
-        }
-    }
+    auto sdisp = CritSatVertical::CritDispSat::
+        KrW::alternateMethod(G, init, tep, true);
 
     return EPSPtr {
         new EPS {
@@ -1441,9 +1375,10 @@ Create::ThreePoint::Kr::W(const ::Opm::ECLGraph&        G,
 
 Create::ThreePoint::EPSPtr
 Create::ThreePoint::
-scalingFunction(const ::Opm::ECLGraph&                       G,
-                const ::Opm::ECLInitFileData&                init,
-                const ::Opm::SatFunc::CreateEPS::EPSOptions& opt)
+scalingFunction(const ::Opm::ECLGraph&        G,
+                const ::Opm::ECLInitFileData& init,
+                const EPSOpt&                 opt,
+                const RTEP&                   tep)
 {
 #if !defined(NDEBUG)
     using FCat  = ::Opm::SatFunc::CreateEPS::FunctionCategory;
@@ -1464,10 +1399,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
         }
 
         if (opt.thisPh == PhIdx::Aqua) {
-            return Create::ThreePoint::Kr::W(G, init);
+            return Create::ThreePoint::Kr::W(G, init, tep);
         }
 
-        return Create::ThreePoint::Kr::OW(G, init);
+        return Create::ThreePoint::Kr::OW(G, init, tep);
     }
 
     if (opt.subSys == SSys::OilGas) {
@@ -1479,10 +1414,10 @@ scalingFunction(const ::Opm::ECLGraph&                       G,
         }
 
         if (opt.thisPh == PhIdx::Vapour) {
-            return Create::ThreePoint::Kr::G(G, init);
+            return Create::ThreePoint::Kr::G(G, init, tep);
         }
 
-        return Create::ThreePoint::Kr::OG(G, init);
+        return Create::ThreePoint::Kr::OG(G, init, tep);
     }
 
     // Invalid.
@@ -1726,62 +1661,355 @@ scalingFunction(const ::Opm::ECLGraph&        G,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Implementation of Create::CritSatVertical::scalingFunction()
 
-namespace {
-    template <class Extract>
-    std::vector<double>
-    extractCritSat(const std::vector<Opm::SatFunc::CreateEPS::RawTableEndPoints>& tep,
-                   Extract&& extract)
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrG::twoPointMethod(const ::Opm::ECLGraph&        G,
+                    const ::Opm::ECLInitFileData& init,
+                    const RTEP&                   tep,
+                    const bool                    activeOil)
+{
+    const auto& sgcr = tep.crit.gas;
+    const auto& sgu  = tep.smax.gas;
+
+    auto t = std::vector<double>(sgcr.size(), 0.0);
+    if (activeOil) {
+        // G/O or G/O/W system
+        for (auto n = sgcr.size(), i = 0*n; i < n; ++i) {
+            const auto sr = 1.0 - (tep.crit.oil_in_gas[i] +
+                                   tep.conn.water     [i]);
+
+            t[i] = (sr - sgcr[i]) / (sgu[i] - sgcr[i]);
+        }
+    }
+    else {
+        // G/W system.
+        for (auto n = sgcr.size(), i = 0*n; i < n; ++i) {
+            const auto sr = 1.0 - tep.crit.water[i];
+
+            t[i] = (sr - sgcr[i]) / (sgu[i] - sgcr[i]);
+        }
+    }
+
+    return transformedCritSat(G, init, t,
+                              sgCrit(G, init, tep),
+                              sgMax (G, init, tep));
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrG::alternateMethod(const ::Opm::ECLGraph&        G,
+                     const ::Opm::ECLInitFileData& init,
+                     const RTEP&                   tep,
+                     const bool                    activeOil)
+{
+    auto sdisp = std::vector<double>(G.numCells(), 0.0);
+
+    if (activeOil) {
+        // G/O or G/O/W system.
+        const auto sogcr = sogCrit(G, init, tep);
+        const auto swl   = ::Opm::SatFunc::scaledConnateWater(G, init, tep);
+
+        std::transform(std::begin(sogcr), std::end(sogcr), std::begin(swl),
+                       std::begin(sdisp),
+            [](const double so, const double sw) -> double
+        {
+            return 1.0 - (so + sw);
+        });
+    }
+    else {
+        // G/W system.
+        const auto swcr = swCrit(G, init, tep);
+
+        std::transform(std::begin(swcr), std::end(swcr),
+                       std::begin(sdisp),
+            [](const double sw) -> double
+        {
+            return 1.0 - sw;
+        });
+    }
+
+    return sdisp;
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrGO::twoPointMethod(const ::Opm::ECLGraph&        G,
+                     const ::Opm::ECLInitFileData& init,
+                     const RTEP&                   tep)
+{
+    const auto& sogcr = tep.crit.oil_in_gas;
+
+    auto t = std::vector<double>(sogcr.size(), 0.0);
     {
-        auto scr = std::vector<double>(tep.size(), 0.0);
+        const auto& sgco = tep.conn.gas;
+        const auto& swco = tep.conn.gas;
+        const auto& sgcr = tep.crit.gas;
 
-        std::transform(std::begin(tep), std::end(tep), std::begin(scr),
-                       std::forward<Extract>(extract));
+        for (auto n = sgcr.size(), i = 0*n; i < n; ++i) {
+            const auto sr   = 1.0 - (sgcr[i] + swco[i]);
+            const auto smax = 1.0 - (sgco[i] + swco[i]); // >= sr
 
-        return scr;
+            t[i] = (sr - sogcr[i]) / (smax - sogcr[i]);
+        }
+    }
+
+    return transformedCritSat(G, init, t,
+                              sogCrit(G, init, tep),
+                              soMax  (G, init, tep));
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrGO::alternateMethod(const ::Opm::ECLGraph&        G,
+                      const ::Opm::ECLInitFileData& init,
+                      const RTEP&                   tep)
+{
+    auto sdisp = std::vector<double>(G.numCells(), 0.0);
+
+    const auto sgcr = sgCrit(G, init, tep);
+    const auto swl  = ::Opm::SatFunc::scaledConnateWater(G, init, tep);
+
+    std::transform(std::begin(sgcr), std::end(sgcr), std::begin(swl),
+                   std::begin(sdisp),
+        [](const double sg, const double sw) -> double
+    {
+        return 1.0 - (sg + sw);
+    });
+
+    return sdisp;
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrOW::twoPointMethod(const ::Opm::ECLGraph&        G,
+                     const ::Opm::ECLInitFileData& init,
+                     const RTEP&                   tep)
+{
+    const auto& sowcr = tep.crit.oil_in_water;
+
+    auto t = std::vector<double>(sowcr.size(), 0.0);
+    {
+        const auto& sgco = tep.conn.gas;
+        const auto& swco = tep.conn.gas;
+        const auto& swcr = tep.crit.water;
+
+        for (auto n = swcr.size(), i = 0*n; i < n; ++i) {
+            const auto sr   = 1.0 - (swcr[i] + sgco[i]);
+            const auto smax = 1.0 - (swco[i] + sgco[i]); // >= sr
+
+            t[i] = (sr - sowcr[i]) / (smax - sowcr[i]);
+        }
+    }
+
+    return transformedCritSat(G, init, t,
+                              sowCrit(G, init, tep),
+                              soMax  (G, init, tep));
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrOW::alternateMethod(const ::Opm::ECLGraph&        G,
+                      const ::Opm::ECLInitFileData& init,
+                      const RTEP&                   tep)
+{
+    auto sdisp = std::vector<double>(G.numCells(), 0.0);
+
+    const auto swcr = swCrit(G, init, tep);
+    const auto sgl  = ::Opm::SatFunc::scaledConnateGas(G, init, tep);
+
+    std::transform(std::begin(swcr), std::end(swcr), std::begin(sgl),
+                   std::begin(sdisp),
+        [](const double sw, const double sg) -> double
+    {
+        return 1.0 - (sg + sw);
+    });
+
+    return sdisp;
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrW::twoPointMethod(const ::Opm::ECLGraph&        G,
+                    const ::Opm::ECLInitFileData& init,
+                    const RTEP&                   tep,
+                    const bool                    activeOil)
+{
+    const auto& swcr = tep.crit.water;
+    const auto& swu  = tep.smax.water;
+
+    auto t = std::vector<double>(swcr.size(), 0.0);
+    if (activeOil) {
+        // G/O or G/O/W system
+        for (auto n = swcr.size(), i = 0*n; i < n; ++i) {
+            const auto sr = 1.0 - (tep.crit.oil_in_water[i] +
+                                   tep.conn.gas         [i]);
+
+            t[i] = (sr - swcr[i]) / (swu[i] - swcr[i]);
+        }
+    }
+    else {
+        // G/W system.
+        for (auto n = swcr.size(), i = 0*n; i < n; ++i) {
+            const auto sr = 1.0 - tep.crit.gas[i];
+
+            t[i] = (sr - swcr[i]) / (swu[i] - swcr[i]);
+        }
+    }
+
+    return transformedCritSat(G, init, t,
+                              swCrit(G, init, tep),
+                              swMax (G, init, tep));
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+KrW::alternateMethod(const ::Opm::ECLGraph&        G,
+                     const ::Opm::ECLInitFileData& init,
+                     const RTEP&                   tep,
+                     const bool                    activeOil)
+{
+    auto sdisp = std::vector<double>(G.numCells(), 0.0);
+
+    if (activeOil) {
+        // G/O or G/O/W system.
+        const auto sowcr = sowCrit(G, init, tep);
+        const auto sgl   = ::Opm::SatFunc::scaledConnateGas(G, init, tep);
+
+        std::transform(std::begin(sowcr), std::end(sowcr), std::begin(sgl),
+                       std::begin(sdisp),
+            [](const double so, const double sg) -> double
+        {
+            return 1.0 - (so + sg);
+        });
+    }
+    else {
+        // G/W system.
+        const auto sgcr = sgCrit(G, init, tep);
+
+        std::transform(std::begin(sgcr), std::end(sgcr),
+                       std::begin(sdisp),
+            [](const double sg) -> double
+        {
+            return 1.0 - sg;
+        });
+    }
+
+    return sdisp;
+}
+
+std::vector<double>
+Create::CritSatVertical::CritDispSat::
+transformedCritSat(const ::Opm::ECLGraph&        G,
+                   const ::Opm::ECLInitFileData& init,
+                   const std::vector<double>&    t,
+                   const std::vector<double>&    left,
+                   const std::vector<double>&    right)
+{
+    auto sdisp = std::vector<double>(G.numCells(), 0.0);
+
+    auto cellID = std::vector<double>::size_type{0};
+    for (const auto& gridID : G.activeGrids()) {
+        const auto nc = G.numCells(gridID);
+
+        const auto& snum = init.haveKeywordData("SATNUM", gridID)
+            ? G.rawLinearisedCellData<int>(init, "SATNUM", gridID)
+            : std::vector<int>(nc, 1);
+
+        for (auto c = 0*nc; c < nc; ++c, ++cellID) {
+            const auto x = t[snum[c] - 1];
+
+            sdisp[cellID] = (1.0 - x)*left[cellID] + x*right[cellID];
+        }
+    }
+
+    return sdisp;
+}
+
+namespace {
+    std::vector<double>
+    critDispSat(const ::Opm::ECLGraph&                              G,
+                const ::Opm::ECLInitFileData&                       init,
+                const ::Opm::SatFunc::CreateEPS::EPSOptions&        opt,
+                const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& rtep)
+    {
+        namespace CDS = Create::CritSatVertical::CritDispSat;
+
+        if (opt.curve != ::Opm::SatFunc::CreateEPS::FunctionCategory::Relperm) {
+            return {};
+        }
+
+        const auto& ih        = init.keywordData<int>(INTEHEAD_KW);
+        const auto  activeOil =
+            (ih[INTEHEAD_PHASE_INDEX] & (1u << 0u)) != 0;
+
+        if (opt.subSys == ::Opm::SatFunc::CreateEPS::SubSystem::OilGas) {
+            if (opt.thisPh == ::Opm::ECLPhaseIndex::Aqua) {
+                throw std::invalid_argument {
+                    "Cannot request Critical Scaled Saturation "
+                    "for water in Gas/Oil system"
+                };
+            }
+
+            if (opt.thisPh == ::Opm::ECLPhaseIndex::Liquid) {
+                return !opt.use3PtScaling
+                    ? CDS::KrGO::twoPointMethod (G, init, rtep)
+                    : CDS::KrGO::alternateMethod(G, init, rtep);
+            }
+
+            return !opt.use3PtScaling
+                ? CDS::KrG::twoPointMethod (G, init, rtep, activeOil)
+                : CDS::KrG::alternateMethod(G, init, rtep, activeOil);
+        }
+
+        if (opt.subSys == ::Opm::SatFunc::CreateEPS::SubSystem::OilWater) {
+            if (opt.thisPh == ::Opm::ECLPhaseIndex::Vapour) {
+                throw std::invalid_argument {
+                    "Cannot request Critical Scaled Saturation "
+                    "for gas in Oil/Water system"
+                };
+            }
+
+            if (opt.thisPh == ::Opm::ECLPhaseIndex::Liquid) {
+                return !opt.use3PtScaling
+                    ? CDS::KrOW::twoPointMethod (G, init, rtep)
+                    : CDS::KrOW::alternateMethod(G, init, rtep);
+            }
+
+            return !opt.use3PtScaling
+                ? CDS::KrW::twoPointMethod (G, init, rtep, activeOil)
+                : CDS::KrW::alternateMethod(G, init, rtep, activeOil);
+        }
+
+        // Invalid
+        return {};
+    }
+
+    std::vector<double>
+    maximumSat(const ::Opm::ECLGraph&                              G,
+               const ::Opm::ECLInitFileData&                       init,
+               const ::Opm::SatFunc::CreateEPS::EPSOptions&        opt,
+               const ::Opm::SatFunc::CreateEPS::RawTableEndPoints& tep)
+    {
+        switch (opt.thisPh) {
+        case ::Opm::ECLPhaseIndex::Aqua:   return swMax(G, init, tep);
+        case ::Opm::ECLPhaseIndex::Liquid: return soMax(G, init, tep);
+        case ::Opm::ECLPhaseIndex::Vapour: return sgMax(G, init, tep);
+        }
+
+        throw std::invalid_argument {
+            "Unsupported Phase Index"
+        };
     }
 }
 
 Create::CritSatVertical::ScalPtr
 Create::CritSatVertical::Kr::G(const ::Opm::ECLGraph&        G,
                                const ::Opm::ECLInitFileData& init,
-                               const RTEP&                   rtep,
+                               std::vector<double>&&         sdisp,
+                               std::vector<double>&&         smax,
                                const FValVec&                fval)
 {
     using FVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
-
-    const auto& ih   = init.keywordData<int>(INTEHEAD_KW);
-    const auto  iphs = static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
-
-    auto sdisp = std::vector<double>(G.numCells());
-
-    if ((iphs & (1u << 0)) != 0) { // Oil active
-        auto sogcr =
-            gridDefaultedVector(G, init, "SOGCR", rtep.crit.oil_in_gas,
-                                [](const double s) { return s; });
-
-        auto swl =
-            gridDefaultedVector(G, init, "SWL", rtep.conn.water,
-                                [](const double s) { return s; });
-
-        std::transform(std::begin(sogcr), std::end(sogcr),
-                       std::begin(swl), std::begin(sdisp),
-            [](const double so, const double sw)
-        {
-            return 1.0 - (so + sw);
-        });
-    }
-    else {                      // Oil not active (G/W?)
-        auto swcr =
-            gridDefaultedVector(G, init, "SWCR", rtep.crit.water,
-                                [](const double s) { return s; });
-
-        std::transform(std::begin(swcr), std::end(swcr),
-                       std::begin(sdisp),
-            [](const double sw)
-        {
-            return 1.0 - sw;
-        });
-    }
 
     auto dflt_fdisp = std::vector<double>(fval.size(), 0.0);
     std::transform(std::begin(fval), std::end(fval),
@@ -1803,7 +2031,8 @@ Create::CritSatVertical::Kr::G(const ::Opm::ECLGraph&        G,
 
     return ScalPtr {
         new ::Opm::SatFunc::CritSatVerticalScaling {
-            std::move(sdisp), std::move(fdisp), std::move(fmax)
+            std::move(sdisp), std::move(fdisp),
+            std::move(smax) , std::move(fmax)
         }
     };
 }
@@ -1811,26 +2040,11 @@ Create::CritSatVertical::Kr::G(const ::Opm::ECLGraph&        G,
 Create::CritSatVertical::ScalPtr
 Create::CritSatVertical::Kr::GO(const ::Opm::ECLGraph&        G,
                                 const ::Opm::ECLInitFileData& init,
-                                const RTEP&                   tep,
+                                std::vector<double>&&         sdisp,
+                                std::vector<double>&&         smax,
                                 const FValVec&                fval)
 {
     using FVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
-    auto sdisp = std::vector<double>(G.numCells());
-
-    auto sgcr =
-        gridDefaultedVector(G, init, "SGCR", tep.crit.gas,
-                            [](const double s) { return s; });
-
-    auto swl =
-        gridDefaultedVector(G, init, "SWL", tep.conn.water,
-                            [](const double s) { return s; });
-
-    std::transform(std::begin(sgcr), std::end(sgcr),
-                   std::begin(swl), std::begin(sdisp),
-        [](const double sg, const double sw)
-    {
-        return 1.0 - (sg + sw);
-    });
 
     auto dflt_fdisp = std::vector<double>(fval.size(), 0.0);
     std::transform(std::begin(fval), std::end(fval),
@@ -1852,7 +2066,8 @@ Create::CritSatVertical::Kr::GO(const ::Opm::ECLGraph&        G,
 
     return ScalPtr {
         new ::Opm::SatFunc::CritSatVerticalScaling {
-            std::move(sdisp), std::move(fdisp), std::move(fmax)
+            std::move(sdisp), std::move(fdisp),
+            std::move(smax) , std::move(fmax)
         }
     };
 }
@@ -1860,26 +2075,11 @@ Create::CritSatVertical::Kr::GO(const ::Opm::ECLGraph&        G,
 Create::CritSatVertical::ScalPtr
 Create::CritSatVertical::Kr::OW(const ::Opm::ECLGraph&        G,
                                 const ::Opm::ECLInitFileData& init,
-                                const RTEP&                   tep,
+                                std::vector<double>&&         sdisp,
+                                std::vector<double>&&         smax,
                                 const FValVec&                fval)
 {
     using FVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
-    auto sdisp = std::vector<double>(G.numCells());
-
-    auto swcr =
-        gridDefaultedVector(G, init, "SWCR", tep.crit.water,
-                            [](const double s) { return s; });
-
-    auto sgl =
-        gridDefaultedVector(G, init, "SGL", tep.conn.gas,
-                            [](const double s) { return s; });
-
-    std::transform(std::begin(swcr), std::end(swcr),
-                   std::begin(sgl), std::begin(sdisp),
-        [](const double sw, const double sg)
-    {
-        return 1.0 - (sg + sw);
-    });
 
     auto dflt_fdisp = std::vector<double>(fval.size(), 0.0);
     std::transform(std::begin(fval), std::end(fval),
@@ -1901,7 +2101,8 @@ Create::CritSatVertical::Kr::OW(const ::Opm::ECLGraph&        G,
 
     return ScalPtr {
         new ::Opm::SatFunc::CritSatVerticalScaling {
-            std::move(sdisp), std::move(fdisp), std::move(fmax)
+            std::move(sdisp), std::move(fdisp),
+            std::move(smax) , std::move(fmax)
         }
     };
 }
@@ -1909,44 +2110,11 @@ Create::CritSatVertical::Kr::OW(const ::Opm::ECLGraph&        G,
 Create::CritSatVertical::ScalPtr
 Create::CritSatVertical::Kr::W(const ::Opm::ECLGraph&        G,
                                const ::Opm::ECLInitFileData& init,
-                               const RTEP&                   tep,
+                               std::vector<double>&&         sdisp,
+                               std::vector<double>&&         smax,
                                const FValVec&                fval)
 {
     using FVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
-
-    const auto& ih   = init.keywordData<int>(INTEHEAD_KW);
-    const auto  iphs = static_cast<unsigned int>(ih[INTEHEAD_PHASE_INDEX]);
-
-    auto sdisp = std::vector<double>(G.numCells());
-
-    if ((iphs & (1u << 0)) != 0) { // Oil active
-        auto sowcr =
-            gridDefaultedVector(G, init, "SOWCR", tep.crit.oil_in_water,
-                                [](const double s) { return s; });
-
-        auto sgl =
-            gridDefaultedVector(G, init, "SGL", tep.conn.gas,
-                                [](const double s) { return s; });
-
-        std::transform(std::begin(sowcr), std::end(sowcr),
-                       std::begin(sgl), std::begin(sdisp),
-            [](const double so, const double sg)
-        {
-            return 1.0 - (so + sg);
-        });
-    }
-    else {                      // Oil not active (G/W?)
-        auto sgcr =
-            gridDefaultedVector(G, init, "SGCR", tep.crit.gas,
-                                [](const double s) { return s; });
-
-        std::transform(std::begin(sgcr), std::end(sgcr),
-                       std::begin(sdisp),
-            [](const double sg)
-        {
-            return 1.0 - sg;
-        });
-    }
 
     auto dflt_fdisp = std::vector<double>(fval.size(), 0.0);
     std::transform(std::begin(fval), std::end(fval),
@@ -1968,7 +2136,8 @@ Create::CritSatVertical::Kr::W(const ::Opm::ECLGraph&        G,
 
     return ScalPtr {
         new ::Opm::SatFunc::CritSatVerticalScaling {
-            std::move(sdisp), std::move(fdisp), std::move(fmax)
+            std::move(sdisp), std::move(fdisp),
+            std::move(smax) , std::move(fmax)
         }
     };
 }
@@ -1984,6 +2153,9 @@ scalingFunction(const ::Opm::ECLGraph&        G,
     using SSys  = ::Opm::SatFunc::CreateEPS::SubSystem;
     using PhIdx = ::Opm::ECLPhaseIndex;
 
+    auto scr  = critDispSat(G, init, opt, tep);
+    auto smax = maximumSat (G, init, opt, tep);
+
     if (opt.subSys == SSys::OilWater) {
         if (opt.thisPh == PhIdx::Vapour) {
             throw std::invalid_argument {
@@ -1993,10 +2165,12 @@ scalingFunction(const ::Opm::ECLGraph&        G,
         }
 
         if (opt.thisPh == PhIdx::Aqua) {
-            return Create::CritSatVertical::Kr::W(G, init, tep, fvals);
+            return Create::CritSatVertical::
+                Kr::W(G, init, std::move(scr), std::move(smax), fvals);
         }
 
-        return Create::CritSatVertical::Kr::OW(G, init, tep, fvals);
+        return Create::CritSatVertical::
+            Kr::OW(G, init, std::move(scr), std::move(smax), fvals);
     }
 
     if (opt.subSys == SSys::OilGas) {
@@ -2008,10 +2182,12 @@ scalingFunction(const ::Opm::ECLGraph&        G,
         }
 
         if (opt.thisPh == PhIdx::Vapour) {
-            return Create::CritSatVertical::Kr::G(G, init, tep, fvals);
+            return Create::CritSatVertical::
+                Kr::G(G, init, std::move(scr), std::move(smax), fvals);
         }
 
-        return Create::CritSatVertical::Kr::GO(G, init, tep, fvals);
+        return Create::CritSatVertical::
+            Kr::GO(G, init, std::move(scr), std::move(smax), fvals);
     }
 
     // Invalid.
@@ -2209,8 +2385,10 @@ Opm::SatFunc::ThreePointScaling::clone() const
 Opm::SatFunc::CritSatVerticalScaling::
 CritSatVerticalScaling(std::vector<double> sdisp,
                        std::vector<double> fdisp,
+                       std::vector<double> smax,
                        std::vector<double> fmax)
-    : pImpl_(new Impl(std::move(sdisp), std::move(fdisp), std::move(fmax)))
+    : pImpl_(new Impl(std::move(sdisp), std::move(fdisp),
+                      std::move(smax) , std::move(fmax)))
 {}
 
 Opm::SatFunc::CritSatVerticalScaling::~CritSatVerticalScaling()
@@ -2266,19 +2444,20 @@ Opm::SatFunc::CritSatVerticalScaling::clone() const
 
 std::unique_ptr<Opm::SatFunc::EPSEvalInterface>
 Opm::SatFunc::CreateEPS::Horizontal::
-fromECLOutput(const ECLGraph&        G,
-              const ECLInitFileData& init,
-              const EPSOptions&      opt)
+fromECLOutput(const ECLGraph&          G,
+              const ECLInitFileData&   init,
+              const EPSOptions&        opt,
+              const RawTableEndPoints& tep)
 {
     if ((opt.curve == FunctionCategory::CapPress) ||
         (! opt.use3PtScaling))
     {
-        return Create::TwoPoint::scalingFunction(G, init, opt);
+        return Create::TwoPoint::scalingFunction(G, init, opt, tep);
     }
 
     if ((opt.curve == FunctionCategory::Relperm) && opt.use3PtScaling)
     {
-        return Create::ThreePoint::scalingFunction(G, init, opt);
+        return Create::ThreePoint::scalingFunction(G, init, opt, tep);
     }
 
     // Invalid
@@ -2290,8 +2469,8 @@ fromECLOutput(const ECLGraph&        G,
 
 std::vector<Opm::SatFunc::EPSEvalInterface::TableEndPoints>
 Opm::SatFunc::CreateEPS::Horizontal::
-unscaledEndPoints(const RawTableEndPoints& ep,
-                  const EPSOptions&        opt)
+unscaledEndPoints(const EPSOptions&        opt,
+                  const RawTableEndPoints& ep)
 {
     if ((opt.curve == FunctionCategory::CapPress) ||
         (! opt.use3PtScaling))
@@ -2319,8 +2498,7 @@ fromECLOutput(const ECLGraph&          G,
               const RawTableEndPoints& tep,
               const FuncValVector&     fvals)
 {
-    const auto haveScaleCRS =
-        haveScaledRelPermAtCritSat(G, init, opt.thisPh, opt.subSys);
+    const auto haveScaleCRS = haveScaledRelPermAtCritSat(G, init, opt);
 
     if ((opt.curve == FunctionCategory::CapPress) || (! haveScaleCRS))
     {
@@ -2351,8 +2529,7 @@ unscaledFunctionValues(const ECLGraph&          G,
 {
     auto ret = std::vector<VerticalScalingInterface::FunctionValues>{};
 
-    const auto haveScaleCRS =
-        haveScaledRelPermAtCritSat(G, init, opt.thisPh, opt.subSys);
+    const auto haveScaleCRS = haveScaledRelPermAtCritSat(G, init, opt);
 
     if ((opt.curve == FunctionCategory::CapPress) || (! haveScaleCRS)) {
         auto opt_cpy = opt;

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -2388,3 +2388,24 @@ unscaledFunctionValues(const ECLGraph&          G,
 
     return ret;
 }
+
+// ---------------------------------------------------------------------
+// Factory functions Opm::SatFunc::scaledConnate*()
+
+std::vector<double>
+Opm::SatFunc::scaledConnateGas(const ECLGraph&                     G,
+                               const ECLInitFileData&              init,
+                               const CreateEPS::RawTableEndPoints& tep)
+{
+    return gridDefaultedVector(G, init, "SGL", tep.conn.gas,
+                               [](const double s) { return s; });
+}
+
+std::vector<double>
+Opm::SatFunc::scaledConnateWater(const ECLGraph&                     G,
+                                 const ECLInitFileData&              init,
+                                 const CreateEPS::RawTableEndPoints& tep)
+{
+    return gridDefaultedVector(G, init, "SWL", tep.conn.water,
+                               [](const double s) { return s; });
+}

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -469,6 +469,7 @@ namespace Opm { namespace SatFunc {
         /// Constructor.
         explicit CritSatVerticalScaling(std::vector<double> sdisp,
                                         std::vector<double> fdisp,
+                                        std::vector<double> smax,
                                         std::vector<double> fmax);
 
         /// Destructor.
@@ -669,9 +670,10 @@ namespace Opm { namespace SatFunc {
             /// \return EPS evaluator for the particular curve defined by
             ///    the input options.
             static std::unique_ptr<EPSEvalInterface>
-            fromECLOutput(const ECLGraph&        G,
-                          const ECLInitFileData& init,
-                          const EPSOptions&      opt);
+            fromECLOutput(const ECLGraph&          G,
+                          const ECLInitFileData&   init,
+                          const EPSOptions&        opt,
+                          const RawTableEndPoints& tep);
 
             /// Extract table end points relevant to a particular horizontal
             /// EPS evaluator from raw tabulated saturation functions.
@@ -692,8 +694,8 @@ namespace Opm { namespace SatFunc {
             ///    \code eval() \endcode of the \code EPSEvalInterface
             ///    \endcode that corresponds to the input options.
             static std::vector<EPSEvalInterface::TableEndPoints>
-            unscaledEndPoints(const RawTableEndPoints& ep,
-                              const EPSOptions&        opt);
+            unscaledEndPoints(const EPSOptions&        opt,
+                              const RawTableEndPoints& ep);
         };
 
         /// Named constructors for vertical (value) scaling of saturation

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -762,6 +762,16 @@ namespace Opm { namespace SatFunc {
                                    const SatFuncEvaluator&  evalSF);
         };
     };
+
+    std::vector<double>
+    scaledConnateGas(const ECLGraph&                     G,
+                     const ECLInitFileData&              init,
+                     const CreateEPS::RawTableEndPoints& tep);
+
+    std::vector<double>
+    scaledConnateWater(const ECLGraph&                     G,
+                       const ECLInitFileData&              init,
+                       const CreateEPS::RawTableEndPoints& tep);
 }} // namespace Opm::SatFunc
 
 #endif // OPM_ECLENDPOINTSCALING_HEADER_INCLUDED

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -1974,12 +1974,15 @@ kroCurve(const ECLRegionMapping&    rmap,
     if (enableVerticalSFScaling(scaling) &&
         (this->eps_ != nullptr))
     {
+        auto vkr_eval_sat = abscissas;
+        vkr_eval_sat.resize(so.size(), 1.0);
+
         // Evaluate vertical scaling in input saturations.
         if (subsys == RawCurve::SubSystem::OilGas) {
-            this->eps_->vertScaleKrOG(rmap, so, kr);
+            this->eps_->vertScaleKrOG(rmap, vkr_eval_sat, kr);
         }
         else {
-            this->eps_->vertScaleKrOW(rmap, so, kr);
+            this->eps_->vertScaleKrOW(rmap, vkr_eval_sat, kr);
         }
     }
 
@@ -2070,8 +2073,11 @@ krgCurve(const ECLRegionMapping&    rmap,
     if (enableVerticalSFScaling(scaling) &&
         (this->eps_ != nullptr))
     {
+        auto vkr_eval_sat = abscissas;
+        vkr_eval_sat.resize(sg.size(), 1.0);
+
         // Evaluate vertical scaling in input saturations.
-        this->eps_->vertScaleKrGas(rmap, sg, kr);
+        this->eps_->vertScaleKrGas(rmap, vkr_eval_sat, kr);
     }
 
     // FD::Graph == pair<vector<double>, vector<double>>
@@ -2119,8 +2125,11 @@ pcgoCurve(const ECLRegionMapping&    rmap,
     if (enableVerticalSFScaling(scaling) &&
         (this->eps_ != nullptr))
     {
+        auto pcg_eval_sat = abscissas;
+        pcg_eval_sat.resize(sg.size(), 1.0);
+
         // Evaluate vertical scaling in input saturations.
-        this->eps_->vertScalePcGO(rmap, sg, pc);
+        this->eps_->vertScalePcGO(rmap, pcg_eval_sat, pc);
     }
 
     if (this->usys_output_ != nullptr) {
@@ -2216,8 +2225,11 @@ krwCurve(const ECLRegionMapping&    rmap,
     if (enableVerticalSFScaling(scaling) &&
         (this->eps_ != nullptr))
     {
+        auto vkr_eval_sat = abscissas;
+        vkr_eval_sat.resize(sw.size(), 1.0);
+
         // Evaluate vertical scaling in input saturations.
-        this->eps_->vertScaleKrWat(rmap, sw, kr);
+        this->eps_->vertScaleKrWat(rmap, vkr_eval_sat, kr);
     }
 
     // FD::Graph == pair<vector<double>, vector<double>>
@@ -2265,8 +2277,11 @@ pcowCurve(const ECLRegionMapping&    rmap,
     if (enableVerticalSFScaling(scaling) &&
         (this->eps_ != nullptr))
     {
+        auto pcw_eval_sat = abscissas;
+        pcw_eval_sat.resize(sw.size(), 1.0);
+
         // Evaluate vertical scaling in input saturations.
-        this->eps_->vertScalePcOW(rmap, sw, pc);
+        this->eps_->vertScalePcOW(rmap, pcw_eval_sat, pc);
     }
 
     if (this->usys_output_ != nullptr) {

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -1190,9 +1190,9 @@ private:
                 auto& eps = this->oil_in_og_;
 
                 eps.scaling = Create::Horizontal::
-                    fromECLOutput(G, init, opt);
+                    fromECLOutput(G, init, opt, ep);
 
-                eps.tep = this->endPoints(ep, opt);
+                eps.tep = this->endPoints(opt, ep);
 
                 eps.vertfuncval = this->
                     vertFuncVal(G, init, ep, opt, [&host]
@@ -1215,9 +1215,9 @@ private:
                 auto& eps = this->oil_in_ow_;
 
                 eps.scaling = Create::Horizontal::
-                    fromECLOutput(G, init, opt);
+                    fromECLOutput(G, init, opt, ep);
 
-                eps.tep = this->endPoints(ep, opt);
+                eps.tep = this->endPoints(opt, ep);
 
                 eps.vertfuncval = this->
                     vertFuncVal(G, init, ep, opt, [&host]
@@ -1253,9 +1253,9 @@ private:
                 auto& eps = this->gas_.kr;
 
                 eps.scaling = Create::Horizontal::
-                    fromECLOutput(G, init, opt);
+                    fromECLOutput(G, init, opt, ep);
 
-                eps.tep = this->endPoints(ep, opt);
+                eps.tep = this->endPoints(opt, ep);
 
                 eps.vertfuncval = this->
                     vertFuncVal(G, init, ep, opt, [&host]
@@ -1281,9 +1281,9 @@ private:
                 auto& eps = this->gas_.pc;
 
                 eps.scaling = Create::Horizontal::
-                    fromECLOutput(G, init, opt);
+                    fromECLOutput(G, init, opt, ep);
 
-                eps.tep = this->endPoints(ep, opt);
+                eps.tep = this->endPoints(opt, ep);
 
                 eps.vertfuncval = this->
                     vertFuncVal(G, init, ep, opt, [&host]
@@ -1319,9 +1319,9 @@ private:
                 auto& eps = this->wat_.kr;
 
                 eps.scaling = Create::Horizontal::
-                    fromECLOutput(G, init, opt);
+                    fromECLOutput(G, init, opt, ep);
 
-                eps.tep = this->endPoints(ep, opt);
+                eps.tep = this->endPoints(opt, ep);
 
                 eps.vertfuncval = this->
                     vertFuncVal(G, init, ep, opt, [&host]
@@ -1347,9 +1347,9 @@ private:
                 auto& eps = this->wat_.pc;
 
                 eps.scaling = Create::Horizontal::
-                    fromECLOutput(G, init, opt);
+                    fromECLOutput(G, init, opt, ep);
 
-                eps.tep = this->endPoints(ep, opt);
+                eps.tep = this->endPoints(opt, ep);
 
                 eps.vertfuncval = this->
                     vertFuncVal(G, init, ep, opt, [&host]
@@ -1368,10 +1368,11 @@ private:
         }
 
         EndPtsPtr
-        endPoints(const RawTEP& ep, const Create::EPSOptions& opt)
+        endPoints(const Create::EPSOptions& opt,
+                  const RawTEP&             ep)
         {
             return EndPtsPtr {
-                new EPSEndPtVec(Create::Horizontal::unscaledEndPoints(ep, opt))
+                new EPSEndPtVec(Create::Horizontal::unscaledEndPoints(opt, ep))
             };
         }
 

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -31,9 +31,17 @@
 
 #include <opm/utility/ECLEndPointScaling.hpp>
 
+#include <opm/utility/ECLPropTable.hpp>
+#include <opm/utility/ECLPvtCommon.hpp>
+#include <opm/utility/ECLUnitHandling.hpp>
+
+#include <opm/utility/imported/Units.hpp>
+
 #include <exception>
 #include <initializer_list>
 #include <stdexcept>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -68,6 +76,23 @@ namespace {
         }
 
         return sp;
+    }
+
+    std::vector<double>
+    makeTable(const std::size_t             ncol,
+              std::initializer_list<double> data)
+    {
+        auto result = std::vector<double>(data.size(), 0.0);
+        const auto nrows = data.size() / ncol;
+
+        auto di = std::begin(data);
+        for (auto i = 0*nrows; i < nrows; ++i) {
+            for (auto j = 0*ncol; j < ncol; ++j, ++di) {
+                result[i + j*nrows] = *di;
+            }
+        }
+
+        return result;
     }
 
     std::vector<double> sw_core1d_example()
@@ -177,6 +202,192 @@ namespace {
             9.579000000000000e-01,
             1.000000000000000e+00,
             1.000000000000000e+00,
+        };
+    }
+
+    std::vector<double> sgfn_raw()
+    {
+        return makeTable(5, {
+                0,          0,                      0,                      0,  0,
+                5.000e-02,  1.655000000000000e-03,  0,  3.310000000000000e-02,  0,
+                1.000e-01,  6.913000000000000e-03,  0,  1.051600000000000e-01,  0,
+                1.500e-01,  1.621300000000000e-02,  0,  1.860000000000001e-01,  0,
+                2.000e-01,  2.999000000000000e-02,  0,  2.755399999999998e-01,  0,
+                2.500e-01,  4.865500000000000e-02,  0,  3.733000000000000e-01,  0,
+                3.000e-01,  7.257300000000000e-02,  0,  4.783600000000001e-01,  0,
+                3.500e-01,  1.020460000000000e-01,  0,  5.894600000000001e-01,  0,
+                4.000e-01,  1.372870000000000e-01,  0,  7.048199999999992e-01,  0,
+                4.500e-01,  1.784020000000000e-01,  0,  8.223000000000005e-01,  0,
+                5.000e-01,  2.253680000000000e-01,  0,  9.393200000000004e-01,  0,
+                5.500e-01,  2.780300000000000e-01,  0,  1.053239999999999e+00,  0,
+                6.000e-01,  3.360930000000000e-01,  0,  1.161260000000001e+00,  0,
+                6.500e-01,  3.991350000000000e-01,  0,  1.260840000000000e+00,  0,
+                7.000e-01,  4.666310000000000e-01,  0,  1.349920000000002e+00,  0,
+                7.500e-01,  5.380000000000000e-01,  0,  1.427379999999999e+00,  0,
+                8.000e-01,  6.126650000000000e-01,  0,  1.493299999999998e+00,  0,
+                8.500e-01,  6.901690000000000e-01,  0,  1.550080000000002e+00,  0,
+                9.000e-01,  7.703950000000001e-01,  0,  1.604519999999999e+00,  0,
+                9.500e-01,  8.542180000000000e-01,  0,  1.676460000000002e+00,  0,
+                9.999e-01,  9.499000000000000e-01,  0,  1.917474949899796e+00,  0,
+                1.000e+00,  9.500000000000000e-01,  0,  1.000000000000000e+00,  0,
+        });
+    }
+
+    std::vector<double> sofn_raw()
+    {
+        return makeTable(5, {
+                0,                        0,                        0,                        0,                        0,
+                9.999999999998899e-05,    0,                        0,                        0,                        0,
+                5.000000000000004e-02,    1.000000000000000e-05,    7.000000000000000e-06,    1.999999999999998e-04,    1.402805611222443e-04,
+                9.999999999999998e-02,    1.200000000000000e-04,    8.800000000000000e-05,    2.200000000000003e-03,    1.620000000000002e-03,
+                1.500000000000000e-01,    5.100000000000000e-04,    3.840000000000000e-04,    7.799999999999994e-03,    5.919999999999996e-03,
+                2.000000000000000e-01,    1.490000000000000e-03,    1.117000000000000e-03,    1.960000000000003e-02,    1.466000000000002e-02,
+                2.500000000000000e-01,    3.460000000000000e-03,    2.597000000000000e-03,    3.939999999999996e-02,    2.959999999999997e-02,
+                3.000000000000000e-01,    6.990000000000000e-03,    5.254000000000000e-03,    7.059999999999993e-02,    5.313999999999995e-02,
+                3.500000000000000e-01,    1.284000000000000e-02,    9.662000000000000e-03,    1.170000000000002e-01,    8.816000000000013e-02,
+                4.000000000000000e-01,    2.199000000000000e-02,    1.658600000000000e-02,    1.829999999999998e-01,    1.384799999999999e-01,
+                4.500000000000000e-01,    3.572000000000000e-02,    2.703500000000000e-02,    2.746000000000004e-01,    2.089800000000003e-01,
+                5.000000000000000e-01,    5.565000000000000e-02,    4.232400000000000e-02,    3.985999999999996e-01,    3.057799999999997e-01,
+                5.500000000000000e-01,    8.373999999999999e-02,    6.415100000000000e-02,    5.617999999999994e-01,    4.365399999999996e-01,
+                6.000000000000000e-01,    1.223700000000000e-01,    9.467100000000001e-02,    7.726000000000013e-01,    6.104000000000009e-01,
+                6.500000000000000e-01,    1.741500000000000e-01,    1.365540000000000e-01,    1.035599999999999e+00,    8.376599999999993e-01,
+                7.000000000000000e-01,    2.417700000000000e-01,    1.929920000000000e-01,    1.352400000000002e+00,    1.128760000000001e+00,
+                7.500000000000000e-01,    3.275700000000000e-01,    2.675890000000000e-01,    1.715999999999998e+00,    1.491939999999999e+00,
+                8.000000000000000e-01,    4.328600000000000e-01,    3.640430000000000e-01,    2.105799999999999e+00,    1.929079999999998e+00,
+                8.500000000000000e-01,    5.571700000000001e-01,    4.855060000000000e-01,    2.486200000000004e+00,    2.429260000000003e+00,
+                9.000000000000000e-01,    6.974600000000000e-01,    6.335620000000000e-01,    2.805799999999996e+00,    2.961119999999997e+00,
+                9.500000000000000e-01,    8.478200000000000e-01,    8.068880000000000e-01,    3.007200000000005e+00,    3.466520000000006e+00,
+                9.999000000000000e-01,    9.990000000000000e-01,    9.996137760000001e-01,    3.029659318637271e+00,    3.862239999999997e+00,
+                1.000000000000000e+00,    1.000000000000000e+00,    1.000000000000000e+00,    1.000000000000111e+01,    3.862239999999221e+00,
+        });
+    }
+
+    std::vector<double> swfn_raw()
+    {
+        return makeTable(5, {
+                0,           0,             3.756330000000000e+00,    0,                        0,
+                1.00e-04,    0,             3.756320000000000e+00,    0,                       -1.000000000006551e-01,
+                5.00e-02,    8.6000e-04,    1.869810000000000e+00,    1.723446893787575e-02,   -3.780581162324650e+01,
+                1.00e-01,    2.6300e-03,    1.237310000000000e+00,    3.539999999999999e-02,   -1.265000000000000e+01,
+                1.50e-01,    5.2400e-03,    9.182100000000000e-01,    5.220000000000001e-02,   -6.382000000000001e+00,
+                2.00e-01,    8.7700e-03,    7.245100000000000e-01,    7.059999999999998e-02,   -3.873999999999998e+00,
+                2.50e-01,    1.3380e-02,    5.934100000000000e-01,    9.220000000000000e-02,   -2.622000000000000e+00,
+                3.00e-01,    1.9270e-02,    4.981100000000000e-01,    1.178000000000000e-01,   -1.906000000000000e+00,
+                3.50e-01,    2.6720e-02,    4.251100000000000e-01,    1.490000000000001e-01,   -1.460000000000000e+00,
+                4.00e-01,    3.6080e-02,    3.669100000000000e-01,    1.871999999999998e-01,   -1.163999999999998e+00,
+                4.50e-01,    4.7810e-02,    3.191100000000000e-01,    2.346000000000000e-01,   -9.560000000000004e-01,
+                5.00e-01,    6.2500e-02,    2.788100000000000e-01,    2.938000000000001e-01,   -8.060000000000003e-01,
+                5.50e-01,    8.0900e-02,    2.440100000000000e-01,    3.679999999999997e-01,   -6.959999999999993e-01,
+                6.00e-01,    1.0394e-01,    2.135100000000000e-01,    4.608000000000007e-01,   -6.100000000000008e-01,
+                6.50e-01,    1.3277e-01,    1.863100000000000e-01,    5.765999999999993e-01,   -5.439999999999996e-01,
+                7.00e-01,    1.6869e-01,    1.616100000000000e-01,    7.184000000000011e-01,   -4.940000000000007e-01,
+                7.50e-01,    2.1302e-01,    1.390100000000000e-01,    8.865999999999988e-01,   -4.519999999999998e-01,
+                8.00e-01,    2.6667e-01,    1.180100000000000e-01,    1.073000000000000e+00,   -4.199999999999994e-01,
+                8.50e-01,    3.2918e-01,    9.830999999999999e-02,    1.250200000000001e+00,   -3.940000000000007e-01,
+                9.00e-01,    3.9706e-01,    7.961000000000000e-02,    1.357600000000000e+00,   -3.739999999999996e-01,
+                9.50e-01,    4.6103e-01,    6.161000000000000e-02,    1.279400000000001e+00,   -3.600000000000005e-01,
+                1.00e+00,    5.0000e-01,    4.408000000000000e-02,    7.793999999999994e-01,   -3.505999999999996e-01,
+        });
+    }
+
+    Opm::ECLPropTableRawData makeSatFunc(std::vector<double> data)
+    {
+        auto table = Opm::ECLPropTableRawData{};
+
+        table.data = std::move(data);
+
+        table.numTables  = 1;
+        table.numPrimary = 1;
+        table.numCols    = 5;
+        table.numRows    = table.data.size() / table.numCols;
+
+        return table;
+    }
+
+    Opm::SatFuncInterpolant sgfn()
+    {
+        // Input tables follow METRIC unit conventions.
+        const auto usys = Opm::ECLUnits::createUnitSystem(1);
+
+        auto convert = Opm::SatFuncInterpolant::ConvertUnits{};
+
+        convert.indep = [](const double s) { return s; };
+
+        // Krg(Sg)
+        convert.column.emplace_back(
+            [](const double kr) { return kr; });
+
+        // Pcgo(Sg)
+        convert.column.push_back(
+            Opm::ECLPVT::CreateUnitConverter::ToSI::pressure(*usys));
+
+        // dKrg/dSg
+        convert.column.emplace_back(
+            [](const double dkr) { return dkr; });
+
+        // dPcgo/dSg
+        convert.column.push_back(
+            Opm::ECLPVT::CreateUnitConverter::ToSI::pressure(*usys));
+
+        return {
+            makeSatFunc(sgfn_raw()), convert
+        };
+    }
+
+    Opm::SatFuncInterpolant sofn()
+    {
+        auto convert = Opm::SatFuncInterpolant::ConvertUnits{};
+
+        convert.indep = [](const double s) { return s; };
+
+        // Krow(So)
+        convert.column.emplace_back(
+            [](const double kr) { return kr; });
+
+        // Krog(So)
+        convert.column.emplace_back(
+            [](const double kr) { return kr; });
+
+        // dKrow/dSo
+        convert.column.emplace_back(
+            [](const double dkr) { return dkr; });
+
+        // dKrow/dSo
+        convert.column.emplace_back(
+            [](const double dkr) { return dkr; });
+
+        return {
+            makeSatFunc(sofn_raw()), convert
+        };
+    }
+
+    Opm::SatFuncInterpolant swfn()
+    {
+        // Input tables follow METRIC unit conventions.
+        const auto usys = Opm::ECLUnits::createUnitSystem(1);
+
+        auto convert = Opm::SatFuncInterpolant::ConvertUnits{};
+
+        convert.indep = [](const double s) { return s; };
+
+        // Krw(Sw)
+        convert.column.emplace_back(
+            [](const double kr) { return kr; });
+
+        // Pcow(Sw)
+        convert.column.push_back(
+            Opm::ECLPVT::CreateUnitConverter::ToSI::pressure(*usys));
+
+        // dKrw/dSw
+        convert.column.emplace_back(
+            [](const double dkr) { return dkr; });
+
+        // dPcow/dSw
+        convert.column.push_back(
+            Opm::ECLPVT::CreateUnitConverter::ToSI::pressure(*usys));
+
+        return {
+            makeSatFunc(swfn_raw()), convert
         };
     }
 } // Namespace Anonymous
@@ -626,6 +837,178 @@ BOOST_AUTO_TEST_CASE (ScaledBoth)
 BOOST_AUTO_TEST_SUITE_END ()
 
 // =====================================================================
+
+BOOST_AUTO_TEST_SUITE (HorizontalScaling_SatFuncCurves)
+
+BOOST_AUTO_TEST_CASE (KrGas_2Pt)
+{
+    const auto interp = sgfn();
+
+    using Interp = std::remove_cv<
+        std::remove_reference<decltype(interp)>::type
+        >::type;
+
+    const auto SG = std::vector<double>{
+        0.0, 0.025, 0.05, 0.075, 0.1    , 0.125, 0.15 , 0.175,
+        0.2, 0.225, 0.25, 0.275, 0.3    , 0.325, 0.35 , 0.375,
+        0.4, 0.425, 0.45, 0.475, 0.49995, 0.5,
+    };
+
+    // Live Sg in [0, 0.5].  Map to [0, 1] for table lookup
+    const auto eps = ::Opm::SatFunc::
+        TwoPointScaling{ { 0.0 }, { 0.5 } };
+
+    const auto tep = ::Opm::SatFunc::EPSEvalInterface::TableEndPoints {
+        interp.connateSat()[0] , // low
+        interp.connateSat()[0] , // disp (ignored)
+        interp.maximumSat()[0]   // max
+    };
+
+    // Forward: Scaled SG -> Lookup/Table sg
+    {
+        const auto expect = interp.saturationPoints(Interp::InTable{0});
+        const auto sg     = eps.eval(tep, associate(SG));
+
+        check_is_close(sg, expect);
+    }
+
+    // Reverse: Lookup/Table sg -> Scaled SG
+    {
+        const auto sg     = interp.saturationPoints(Interp::InTable{0});
+        const auto scaled = eps.reverse(tep, associate(sg));
+
+        check_is_close(scaled, SG);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (KrOW_3pt)
+{
+    const auto interp = sofn();
+
+    using Interp = std::remove_cv<
+        std::remove_reference<decltype(interp)>::type
+        >::type;
+
+    const auto swl  = 0.1;
+    const auto swcr = 0.1;      // Swcr == Swco in table.
+    const auto sgl  = 0.0;
+
+    // Scaled end-points:
+    //   SOWCR = 0.2,  SWCR = 0.25,  SWL = 0.15,  SGL = 0
+    //     => Mobile So in [ 0.2, 0.85 ], Sr = 0.75.
+
+    const auto eps = ::Opm::SatFunc::
+        ThreePointScaling{ { 0.2 }, { 0.75 }, { 0.85 } };
+
+    const auto tep = ::Opm::SatFunc::EPSEvalInterface::TableEndPoints {
+        interp.criticalSat(Interp::ResultColumn{0})[0], // low
+        1.0 - (swcr + sgl),                             // disp (Sr)
+        1.0 - (swl  + sgl),                             // max
+    };
+
+    // Forward: Scaled SO -> Lookup/Table so.
+    {
+        const auto SO = std::vector<double> {
+            0.0, 0.05, 0.1, 0.15,
+
+            // ------------ Sowcr -----------------
+
+            0.2, 0.25, 0.3, 0.35, 0.4, 0.45,
+            0.5, 0.55, 0.6, 0.65, 0.7, 0.725, 0.749,
+
+            // ------------ Sr --------------------
+
+            0.75, 0.7501, 0.8, 0.825, 0.85,
+        };
+
+        const auto so = eps.eval(tep, associate(SO));
+
+        const auto expect = std::vector<double>{
+            // so = Sowcr.  (SO < SLO)
+
+            9.9999999999988987e-05, // SO = 0.0
+            9.9999999999988987e-05, // SO = 0.05
+            9.9999999999988987e-05, // SO = 0.1
+            9.9999999999988987e-05, // SO = 0.15
+
+            // ------------ SLO ------------------
+
+            // so = tep.low + t*(tep.disp - tep.low)
+            //    = 1.0e-4  + t*(0.9      - 1.0e-4)
+            //
+            // t = (SO - SLO) / (SR   - SLO)
+            //   = (SO - 0.2) / (0.75 - 0.2)
+
+            9.9999999999988987e-05, // SO = 0.2
+            0.081909090909090876,   // SO = 0.25
+            0.16371818181818176,    // SO = 0.3
+            0.24552727272727265,    // SO = 0.35
+            0.32733636363636365,    // SO = 0.4
+            0.40914545454545453,    // SO = 0.45
+            0.49095454545454542,    // SO = 0.5
+            0.57276363636363636,    // SO = 0.55
+            0.6545727272727272,     // SO = 0.6
+            0.73638181818181814,    // SO = 0.65
+            0.81819090909090897,    // SO = 0.7
+            0.85909545454545433,    // SO = 0.725
+            0.89836381818181799,    // SO = 0.749
+
+            // ------------ Sr --------------------
+
+            // Everything below here maps to Somax (=1-Swco) because the
+            // 'tep' data says that Sdisp == Smax in the (purported) input
+            // table.  The actual SOFN data (sofn_raw()) does not account
+            // for Swco = 0.1 (> 0) and therefore provides satfunc values
+            // for So > 0.9.
+
+            0.90000000000000002, // SO = 0.75
+            0.90000000000000002, // SO = 0.751
+            0.90000000000000002, // SO = 0.8
+            0.90000000000000002, // SO = 0.825
+            0.90000000000000002, // SO = 0.85
+        };
+
+        check_is_close(so, expect);
+    }
+
+    // Reverse: Lookup/Table so -> Scaled SO.
+    {
+        const auto SO = std::vector<double> {
+            0.20000000000000001, // so = 0
+            0.20000000000000001, // so = 9.9999999999988987e-05
+            0.23049783309256588, // so = 0.050000000000000037
+            0.2610567840871208,  // so = 0.099999999999999978
+            0.29161573508167576, // so = 0.14999999999999999
+            0.32217468607623073, // so = 0.20000000000000001
+            0.35273363707078564, // so = 0.25
+            0.38329258806534061, // so = 0.29999999999999999
+            0.41385153905989558, // so = 0.34999999999999998
+            0.44441049005445055, // so = 0.40000000000000002
+            0.47496944104900546, // so = 0.45000000000000001
+            0.50552839204356048, // so = 0.5
+            0.53608734303811545, // so = 0.55000000000000004
+            0.56664629403267042, // so = 0.59999999999999998
+            0.59720524502722527, // so = 0.65000000000000002
+            0.62776419602178024, // so = 0.69999999999999996
+            0.6583231470163351,  // so = 0.75
+            0.68888209801089018, // so = 0.80000000000000004
+            0.71944104900544503, // so = 0.84999999999999998
+            0.84999999999999998, // so = 0.90000000000000002
+            0.84999999999999998, // so = 0.94999999999999996
+            0.84999999999999998, // so = 0.99990000000000001
+            0.84999999999999998, // so = 1
+        };
+
+        const auto so     = interp.saturationPoints(Interp::InTable{0});
+        const auto scaled = eps.reverse(tep, associate(so));
+
+        check_is_close(scaled, SO);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
 // Three-point (alternative) scaling, applicable to relperm only.
 // ---------------------------------------------------------------------
 
@@ -955,11 +1338,12 @@ BOOST_AUTO_TEST_CASE (Sw2_Regular)
         SFPt{ 0.9, 0.81 }, // Maximum
     };
 
-    // Scaled residual displacement sat: 0.7
+    // Scaled residual displacement sat: 0.7 (unchanged)
     // Scaled Kr at Scaled Sr (KRxR):    0.6
+    // Scaled maximum saturation:        0.9 (unchanged)
     // Scaled Kr at Smax:     (KRx)      0.7
     const auto scaler = Opm::SatFunc::
-        CritSatVerticalScaling({ 0.71 }, { 0.6 }, { 0.7 });
+        CritSatVerticalScaling({ 0.71 }, { 0.6 }, { 0.9 }, { 0.7 });
 
     const auto y = scaler.vertScale(f, sw, kr);
 
@@ -1005,7 +1389,7 @@ BOOST_AUTO_TEST_CASE (Core1D_Coincident_FVal)
     };
 
     const auto scaler = Opm::SatFunc::
-        CritSatVerticalScaling({ 0.93 }, { 0.9 }, { 1.0 });
+        CritSatVerticalScaling({ 0.93 }, { 0.9 }, { 1.0 }, { 1.0 });
 
     const auto y = scaler.vertScale(f, s, kr);
 
@@ -1062,6 +1446,152 @@ BOOST_AUTO_TEST_CASE (Core1D_Coincident_FVal)
     };
 
     check_is_close(y, expect);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE (VerticalScaling_SatFuncCurves)
+
+BOOST_AUTO_TEST_CASE (Pcow_2Pt)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    const auto interp = swfn();
+
+    using Interp = std::remove_cv<
+        std::remove_reference<decltype(interp)>::type
+        >::type;
+
+    using ImportedOpm::unit::barsa;
+
+    // Maximum Pcow reset to 10 barsa.
+    const auto vscale = ::Opm::SatFunc::PureVerticalScaling {
+        { 10.0*barsa }
+    };
+
+    const auto sw = interp.saturationPoints(Interp::InTable{0});
+    const auto pc = interp           //  Pc_ow = ResultColumn{1}
+        .interpolate(Interp::InTable{0}, Interp::ResultColumn{1}, sw);
+
+    const auto f = SFVal{
+        SFPt{ 1.0, 0.04408*barsa }, // Displacement
+        SFPt{ 0.0, 3.75633*barsa }, // Maximum
+    };
+
+    const auto PC = vscale.vertScale(f, associate(sw), pc);
+
+    const auto expect = std::vector<double> { // pc * (10.0 / 3.75633)
+        1000000,
+        999997.33782708121,
+        497775.75452635949,
+        329393.31741353922,
+        244443.37957527695,
+        192877.09013851287,
+        157976.00317331014,
+        132605.49525733895,
+        113171.63295024665,
+        97677.786562948415,
+        84952.60001118113,
+        74224.043148498662,
+        64959.681391145081,
+        56840.053988866792,
+        49598.943649785826,
+        43023.376540399804,
+        37006.865743957533,
+        31416.302614520024,
+        26171.821964523886,
+        21193.558606405721,
+        16401.64735260214,
+        11734.85822598121,
+    };
+}
+
+BOOST_AUTO_TEST_CASE (KrOG_3Pt)
+{
+    using SFPt  = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues::Point;
+    using SFVal = ::Opm::SatFunc::VerticalScalingInterface::FunctionValues;
+
+    const auto interp = sofn();
+
+    using Interp = std::remove_cv<
+        std::remove_reference<decltype(interp)>::type
+        >::type;
+
+    const auto so   = interp.saturationPoints(Interp::InTable{0});
+    const auto krog = interp           // krog = ResultColumn{1}
+        .interpolate(Interp::InTable{0}, Interp::ResultColumn{1}, so);
+
+    const auto f = SFVal{
+        SFPt{ 0.6, 0.094671 }, // Displacement
+        SFPt{ 1.0, 1.0 },      // Maximum
+    };
+
+    const auto vscale = ::Opm::SatFunc::CritSatVerticalScaling {
+        // s   ,   Kr
+        { 0.6 }, { 0.25 },
+        { 1.0 }, { 0.6  }
+    };
+
+    const auto KROG = vscale.vertScale(f, associate(so), krog);
+
+    const auto expect = std::vector<double> {
+        // Left interval (So <= Sr = f.disp.sat = 0.6)
+        //
+        // Pure vertical scaling (multiply by a constant factor).
+        //
+        //   Kr = Kr(So) * (KRORG / Kr(Sr; table))
+        //      = Kr(So) * (KRORG / f.disp.val)
+        //      = Kr(So) * (0.25 / 0.094671)
+        //
+        0,                      // So = 0,      Kr(So) = 0,
+        0,                      // So = 1.0e-4  Kr(So) = 0,
+        1.8485069345417287e-05, // So = 0.05    Kr(So) = 7.0000e-06
+        0.00023238372891381731, // So = 0.1     Kr(So) = 8.8000e-05
+        0.0010140380898057484,  // So = 0.15    Kr(So) = 3.8400e-04
+        0.0029496889226901584,  // So = 0.2     Kr(So) = 1.1170e-03
+        0.0068579607271498132,  // So = 0.25    Kr(So) = 2.5970e-03
+        0.013874364905831774,   // So = 0.3     Kr(So) = 5.2540e-03
+        0.025514677145060262,   // So = 0.35    Kr(So) = 9.6620e-03
+        0.043799051451870158,   // So = 0.4     Kr(So) = 1.6586e-02
+        0.071391978536193765,   // So = 0.45    Kr(So) = 2.7035e-02
+        0.11176601071077732,    // So = 0.5     Kr(So) = 4.2324e-02
+        0.16940509765398062,    // So = 0.55    Kr(So) = 6.4151e-02
+        0.25,                   // So = 0.6     Kr(So) = 9.4671e-02
+
+        // ------------------------------------------
+        //
+        // Right interval (So >= Sr)
+        //
+        // Scaled Kr values defined by linear function between relperm
+        // points (Kr(Sr),KRORG) and (Krmax,KRO)
+        //
+        //                  Kr(So) - Kr(Sr)
+        //    Kr = KRORG + ----------------- (KRO - KRORG)
+        //                  Krmax  - Kr(Sr)
+        //
+        //                    Kr(So)  - f.disp.val
+        //       = KRORG + ------------------------ (KRO - KRORG)
+        //                  f.max.val - f.disp.val
+        //
+        //                 Kr(So) - 0.094671
+        //       = 0.25 + ------------------- (0.6 - 0.25)
+        //                 1      - 0.094671
+        //
+        0.26619195894531161,    // So = 0.65    Kr(So) = 0.136554
+        0.28801087781347995,    // So = 0.7     Kr(So) = 0.192992
+        0.31685006224256596,    // So = 0.75    Kr(So) = 0.267589
+        0.35413915825075742,    // So = 0.8     Kr(So) = 0.364043
+        0.40109672837167476,    // So = 0.85    Kr(So) = 0.485506
+        0.45833514667043695,    // So = 0.9     Kr(So) = 0.633562
+        0.52534294162674566,    // So = 0.95    Kr(So) = 0.806888
+        0.59985068588325352,    // So = 0.9999  Kr(So) = 0.999613776
+        0.59999999999999998,    // So = 1.0     Kr(So) = 1.0
+    };
+
+    check_is_close(KROG, expect);
 }
 
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
When the vertical scaling keywords activate independent scaling of relative permeability at scaled critical displacement saturation, we need to account for the possibility that the three-point EPS option has not been activated (`LOGIHEAD(20).EQ..FALSE.`, `SCALECRS=NO`).  In this case, the Sr is supposed to be the corresponding pure table point translated according to the scaled critical and maximum phase
saturations of the two-point method.

Add new functions
```
CritSatVertical::CritDispSat::KrX::twoPointMethod()
CritSatVertical::CritDispSat::KrX::alternateMethod()
```
that extract the correct scaled Sr for vertical scaling at critical displacing saturation depending on which EPS option has been selected.

While here, also add convenience functions that extract critical and maximum phase saturations from the INIT result set&mdash;defaulting to the appropriate table points&mdash;and use these helper functions where appropriate to minimise risk of calling `gridDefaultedVector()` with incorrect arguments.

Finally, make `CritSatVerticalScaling::Impl::vertScale()` use the scaled Sr&mdash;rather than the table point&mdash;to decide which of the two formulae to employ in any particular (S,Kr) situation.  This depends on callers passing the actual live saturation values for each cell. This, in turn, means that `CritSatVerticalScaling::Impl` objects must know the actual scaled Sr for each cell so update the constructor and data-members accordingly and fix all constructor calls.

Add a couple of new unit tests to demonstrate the new behaviour.

We also ensure that we always calculate the correct saturation for the "other" phase when translating a scaled oil saturation (for `SOFN`) to the appropriate active phase saturation in the G/O or O/W two-phase systems.  We must use the maximum attainable phase saturation sum for this purpose, not merely the maximum tabulated So.  Otherwise we potentially get negative gas saturation values in cases that have a non-zero connate water saturation.

Collectively, these changes are sufficient to correct the issues identified in Opm/ResInsight#2420 in local testing on simple models.  Additional testing using real field cases by the end user is needed to investigate if the problems are indeed corrected.