### PR TITLE
INIT File: Use Global View Unless Result Set has LGR Keyword

### DIFF
--- a/opm/utility/ECLResultData.cpp
+++ b/opm/utility/ECLResultData.cpp
@@ -773,17 +773,23 @@ ECLImpl::InitFileSections::InitFileSections(const ecl_file_type* init)
     // Note: ecl_file_get_global_view() does not modify input arg
     : init_(ecl_file_get_global_view(const_cast<ecl_file_type*>(init)))
 {
-    const auto* endLGR_kw = "LGRSGONE";
-    const auto nEndLGR =
-        ecl_file_view_get_num_named_kw(this->init_, endLGR_kw);
-
-    if (nEndLGR == 0) {
+    if (! ecl_file_view_has_kw(this->init_, LGR_KW)) {
         // No LGRs in model.  INIT file consists of global section only,
         // meaning that the only available section is equal to the global
         // view (i.e., this->init_).
+        //
+        // Note that it is possible (e.g., tNav--see ResInsight Issue 4966,
+        // https://github.com/OPM/ResInsight/issues/4966) for a case to have
+        // LGRSGONE without having any LGRs or associate LGR data.
         this->sect_.push_back(Section{ this->init_ });
     }
     else {
+        // INIT file has LGRs.  Determine number of LGR data sections and
+        // derive sectioning structure for later lookup() operations.
+        const auto* endLGR_kw = "LGRSGONE";
+        const auto nEndLGR =
+            ecl_file_view_get_num_named_kw(this->init_, endLGR_kw);
+
         const auto* start_kw = INTEHEAD_KW;
         const auto* end_kw   = endLGR_kw;
 


### PR DESCRIPTION
This PR switches the logic for whether or not to use the global file view into looking for the 'LGR' keyword.  The previous logic, based on 'LGRSGONE', would produce false positives (assuming LGR when none present) when presented with a result set from tNav.  That simulator appears to output 'LGRSGONE' even if there is no LGR data.

Additional details at OPM/ResInsight#4966.

This PR fixes #99, supersedes and closes #100.