### PR TITLE
Fix End-Point Scaling Bugs for Two- and Three-Point Scaling Options

### DIFF
--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -340,37 +340,6 @@ namespace {
         return Opm::ECLUnits::serialisedUnitConventions(init);
     }
 
-    Opm::SatFunc::EPSEvalInterface::InvalidEndpointBehaviour
-    handleInvalid(const std::string& behaviour)
-    {
-        using IEB = Opm::SatFunc::
-            EPSEvalInterface::InvalidEndpointBehaviour;
-
-        if ((behaviour == "ignore") ||
-            (behaviour == "ignore-point") ||
-            (behaviour == "ignore_point") ||
-            (behaviour == "ignorepoint"))
-        {
-            return IEB::IgnorePoint;
-        }
-
-        return IEB::UseUnscaled;
-    }
-
-    auto handleInvalid(const Opm::ParameterGroup& prm)
-        -> decltype(handleInvalid("ignore"))
-    {
-        for (const auto* param : { "handle_invalid" ,
-                                   "hInv", "handleInv" })
-        {
-            if (prm.has(param)) {
-                return handleInvalid(prm.get<std::string>(param));
-            }
-        }
-
-        return handleInvalid("ignore");
-    }
-
     int getActiveCell(const Opm::ECLGraph&       G,
                       const Opm::ParameterGroup& prm)
     {
@@ -424,8 +393,7 @@ namespace {
             prm.getDefault("useEPS", std::string{"off"});
 
         auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
-        scaling.enable  = static_cast<unsigned char>(0);
-        scaling.invalid = handleInvalid(prm);
+        scaling.enable = static_cast<unsigned char>(0);
 
         if (std::regex_search(useEPS, horiz)) {
             scaling.enable |= T::Horizontal;

--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -54,13 +54,13 @@ namespace {
             const auto& x = graph.first;
             const auto& y = graph.second;
 
-            os << name << '{' << k << "} = [\n";
+            os << name << '{' << k << "} = extendTab([\n";
 
             for (auto n = x.size(), i = 0*n; i < n; ++i) {
                 os << x[i] << ' ' << y[i] << '\n';
             }
 
-            os << "];\n\n";
+            os << "]);\n\n";
             k += 1;
         }
 
@@ -118,7 +118,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, scaling);
 
-        printGraph(std::cout, "krg", graph);
+        printGraph(std::cout, "crv.krg", graph);
     }
 
     void krog(const Opm::ECLSaturationFunc&                 sfunc,
@@ -140,7 +140,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, scaling);
 
-        printGraph(std::cout, "krog", graph);
+        printGraph(std::cout, "crv.krog", graph);
     }
 
     void krow(const Opm::ECLSaturationFunc&                 sfunc,
@@ -162,7 +162,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, scaling);
 
-        printGraph(std::cout, "krow", graph);
+        printGraph(std::cout, "crv.krow", graph);
     }
 
     void krw(const Opm::ECLSaturationFunc&                 sfunc,
@@ -184,7 +184,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, scaling);
 
-        printGraph(std::cout, "krw", graph);
+        printGraph(std::cout, "crv.krw", graph);
     }
 
     // -----------------------------------------------------------------
@@ -209,7 +209,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, scaling);
 
