### PR TITLE
Load NNC Helper: Chase Update to LibECL Function

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -685,7 +685,7 @@ ECL::loadNNC(const ecl_grid_type* G,
 
     auto nncData = std::vector<ecl_nnc_type>{};
 
-    const auto numNNC = make_szt(ecl_nnc_export_get_size(G));
+    const auto numNNC = make_szt(ecl_nnc_export_get_size(G, init));
 
     if (numNNC > 0) {
         nncData.resize(numNNC);


### PR DESCRIPTION
Function `ecl_nnc_export_get_size()` gained a new parameter (`init`) in commit [d722ea79](https://github.com/Statoil/libecl/commit/d722ea799e532df672cffa212327ee87a8154778).  Update caller accordingly.

Note that this change is not backwards compatible, so this effectively updates the minimum requirements on LibECL to one that has the requisite commit.