### PR TITLE
Guard negative index calculations

### DIFF
--- a/opm/utility/ECLPvtCommon.cpp
+++ b/opm/utility/ECLPvtCommon.cpp
@@ -310,6 +310,11 @@ Opm::ECLPVT::surfaceMassDensity(const ECLInitFileData& init,
 
     // Subtract one to account for 1-based indices.
     const auto start = tabdims[ TABDIMS_IBDENS_OFFSET_ITEM ] - 1;
+    if (start < 0) {
+        throw std::invalid_argument(
+            "Invalid table offset for TABDIMS_IBDENS_OFFSET_ITEM");
+    }
+
     const auto nreg  = tabdims[ TABDIMS_NTDENS_ITEM ];
 
     // Phase densities for 'phase' constitute 'nreg' consecutive entries

--- a/opm/utility/ECLPvtGas.cpp
+++ b/opm/utility/ECLPvtGas.cpp
@@ -642,6 +642,10 @@ fromECLOutput(const ECLInitFileData& init)
 
         // Subtract one to account for 1-based indices.
         const auto start = tabdims[ TABDIMS_JBPVTG_OFFSET_ITEM ] - 1;
+        if (start < 0) {
+            throw std::invalid_argument(
+                "Invalid table offset for TABDIMS_JBPVTG_OFFSET_ITEM");
+        }
 
         raw.primaryKey.assign(&tab[start], &tab[start] + nTabElem);
     }
@@ -653,6 +657,10 @@ fromECLOutput(const ECLInitFileData& init)
 
         // Subtract one to account for 1-based indices.
         const auto start = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
+        if (start < 0) {
+            throw std::invalid_argument(
+                "Invalid table offset for TABDIMS_IBPVTG_OFFSET_ITEM");
+        }
 
         raw.data.assign(&tab[start], &tab[start] + nTabElem);
     }

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -837,6 +837,10 @@ fromECLOutput(const ECLInitFileData& init)
 
         // Subtract one to account for 1-based indices.
         const auto start = tabdims[ TABDIMS_JBPVTO_OFFSET_ITEM ] - 1;
+        if (start < 0) {
+            throw std::invalid_argument(
+                "Invalid table offset for TABDIMS_JBPVTO_OFFSET_ITEM");
+        }
 
         raw.primaryKey.assign(&tab[start], &tab[start] + nTabElem);
     }
@@ -848,6 +852,10 @@ fromECLOutput(const ECLInitFileData& init)
 
         // Subtract one to account for 1-based indices.
         const auto start = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
+        if (start < 0) {
+            throw std::invalid_argument(
+                "Invalid table offset for TABDIMS_IBPVTO_OFFSET_ITEM");
+        }
 
         raw.data.assign(&tab[start], &tab[start] + nTabElem);
     }

--- a/opm/utility/ECLPvtWater.cpp
+++ b/opm/utility/ECLPvtWater.cpp
@@ -364,6 +364,10 @@ fromECLOutput(const ECLInitFileData& init)
 
         // Subtract one to account for 1-based indices.
         const auto start = tabdims[ TABDIMS_IBPVTW_OFFSET_ITEM ] - 1;
+        if (start < 0) {
+            throw std::invalid_argument(
+                "Invalid table offset for TABDIMS_IBPVTW_OFFSET_ITEM");
+        }
 
         raw.data.assign(&tab[start], &tab[start] + nTabElem);
     }

--- a/opm/utility/ECLSaturationFunc.cpp
+++ b/opm/utility/ECLSaturationFunc.cpp
@@ -598,6 +598,10 @@ Gas::Details::tableData(const std::vector<int>&    tabdims,
 
     // Subtract one to account for offset being one-based index.
     const auto start = tabdims[ TABDIMS_IBSGFN_OFFSET_ITEM ] - 1;
+    if (start < 0) {
+        throw std::invalid_argument(
+            "Invalid table offset for TABDIMS_IBSGFN_OFFSET_ITEM");
+    }
 
     t.data.assign(&tab[start], &tab[start] + nTabElems);
 
@@ -649,6 +653,10 @@ Oil::Details::tableData(const std::vector<int>&    tabdims,
 
     // Subtract one to account for offset being one-based index.
     const auto start = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
+    if (start < 0) {
+        throw std::invalid_argument(
+            "Invalid table offset for TABDIMS_IBSOFN_OFFSET_ITEM");
+    }
 
     t.data.assign(&tab[start], &tab[start] + nTabElems);
 
@@ -689,6 +697,10 @@ Water::Details::tableData(const std::vector<int>&    tabdims,
 
     // Subtract one to account for offset being one-based index.
     const auto start = tabdims[ TABDIMS_IBSWFN_OFFSET_ITEM ] - 1;
+    if (start < 0) {
+        throw std::invalid_argument(
+            "Invalid table offset for TABDIMS_IBSWFN_OFFSET_ITEM");
+    }
 
     t.data.assign(&tab[start], &tab[start] + nTabElems);
 


### PR DESCRIPTION
Testing on dual porosity models revealed existence of negative 0-based indices. Add code to guard for negative indices.