-        printGraph(std::cout, "pcgo", graph);
+        printGraph(std::cout, "crv.pcgo", graph);
     }
 
     void pcow(const Opm::ECLSaturationFunc&                 sfunc,
@@ -231,7 +231,7 @@ namespace {
         const auto graph =
             sfunc.getSatFuncCurve(func, activeCell, scaling);
 
-        printGraph(std::cout, "pcow", graph);
+        printGraph(std::cout, "crv.pcow", graph);
     }
 
     // -----------------------------------------------------------------
@@ -245,7 +245,7 @@ namespace {
         const auto graph = pvtCurves
             .getPvtCurve(RC::FVF, Opm::ECLPhaseIndex::Vapour, activeCell);
 
-        printGraph(std::cout, "Bg", graph);
+        printGraph(std::cout, "crv.Bg", graph);
     }
 
     void mu_g(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCurves,
@@ -256,7 +256,7 @@ namespace {
         const auto graph = pvtCurves
             .getPvtCurve(RC::Viscosity, Opm::ECLPhaseIndex::Vapour, activeCell);
 
-        printGraph(std::cout, "mu_g", graph);
+        printGraph(std::cout, "crv.mu_g", graph);
     }
 
     void Bo(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCurves,
@@ -267,7 +267,7 @@ namespace {
         const auto graph = pvtCurves
             .getPvtCurve(RC::FVF, Opm::ECLPhaseIndex::Liquid, activeCell);
 
-        printGraph(std::cout, "Bo", graph);
+        printGraph(std::cout, "crv.Bo", graph);
     }
 
     void mu_o(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCurves,
@@ -278,7 +278,7 @@ namespace {
         const auto graph = pvtCurves
             .getPvtCurve(RC::Viscosity, Opm::ECLPhaseIndex::Liquid, activeCell);
 
-        printGraph(std::cout, "mu_o", graph);
+        printGraph(std::cout, "crv.mu_o", graph);
     }
 
     // -----------------------------------------------------------------
@@ -293,7 +293,7 @@ namespace {
         const auto graph = pvtCurves
             .getPvtCurve(RC::SaturatedState, PI::Vapour, activeCell);
 
-        printGraph(std::cout, "rvSat", graph);
+        printGraph(std::cout, "crv.rvSat", graph);
     }
 
     void rsSat(const Opm::ECLPVT::ECLPvtCurveCollection& pvtCurves,
@@ -305,7 +305,7 @@ namespace {
         const auto graph = pvtCurves
             .getPvtCurve(RC::SaturatedState, PI::Liquid, activeCell);
 
-        printGraph(std::cout, "rsSat", graph);
+        printGraph(std::cout, "crv.rsSat", graph);
     }
 
     // -----------------------------------------------------------------
@@ -460,6 +460,8 @@ try {
         pvtCC.setOutputUnits(std::move(units));
     }
 
+    std::cout << "function crv = pcurves()\n";
+
     // -----------------------------------------------------------------
     // Relative permeability
 
@@ -470,7 +472,8 @@ try {
 
     // -----------------------------------------------------------------
     // Capillary pressure
-    if (prm.getDefault("pcgo", false)) { pcgo(sfunc, cellID, scaling); }
+    if (prm.getDefault("pcog", false) || // Alias pcog -> pcgo
+        prm.getDefault("pcgo", false)) { pcgo(sfunc, cellID, scaling); }
     if (prm.getDefault("pcow", false)) { pcow(sfunc, cellID, scaling); }
 
     // -----------------------------------------------------------------

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -619,21 +619,25 @@ Impl::eval(const TableEndPoints&   tep,
             // s <= sLO
             s_eff = tep.low;
         }
-        else if (! (eval_pt.sat < sHI)) {
-            // s >= sHI
-            s_eff = tep.high;
-        }
-        else if (eval_pt.sat < sR) {
-            // s \in (sLO, sR)
+        else if (eval_pt.sat < std::min(sR, sHI)) {
+            // s in scaled interval [sLO, sR)
+            // Map to tabulated saturation in [tep.low, tep.disp)
             const auto t = (eval_pt.sat - sLO) / (sR - sLO);
 
             s_eff = tep.low + t*(tep.disp - tep.low);
         }
-        else {
-            // s \in (sR, sHI)
+        else if (eval_pt.sat < sHI) {
+            // s in scaled interval [sR, sHI)
+            // Map to tabulated saturation in [tep.disp, tep.high)
+            assert (sHI > sR);
+
             const auto t = (eval_pt.sat - sR) / (sHI - sR);
 
             s_eff = tep.disp + t*(tep.high - tep.disp);
+        }
+        else {
+            // s >= sHI
+            s_eff = tep.high;
         }
     }
 

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -674,7 +674,7 @@ Impl::reverse(const TableEndPoints&   tep,
                 (eval_pt.sat - tep.low)
                 / (tep.disp  - tep.low);
 
-            s_unsc = sLO + t*(sR - sLO);
+            s_unsc = std::min(sLO + t*(sR - sLO), sHI);
         }
         else if (eval_pt.sat < tep.high) {
             // s in tabulated interval [tep.disp, tep.high)
@@ -685,7 +685,7 @@ Impl::reverse(const TableEndPoints&   tep,
                 (eval_pt.sat - tep.disp)
                 / (tep.high  - tep.disp);
 
-            s_unsc = sR + t*(sHI - sR);
+            s_unsc = std::min(sR + t*std::max(sHI - sR, 0.0), sHI);
         }
         else {
             s_unsc = sHI;

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -249,9 +249,7 @@ class Opm::SatFunc::TwoPointScaling::Impl
 public:
     Impl(std::vector<double> smin,
          std::vector<double> smax)
-        : smin_          (std::move(smin))
-        , smax_          (std::move(smax))
-        , handle_invalid_(InvalidEndpointBehaviour::UseUnscaled)
+        : smin_(std::move(smin)), smax_(std::move(smax))
     {
         if (this->smin_.size() != this->smax_.size()) {
             throw std::invalid_argument {
@@ -272,8 +270,6 @@ public:
 private:
     std::vector<double> smin_;
     std::vector<double> smax_;
-
-    InvalidEndpointBehaviour handle_invalid_;
 
     double sMin(const std::vector<int>::size_type cell,
                 const TableEndPoints&             tep) const
@@ -548,10 +544,7 @@ public:
     Impl(std::vector<double> smin ,
          std::vector<double> sdisp,
          std::vector<double> smax )
-        : smin_          (std::move(smin ))
-        , sdisp_         (std::move(sdisp))
-        , smax_          (std::move(smax ))
-        , handle_invalid_(InvalidEndpointBehaviour::UseUnscaled)
+        : smin_(std::move(smin)), sdisp_(std::move(sdisp)), smax_(std::move(smax))
     {
         if ((this->sdisp_.size() != this->smin_.size()) ||
             (this->sdisp_.size() != this->smax_.size()))
@@ -575,8 +568,6 @@ private:
     std::vector<double> smin_;
     std::vector<double> sdisp_;
     std::vector<double> smax_;
-
-    InvalidEndpointBehaviour handle_invalid_;
 
     double sMin(const std::vector<int>::size_type cell,
                 const TableEndPoints&             tep) const
@@ -708,7 +699,6 @@ namespace Create {
     using EPSOpt = ::Opm::SatFunc::CreateEPS::EPSOptions;
     using RTEP   = ::Opm::SatFunc::CreateEPS::RawTableEndPoints;
     using TEP    = ::Opm::SatFunc::EPSEvalInterface::TableEndPoints;
-    using InvBeh = ::Opm::SatFunc::EPSEvalInterface::InvalidEndpointBehaviour;
 
     namespace TwoPoint {
         using EPS    = ::Opm::SatFunc::TwoPointScaling;

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -688,7 +688,7 @@ Impl::reverse(const TableEndPoints&   tep,
             s_unsc = std::min(sR + t*std::max(sHI - sR, 0.0), sHI);
         }
         else {
-            s_unsc = sHI;
+            s_unsc = (tep.high > tep.disp) ? sHI : sR;
         }
     }
 

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -1787,7 +1787,7 @@ KrGO::twoPointMethod(const ::Opm::ECLGraph&        G,
     auto t = std::vector<double>(sogcr.size(), 0.0);
     {
         const auto& sgco = tep.conn.gas;
-        const auto& swco = tep.conn.gas;
+        const auto& swco = tep.conn.water;
         const auto& sgcr = tep.crit.gas;
 
         for (auto n = sgcr.size(), i = 0*n; i < n; ++i) {
@@ -1835,7 +1835,7 @@ KrOW::twoPointMethod(const ::Opm::ECLGraph&        G,
     auto t = std::vector<double>(sowcr.size(), 0.0);
     {
         const auto& sgco = tep.conn.gas;
-        const auto& swco = tep.conn.gas;
+        const auto& swco = tep.conn.water;
         const auto& swcr = tep.crit.water;
 
         for (auto n = swcr.size(), i = 0*n; i < n; ++i) {

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -503,13 +503,13 @@ vertScale(const FunctionValues&   f,
 
         const auto c  = sp[i].cell;
         const auto s  = sp[i].sat;
-        const auto sr = this->sdisp_[c];
+        const auto sr = std::min(this->sdisp_[c], this->smax_[c]);
         const auto fr = this->fdisp_[c];
         const auto sm = this->smax_ [c];
         const auto fm = this->fmax_ [c];
 
-        if (! (s > sr)) {
-            // s <= sr: Pure vertical scaling in left interval.
+        if (s < sr) {
+            // s < sr: Pure vertical scaling in left interval.
             y *= fr / fdisp;
         }
         else if (sepfv) {

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -667,11 +667,6 @@ Impl::reverse(const TableEndPoints&   tep,
             // Map to Minimum Input Saturation in cell (sLO).
             s_unsc = sLO;
         }
-        else if (! (eval_pt.sat < tep.high)) {
-            // s >= maximum tabulated saturation.
-            // Map to Maximum Input Saturation in cell (sHI).
-            s_unsc = sHI;
-        }
         else if (eval_pt.sat < tep.disp) {
             // s in tabulated interval (tep.low, tep.disp)
             // Map to Input Saturation in (sLO, sR)
@@ -681,14 +676,19 @@ Impl::reverse(const TableEndPoints&   tep,
 
             s_unsc = sLO + t*(sR - sLO);
         }
-        else {
-            // s in tabulated interval (tep.disp, tep.high)
-            // Map to Input Saturation in (sR, sHI)
+        else if (eval_pt.sat < tep.high) {
+            // s in tabulated interval [tep.disp, tep.high)
+            // Map to Input Saturation in [sR, sHI)
+            assert (tep.high > tep.disp);
+
             const auto t =
                 (eval_pt.sat - tep.disp)
                 / (tep.high  - tep.disp);
 
             s_unsc = sR + t*(sHI - sR);
+        }
+        else {
+            s_unsc = sHI;
         }
     }
 

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -67,19 +67,6 @@ namespace Opm { namespace SatFunc {
             double sat;
         };
 
-        /// Policy for how to handle an invalid end-point scaling (e.g., if
-        /// lower and/or upper scaled saturations have nonsensical values
-        /// like -1.0E+20).
-        enum class InvalidEndpointBehaviour {
-            /// Use the unscaled value for this point.
-            UseUnscaled,
-
-            /// Ignore this scaling request (e.g., produce no graphical
-            /// output for a scaled saturation function when the scaled
-            /// end-points are meaningless).
-            IgnorePoint,
-        };
-
         /// Convenience type alias.
         using SaturationPoints = std::vector<SaturationAssoc>;
 
@@ -574,13 +561,6 @@ namespace Opm { namespace SatFunc {
             ///   auto eps = CreateEPS::fromECLOutput(G, init, opt);
             /// \endcode
             ::Opm::ECLPhaseIndex thisPh;
-
-            /// How to handle an invalid end-point scaling (e.g., if lower
-            /// and/or upper scaled saturations have nonsensical values like
-            /// -1.0E+20).
-            EPSEvalInterface::InvalidEndpointBehaviour handle_invalid {
-                EPSEvalInterface::InvalidEndpointBehaviour::UseUnscaled
-            };
         };
 
         /// Collection of raw saturation table end points.

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -90,6 +90,8 @@ namespace {
 class PVxGBase
 {
 public:
+    virtual ~PVxGBase() {}
+
     virtual std::vector<double>
     formationVolumeFactor(const std::vector<double>& rv,
                           const std::vector<double>& pg) const = 0;

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -129,6 +129,8 @@ namespace {
 class PVxOBase
 {
 public:
+    virtual ~PVxOBase() {}
+
     virtual std::vector<double>
     formationVolumeFactor(const std::vector<double>& rs,
                           const std::vector<double>& po) const = 0;

--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -473,13 +473,13 @@ namespace {
             explicit InitFileSections(const ecl_file_type* init);
 
             struct Section {
-                Section(const ecl_file_view_type* blk)
+                Section(ecl_file_view_type* blk)
                     : block   (blk)
                     , first_kw(Details::firstBlockKeyword(block))
                 {}
 
-                const ecl_file_view_type* block;
-                std::string               first_kw;
+                ecl_file_view_type* block;
+                std::string         first_kw;
             };
 
             const std::vector<Section>& sections() const
@@ -502,7 +502,7 @@ namespace {
             }
 
         private:
-            const ecl_file_view_type* init_;
+            ecl_file_view_type* init_;
 
             std::vector<Section> sect_;
         };
@@ -796,7 +796,7 @@ ECLImpl::InitFileSections::InitFileSections(const ecl_file_type* init)
                 ? sectID - 1 : 0*sectID;
 
             // Main section 'sectID': [ start_kw, LGRSGONE ]
-            const auto* sect =
+            auto* sect =
                 ecl_file_view_add_blockview2(this->init_, start_kw,
                                              end_kw, start_kw_occurrence);
 
@@ -808,12 +808,12 @@ ECLImpl::InitFileSections::InitFileSections(const ecl_file_type* init)
             const auto occurrence = 0;
 
             // Main grid sub-section of 'sectID': [ start_kw, LGR ]
-            const auto* main_grid_sect =
+            auto* main_grid_sect =
                 ecl_file_view_add_blockview2(sect, firstkw.c_str(),
                                              LGR_KW, occurrence);
 
             // LGR sub-section of 'sectID': [ LGR, LGRSGONE ]
-            const auto* lgr_sect =
+            auto* lgr_sect =
                 ecl_file_view_add_blockview2(sect, LGR_KW,
                                              end_kw, occurrence);
 
@@ -965,7 +965,7 @@ private:
 
         /// Saved original active view from host (prior to restricting view
         /// to single grid ID).
-        const ecl_file_view_type* save_;
+        ecl_file_view_type* save_;
     };
 
     /// Casename prefix.  Mostly to implement copy ctor.
@@ -986,7 +986,7 @@ private:
     std::unique_ptr<ECLImpl::GridIDCache> gridIDCache_;
 
     /// Current active result-set view.
-    mutable const ecl_file_view_type* activeBlock_{ nullptr };
+    mutable ecl_file_view_type* activeBlock_{ nullptr };
 
     /// Support for passing \code *this \endcode to ERT functions that
     /// require an \c ecl_file_type, particularly the function that selects
@@ -1276,7 +1276,7 @@ private:
     /// Sections of the INIT result set.
     ECLImpl::InitFileSections sections_;
 
-    mutable const ecl_file_view_type* activeBlock_{ nullptr };
+    mutable ecl_file_view_type* activeBlock_{ nullptr };
 
     /// Negative look-up cache for haveKeywordData() queries.
     mutable MissingKW missing_kw_;

--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -1415,6 +1415,10 @@ lookup(const std::string& vector, const std::string& gridName) const
         }
     }
 
+    // Status of 'vector' unknown for 'gridName'.  Actually look for the
+    // vector in gridName's sections (main grid if gridName.empty(),
+    // otherwise named local grid).
+
     if (gridName.empty()) {
         return this->lookupMainGrid(key);
     }

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -758,8 +758,7 @@ private:
                     const ActPh&           active)
         {
             auto opt = Create::EPSOptions{};
-            opt.use3PtScaling  = use3PtScaling;
-            opt.handle_invalid = SatFuncScaling::IEB::UseUnscaled;
+            opt.use3PtScaling = use3PtScaling;
 
             if (active.oil) {
                 this->create_oil_eps(host, G, init, ep, active, opt);

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -85,19 +85,12 @@ namespace Opm {
                 Vertical   = 1 << 1u,
             };
 
-            using IEB = SatFunc::EPSEvalInterface::InvalidEndpointBehaviour;
-
             SatFuncScaling()
-                : enable (Type::Horizontal | Type::Vertical)
-                , invalid(IEB::UseUnscaled)
+                : enable(Type::Horizontal | Type::Vertical)
             {}
 
             // Default: Use both Horizontal and Vertical if specified.
             unsigned char enable;
-
-            // Default: Use unscaled values in case of invalid scaled
-            // saturations occurring in the result set.
-            IEB invalid;
         };
 
         /// Constructor

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -972,6 +972,13 @@ BOOST_AUTO_TEST_CASE (KrOW_3pt)
     }
 
     // Reverse: Lookup/Table so -> Scaled SO.
+    //
+    // Note that "tep.disp" is equal to "tep.high" in the input table.  In
+    // this particular case, the reverse scaling will map high saturation
+    // values to 'Sr' rather than the maximum mobile So (= 0.85) in order to
+    // enable distinguishing scaled critical saturation from scaled maximum
+    // saturation for purpose of converting to "regular" phase saturations
+    // (i.e., SW or SG).
     {
         const auto SO = std::vector<double> {
             0.20000000000000001, // so = 0
@@ -993,10 +1000,10 @@ BOOST_AUTO_TEST_CASE (KrOW_3pt)
             0.6583231470163351,  // so = 0.75
             0.68888209801089018, // so = 0.80000000000000004
             0.71944104900544503, // so = 0.84999999999999998
-            0.84999999999999998, // so = 0.90000000000000002
-            0.84999999999999998, // so = 0.94999999999999996
-            0.84999999999999998, // so = 0.99990000000000001
-            0.84999999999999998, // so = 1
+            0.75,                // so = 0.90000000000000002
+            0.75,                // so = 0.94999999999999996
+            0.75,                // so = 0.99990000000000001
+            0.75,                // so = 1
         };
 
         const auto so     = interp.saturationPoints(Interp::InTable{0});


### PR DESCRIPTION
This pull request refines the handling of the various saturation intervals during reverse, forward and vertical scaling for the two- and three-point end-point scaling options.  This is needed to handle various special cases relating to coincident points in either the input (tabulated) or scaled saturation points, and to guard against strange situations that happen if the scaled saturations don't always satisfy all the implied consistency requirements.

Collectively, these fixes are enough to produce the expected output on the `SIMPLE_V4_EPS_KRWR_DEBUG_2PT` and `SIMPLE_V4_EPS_KRWR_DEBUG_3PT` test models.

There is one external API change associated to this pull request.  We remove the option for handling "invalid" saturations.  That option was introduced at a time when we did not understand the implication of sentinel values&mdash;specifically `-1.0E+20`&mdash;in input arrays such as `SWU` or `KRORW` and would subsequently interpolate out of bounds for the input tables.  Now that we do know what those values mean&mdash;pick the corresponding point from the input tables&mdash;there is no longer any need to provide this option.

We also fix one egregious error in the base classes for the gas and oil PVT interpolants.  Since we destroy objects of derived types through pointers to base the base needs to provide a virtual destructor.  Pointy hat to me and thanks to GCC's address sanitizer mode for pointing out the missing destructor.