### PR TITLE
WIP make the code compile with libecl version-2.7. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #                                                                         #
 ###########################################################################
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.10)
 
 # additional search modules
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
@@ -51,6 +51,7 @@ endif()
 find_package(opm-common REQUIRED)
 
 include(OpmInit)
+OpmSetPolicies()
 
 # not the same location as most of the other projects; this hook overrides
 macro (dir_hook)
@@ -97,3 +98,6 @@ if (HAVE_OPM_TESTS)
   # Regression test data available.  Enable additional tests.
   include (${CMAKE_CURRENT_SOURCE_DIR}/AcceptanceTests.cmake)
 endif()
+
+include_directories(${CMAKE_SOURCE_DIR}/../libecl/lib/include)
+include_directories(${CMAKE_SOURCE_DIR}/../libecl/build/lib/include)

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-flowdiagnostics-applications
 Description: flow diagnostics applications and examples
-Version: 2020.04-pre
-Label: 2020.04-pre
+Version: 2023.04-pre
+Label: 2023.04-pre
 Maintainer: bard.skaflestad@sintef.no
 MaintainerName: Bård Skaflestad
 Url: http://opm-project.org

--- a/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/opm-flowdiagnostics-applications-prereqs.cmake
@@ -5,7 +5,7 @@ set (opm-flowdiagnostics-applications_CONFIG_VAR
 # Build prerequisites
 set (opm-flowdiagnostics-applications_DEPS
   # This module requires C++11 support, including std::regex
-  "CXX11Features REQUIRED"
+  #"CXX11Features REQUIRED"
   # We need Boost.Filesystem for advanced file handling
   #   filesystem::path
   #   filesystem::directory_iterator

--- a/opm/utility/ECLCaseUtilities.cpp
+++ b/opm/utility/ECLCaseUtilities.cpp
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include <boost/filesystem.hpp>
-
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_file_kw.h>
 #include <ert/ecl/ecl_file_view.h>


### PR DESCRIPTION
The build system finds libecl (I have build  an older 2.7 version in my local folder (i.e. not installed it)

I hardcoded
```cmake
include_directories(${CMAKE_SOURCE_DIR}/../libecl/lib/include)
include_directories(${CMAKE_SOURCE_DIR}/../libecl/build/lib/include)
```
for the code to find the header files, and then the library part build fine, but when building the application it does not find the libecl functions. 

Any hint on how this should be done would be appreciated. 