### PR TITLE
For dual porosity models, use PORV from matrix

### DIFF
--- a/opm/utility/ECLGraph.cpp
+++ b/opm/utility/ECLGraph.cpp
@@ -597,6 +597,13 @@ ECL::getPVolVector(const ecl_grid_type*          G,
     if (init.haveKeywordData(kw, gridID)) {
         pvol = init.keywordData<double>(kw, gridID);
 
+        if (pvol.size() == nglob * 2)
+        {
+            // For dual perm/poro models, the result count is 2x the number of cells, as results are present for
+            // both matrix and fracture. Use only the matrix results (first half of the result values)
+            pvol.resize(nglob);
+        }
+
         assert ((pvol.size() == nglob) &&
                 "Pore-volume must be provided for all global cells");
 


### PR DESCRIPTION
Users want to plot PVT and Rel Perm curves for dual porosity models. These models have a result value count that is twice the number of cells. This workaround will use the PORV values from the matrix part of the results, to make sure the result vector size matches other parts of the code.

See https://github.com/OPM/ResInsight/issues/7335