### PR TITLE
Don't crash on Unexpected Input

### DIFF
--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -504,14 +504,12 @@ vertScale(const FunctionValues&   f,
           const SaturationPoints& sp,
           std::vector<double>     val) const
 {
-    assert ((sp.size() == val.size())  && "Internal Error in Vertical Scaling");
-    assert (! (f.max.val < f.disp.val) && "Internal Error in Table Extraction");
-    assert (! (f.max.sat < f.disp.sat) && "Internal Error in Table Extraction");
+    assert ((sp.size() == val.size()) && "Internal Error in Vertical Scaling");
 
     auto ret = std::move(val);
 
     const auto fdisp = f.disp.val;
-    const auto fmax  = f.max .val;
+    const auto fmax  = std::max(f.disp.val, f.max.val);
     const auto sepfv = fmax > fdisp;
 
     for (auto n = sp.size(), i = 0*n; i < n; ++i) {

--- a/opm/utility/ECLEndPointScaling.cpp
+++ b/opm/utility/ECLEndPointScaling.cpp
@@ -2532,6 +2532,9 @@ unscaledFunctionValues(const ECLGraph&          G,
         ret.resize(uep.size());
 
         for (auto n = uep.size(), i = 0*n; i < n; ++i) {
+            ret[i].disp.sat = uep[i].disp;
+            ret[i].disp.val = evalSF(static_cast<int>(i), ret[i].disp.sat);
+
             ret[i].max.sat = uep[i].high;
             ret[i].max.val = evalSF(static_cast<int>(i), ret[i].max.sat);
         }

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -208,6 +208,11 @@ namespace Opm
     ECLFluxCalc::flux(const ECLRestartData& rstrt,
                       const ECLPhaseIndex   phase) const
     {
+        if (! this->phaseIsActive(phase)) {
+            // Inactive phase.  Return empty flux vector.
+            return {};
+        }
+
         // Obtain dynamic data.
         const auto dyn_data = this->phaseProperties(rstrt, phase);
 
@@ -225,6 +230,11 @@ namespace Opm
     ECLFluxCalc::massflux(const ECLRestartData& rstrt,
                           const ECLPhaseIndex   phase) const
     {
+        if (! this->phaseIsActive(phase)) {
+            // Inactive phase.  Return empty (mass) flux vector.
+            return {};
+        }
+
         // Obtain dynamic data.
         const auto dyn_data = this->phaseProperties(rstrt, phase);
 
@@ -296,6 +306,19 @@ namespace Opm
         return urho * mob * T * dh;
     }
 
+
+    bool ECLFluxCalc::phaseIsActive(const ECLPhaseIndex phase) const
+    {
+        switch (phase) {
+        case ECLPhaseIndex::Aqua:   return this->pvtWat_ != nullptr;
+        case ECLPhaseIndex::Liquid: return this->pvtOil_ != nullptr;
+        case ECLPhaseIndex::Vapour: return this->pvtGas_ != nullptr;
+        }
+
+        throw std::invalid_argument {
+            "phaseIsActive(): Invalid Phase Identifier"
+        };
+    }
 
 
     ECLFluxCalc::DynamicData

--- a/opm/utility/ECLFluxCalc.hpp
+++ b/opm/utility/ECLFluxCalc.hpp
@@ -131,6 +131,8 @@ namespace Opm
                               const DynamicData& dyn_data) const;
 
 
+        bool phaseIsActive(const ECLPhaseIndex phase) const;
+
         DynamicData gasPVT(const ECLRestartData& rstrt,
                            DynamicData&&         dyn_data) const;
 

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -1357,6 +1357,11 @@ private:
                         return host.wat_->pcow(regID, { sat })[0];
                     });
 
+                // Special case treatment of PCOW.  Maximum value at minimum S.
+                for (auto& fval : *eps.vertfuncval) {
+                    fval.max.val = std::max(fval.disp.val, fval.max.val);
+                }
+
                 eps.vertscaling = Create::Vertical::
                     fromECLOutput(G, init, opt, ep,
                                   *eps.vertfuncval);


### PR DESCRIPTION
This pull request adds a few refinements to the library. Mostly, these are robustness improvements to ensure that we don't crash on unexpected input which would arise from trying to compute PVT quantities (e.g., the formation volume factor or the phase viscosity) for an inactive phase or trying to use the three-point method to vertically scale a saturation function when the displacing saturation would be marginally larger than the maximum saturation due to calculating the displacing saturation from values that were converted from `float` to `double` and thus incurring two round-off errors.

We also correct two issues affecting the scaled capillary pressure function `Pc_{ow}(Sw)`. We would previously define vertical scaling in terms of the minimum capillary pressure value (often zero) rather than the maximum value which occurs at the connate water saturation. Moreover we would fail to properly fall back to the scaled connate water/gas saturations (SWL/SGL) in the case of the dedicated scaled capillary pressure connate saturations (SWLPC/SGLPC) being present but set to sentinel values. In that case we would previously incorrectly pick the tabulated connate saturations which would occasionally produce hilariously inconsistent graphical output for the scaled capillary pressure functions (completely wrong saturation ranges).

This PR is the native library edition of OPM/ResInsight#3671 which was previously merged into ResInsight.