### PR TITLE
PVT Evaluation: Give More Meaningful Diagnostic if Interpolant Missing

### DIFF
--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -496,6 +496,13 @@ void
 Opm::ECLPVT::Gas::Impl::validateRegIdx(const RegIdx region) const
 {
     if (region >= this->eval_.size()) {
+        if (this->eval_.empty()) {
+            throw std::invalid_argument{
+                "No Gas PVT Interpolant Available in Region "
+                + std::to_string(region + 1)
+            };
+        }
+
         throw std::invalid_argument {
             "Region Index " +
             std::to_string(region) +

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -691,6 +691,13 @@ void
 Opm::ECLPVT::Oil::Impl::validateRegIdx(const RegIdx region) const
 {
     if (region >= this->eval_.size()) {
+        if (this->eval_.empty()) {
+            throw std::invalid_argument {
+                "No Oil PVT Interpolant Available in Region "
+                + std::to_string(region + 1)
+            };
+        }
+
         throw std::invalid_argument {
             "Region Index " +
             std::to_string(region) +

--- a/opm/utility/ECLPvtWater.cpp
+++ b/opm/utility/ECLPvtWater.cpp
@@ -252,6 +252,13 @@ void
 Opm::ECLPVT::Water::Impl::validateRegIdx(const RegIdx region) const
 {
     if (region >= this->eval_.size()) {
+        if (this->eval_.empty()) {
+            throw std::invalid_argument {
+                "No Water PVT Interpolant Available in Region "
+                + std::to_string(region + 1)
+            };
+        }
+
         throw std::invalid_argument {
             "Region Index " +
             std::to_string(region) +


### PR DESCRIPTION
This commit refines the error message emitted if a particular phase does not have a PVT interpolant--e.g., if the INIT file does not provide PVT data.  Previously we would generate a message akin to
```
Region Index 0 Outside Valid Range (0 .. (size_t)-1)
```
which is not very helpful to users in diagnosing the issue.  The new message does at least indicate that there is no interpolant for the accompanying phase and also emits the (1-based) region index for context.

This imports the change-set that was previously made in OPM/ResInsight#4342 into the upstream sources.