### PR TITLE
Make Flowdiagnosts-Applications Independent of OPM-Common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,106 +1,333 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-###########################################################################
-#                                                                         #
-# Note: The bulk of the build system is located in the cmake/ directory.  #
-#       This file only contains the specializations for this particular   #
-#       project. Most likely you are interested in editing one of these   #
-#       files instead:                                                    #
-#                                                                         #
-#       dune.module                              Name and version number  #
-#       CMakeLists_files.cmake                   Path of source files     #
-#       cmake/Modules/${project}-prereqs.cmake   Dependencies             #
-#                                                                         #
-###########################################################################
+cmake_minimum_required(VERSION 3.27)
 
-cmake_minimum_required (VERSION 3.10)
+project(opm-flowdiagnostics-applications
+  VERSION   2024.04
+  LANGUAGES C CXX
+)
 
-# additional search modules
-option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
+enable_testing()
 
-# Mandatory call to project
-project(opm-flowdiagnostics-applications C CXX)
+set(CMAKE_CXX_STANDARD          17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS        OFF)
 
-if(SIBLING_SEARCH AND NOT opm-common_DIR)
-  # guess the sibling dir
-  get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)
-  get_filename_component(_parent_full_dir ${PROJECT_BINARY_DIR} DIRECTORY)
-  get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
-  #Try if <module-name>/<build-dir> is used
-  get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
-  if(IS_DIRECTORY ${_modules_dir}/opm-common/${_leaf_dir_name})
-    set(opm-common_DIR ${_modules_dir}/opm-common/${_leaf_dir_name})
-  else()
-    string(REPLACE ${PROJECT_NAME} opm-common _opm_common_leaf ${_leaf_dir_name})
-    if(NOT _leaf_dir_name STREQUAL _opm_common_leaf
-        AND IS_DIRECTORY ${_parent_full_dir}/${_opm_common_leaf})
-      # We are using build directories named <prefix><module-name><postfix>
-      set(opm-common_DIR ${_parent_full_dir}/${_opm_common_leaf})
-    elseif(IS_DIRECTORY ${_parent_full_dir}/opm-common)
-      # All modules are in a common build dir
-      set(opm-common_DIR "${_parent_full_dir}/opm-common}")
-    endif()
-  endif()
-endif()
-if(opm-common_DIR AND NOT IS_DIRECTORY ${opm-common_DIR})
-  message(WARNING "Value ${opm-common_DIR} passed to variable"
-    " opm-common_DIR is not a directory")
-endif()
+set(CMAKE_C_STANDARD          99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS        OFF)
 
-find_package(opm-common REQUIRED)
+set(CMAKE_DEBUG_POSTFIX "-d")
 
-include(OpmInit)
-OpmSetPolicies()
+#----------------------------------------------------------------------------
+# Prerequisites
+#----------------------------------------------------------------------------
 
-# not the same location as most of the other projects; this hook overrides
-macro (dir_hook)
-endmacro (dir_hook)
+# Disable Git here in order to not run the internal Git-based version logic
+# in LibECL's build system.  If we do not do this, we get a build failure in
+# the sub-project due to the compiler not being able to use the string literal
+#
+#    "release/ResInsight/2017"
+#
+# as an integer in lib/util/ecl_version.cpp (ecl_version_get_major_version()).
+#
+# This is a hack.
 
-# Look for the "opm-tests" repository (OPM's Regression Test data
-# repository)--HAVE_OPM_TESTS true if found.
-include (Findopm-tests)
+set(CMAKE_DISABLE_FIND_PACKAGE_Git
+  TRUE CACHE INTERNAL
+  "Disable Git-based version logic in LibECL"
+)
 
-# list of prerequisites for this particular project; this is in a
-# separate file (in cmake/Modules sub-directory) because it is shared
-# with the find module
-include (${project}-prereqs)
+include(FetchContent)
+FetchContent_Declare(LibECL
+  GIT_REPOSITORY https://github.com/equinor/resdata.git
+  GIT_TAG        539b836ac8fec7f1be9f3474419f189d54e10edf # 2.7.0
+  SYSTEM
+)
 
-# read the list of components from this file (in the project directory);
-# it should set various lists with the names of the files to include
-include (CMakeLists_files.cmake)
+FetchContent_MakeAvailable(LibECL)
 
-macro (config_hook)
-endmacro (config_hook)
+find_package(Boost
+  1.44
+  REQUIRED
+  COMPONENTS "filesystem" "system" "unit_test_framework"
+)
 
-macro (prereqs_hook)
-endmacro (prereqs_hook)
+find_package(OpmFDEngine 2024.04 REQUIRED)
 
-macro (sources_hook)
-endmacro (sources_hook)
+#----------------------------------------------------------------------------
+# Main Library
+#----------------------------------------------------------------------------
 
-macro (fortran_hook)
-endmacro (fortran_hook)
+add_library(OpmFDApplications STATIC)
 
-macro (files_hook)
-endmacro (files_hook)
+set_target_properties (OpmFDApplications PROPERTIES
+  SOVERSION 1
+  VERSION   2024.04
+)
 
-macro (tests_hook)
-endmacro (tests_hook)
+target_sources(OpmFDApplications
+  PRIVATE
+    opm/utility/ECLCaseUtilities.cpp
+    opm/utility/ECLEndPointScaling.cpp
+    opm/utility/ECLFluxCalc.cpp
+    opm/utility/ECLGraph.cpp
+    opm/utility/ECLPropertyUnitConversion.cpp
+    opm/utility/ECLPropTable.cpp
+    opm/utility/ECLPvtCommon.cpp
+    opm/utility/ECLPvtCurveCollection.cpp
+    opm/utility/ECLPvtGas.cpp
+    opm/utility/ECLPvtOil.cpp
+    opm/utility/ECLPvtWater.cpp
+    opm/utility/ECLRegionMapping.cpp
+    opm/utility/ECLResultData.cpp
+    opm/utility/ECLSaturationFunc.cpp
+    opm/utility/ECLTableInterpolation1D.cpp
+    opm/utility/ECLUnitHandling.cpp
+    opm/utility/ECLWellSolution.cpp
 
-macro (install_hook)
-endmacro (install_hook)
+  PUBLIC FILE_SET applications_public_headers
+    TYPE HEADERS
+    FILES
+      opm/utility/ECLCaseUtilities.hpp
+      opm/utility/ECLEndPointScaling.hpp
+      opm/utility/ECLFluxCalc.hpp
+      opm/utility/ECLGraph.hpp
+      opm/utility/ECLPhaseIndex.hpp
+      opm/utility/ECLPiecewiseLinearInterpolant.hpp
+      opm/utility/ECLPropertyUnitConversion.hpp
+      opm/utility/ECLPropTable.hpp
+      opm/utility/ECLPvtCommon.hpp
+      opm/utility/ECLPvtCurveCollection.hpp
+      opm/utility/ECLPvtGas.hpp
+      opm/utility/ECLPvtOil.hpp
+      opm/utility/ECLPvtWater.hpp
+      opm/utility/ECLRegionMapping.hpp
+      opm/utility/ECLResultData.hpp
+      opm/utility/ECLSaturationFunc.hpp
+      opm/utility/ECLTableInterpolation1D.hpp
+      opm/utility/ECLUnitHandling.hpp
+      opm/utility/ECLWellSolution.hpp
 
-# all setup common to the OPM library modules is done here
-include (OpmLibMain)
+      opm/utility/imported/Units.hpp
+)
 
-# LIBECL is renamed to resdata (https://github.com/equinor/resdata)
-# To build opmflowdiagnosticsapplication you will need to install an old version of libecl 
-#include_directories(${CMAKE_SOURCE_DIR}/../ecl/lib/include)
-#include_directories(${CMAKE_SOURCE_DIR}/../ecl/build/lib/include)
-#target_link_libraries(opmflowdiagnosticsapplications PUBLIC ecl)
 
-if (HAVE_OPM_TESTS)
-  # Regression test data available.  Enable additional tests.
-  include (${CMAKE_CURRENT_SOURCE_DIR}/AcceptanceTests.cmake)
-endif()
+target_link_libraries(OpmFDApplications
+  PUBLIC
+    OpmFDEngine::OpmFDEngine
+    Boost::filesystem
+    ecl
+)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(OpmFDApplicationsConfigVersion.cmake
+  VERSION ${OpmFDApplications_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
+install(TARGETS OpmFDApplications EXPORT OpmFDApplicationsTargets
+  RUNTIME           # Following options apply to runtime artifacts.
+    COMPONENT OpmFDApplications_Runtime
+  LIBRARY           # Following options apply to library artifacts.
+    COMPONENT OpmFDApplications_Runtime
+    NAMELINK_COMPONENT OpmFDApplications_Development
+  ARCHIVE           # Following options apply to archive artifacts.
+    COMPONENT OpmFDApplications_Development
+  FILE_SET applications_public_headers # Following options apply to file set HEADERS.
+    COMPONENT OpmFDApplications_Development
+)
+
+install(EXPORT OpmFDApplicationsTargets
+  FILE OpmFDApplicationsTargets.cmake
+  NAMESPACE OpmFDApplications::
+  DESTINATION share/cmake/OpmFDApplications
+)
+
+install(FILES
+    "OpmFDApplicationsConfig.cmake"
+    "${CMAKE_BINARY_DIR}/OpmFDApplicationsConfigVersion.cmake"
+  DESTINATION
+    share/cmake/OpmFDApplications
+)
+
+#----------------------------------------------------------------------------
+# Example Applications
+#----------------------------------------------------------------------------
+
+add_library(FDExampleParameterHandling STATIC)
+target_sources(FDExampleParameterHandling
+  PRIVATE
+    opm/utility/imported/ParameterGroup.cpp
+    opm/utility/imported/ParameterRequirement.cpp
+    opm/utility/imported/ParameterTools.cpp
+    opm/utility/imported/Parameter.cpp
+
+  PUBLIC FILE_SET parameter_public_headers
+    TYPE HEADERS
+    FILES
+      opm/utility/imported/ParameterGroup.hpp
+      opm/utility/imported/ParameterGroup_impl.hpp
+      opm/utility/imported/ParameterMapItem.hpp
+      opm/utility/imported/ParameterRequirement.hpp
+      opm/utility/imported/ParameterStrings.hpp
+      opm/utility/imported/ParameterTools.hpp
+      opm/utility/imported/Parameter.hpp
+)
+
+add_executable(computeTracers)
+target_sources(computeTracers
+  PRIVATE
+    examples/computeTracers.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(computeTracers
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+    Boost::filesystem
+)
+
+add_executable(dynamicCellProperty)
+target_sources(dynamicCellProperty
+  PRIVATE
+    examples/dynamicCellProperty.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(dynamicCellProperty
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+    Boost::filesystem
+)
+
+add_executable(extractFromRestart)
+target_sources(extractFromRestart
+  PRIVATE
+    examples/extractFromRestart.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(extractFromRestart
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+)
+
+add_executable(extractPropCurves)
+target_sources(extractPropCurves
+  PRIVATE
+    examples/extractPropCurves.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(extractPropCurves
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+    Boost::filesystem
+)
+
+add_executable(computeFlowStorageCurve)
+target_sources(computeFlowStorageCurve
+  PRIVATE
+    examples/computeFlowStorageCurve.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(computeFlowStorageCurve
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+)
+
+add_executable(computeLocalSolutions)
+target_sources(computeLocalSolutions
+  PRIVATE
+    examples/computeLocalSolutions.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(computeLocalSolutions
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+)
+
+add_executable(computePhaseFluxes)
+target_sources(computePhaseFluxes
+  PRIVATE
+    examples/computePhaseFluxes.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(computePhaseFluxes
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+    Boost::filesystem
+    Boost::system
+)
+
+add_executable(computeToFandTracers)
+target_sources(computeToFandTracers
+  PRIVATE
+    examples/computeToFandTracers.cpp
+    examples/exampleSetup.hpp
+)
+target_link_libraries(computeToFandTracers
+  PUBLIC
+    OpmFDApplications
+    FDExampleParameterHandling
+    OpmFDEngine::OpmFDEngine
+)
+
+#----------------------------------------------------------------------------
+# Unit Tests
+#----------------------------------------------------------------------------
+
+add_executable(test_eclendpointscaling tests/test_eclendpointscaling.cpp)
+target_link_libraries(test_eclendpointscaling
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_executable(test_eclpropertyunitconversion tests/test_eclpropertyunitconversion.cpp)
+target_link_libraries(test_eclpropertyunitconversion
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_executable(test_eclproptable tests/test_eclproptable.cpp)
+target_link_libraries(test_eclproptable
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_executable(test_eclpvtcommon tests/test_eclpvtcommon.cpp)
+target_link_libraries(test_eclpvtcommon
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_executable(test_eclregionmapping tests/test_eclregionmapping.cpp)
+target_link_libraries(test_eclregionmapping
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_executable(test_eclsimple1dinterpolant tests/test_eclsimple1dinterpolant.cpp)
+target_link_libraries(test_eclsimple1dinterpolant
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_executable(test_eclunithandling tests/test_eclunithandling.cpp)
+target_link_libraries(test_eclunithandling
+  PRIVATE OpmFDApplications Boost::unit_test_framework
+  )
+
+add_test(Test.eclendpointscaling test_eclendpointscaling)
+add_test(Test.eclproptable test_eclproptable)
+add_test(Test.eclpvtcommon test_eclpvtcommon)
+add_test(Test.eclregionmapping test_eclregionmapping)
+add_test(Test.eclsimple1dinterpolant test_eclsimple1dinterpolant)
+add_test(Test.eclunithandling test_eclunithandling)

--- a/OpmFDApplicationsConfig.cmake
+++ b/OpmFDApplicationsConfig.cmake
@@ -1,0 +1,9 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(OpmFDEngine 2024.04)
+find_dependency(Boost
+  COMPONENTS "filesystem"
+)
+find_dependency(ecl)
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpmFDApplicationsTargets.cmake")

--- a/examples/computeTracers.cpp
+++ b/examples/computeTracers.cpp
@@ -24,6 +24,8 @@
 
 #include "exampleSetup.hpp"
 
+#include <iostream>
+#include <stdexcept>
 
 int main(int argc, char** argv)
 try {

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -21,10 +21,6 @@
 #ifndef OPM_EXAMPLESETUP_HEADER_INCLUDED
 #define OPM_EXAMPLESETUP_HEADER_INCLUDED
 
-
-
-#include <opm/common/utility/parameters/ParameterGroup.hpp>
-
 #include <opm/flowdiagnostics/ConnectivityGraph.hpp>
 #include <opm/flowdiagnostics/ConnectionValues.hpp>
 #include <opm/flowdiagnostics/Toolbox.hpp>
@@ -35,6 +31,8 @@
 #include <opm/utility/ECLPhaseIndex.hpp>
 #include <opm/utility/ECLResultData.hpp>
 #include <opm/utility/ECLWellSolution.hpp>
+
+#include <opm/utility/imported/ParameterGroup.hpp>
 
 #include <exception>
 #include <initializer_list>

--- a/examples/extractFromRestart.cpp
+++ b/examples/extractFromRestart.cpp
@@ -22,10 +22,14 @@
 #include <config.h>
 #endif
 
-#include <opm/common/utility/parameters/ParameterGroup.hpp>
 #include <opm/utility/ECLResultData.hpp>
 
+#include <opm/utility/imported/ParameterGroup.hpp>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
+#include <vector>
 
 // Syntax (typical):
 //   extractFromRestart unrst=<ecl_unrst file> step=<report_number> keyword=<keyword to dump> grid_id=<grid number>
@@ -43,7 +47,7 @@ int main(int argc, char* argv[]) {
 
         if (!restart_file.selectReportStep(report_step)) {
             std::cerr << "Could not find report step " << report_step << "." << std::endl;
-            exit(-1);
+            std::exit(-1);
         }
 
         if (restart_file.haveKeywordData(keyword, grid_id)) {
@@ -66,7 +70,7 @@ int main(int argc, char* argv[]) {
         else {
             std::cerr << "Could not find the keyword " << keyword
                     << " in report step " << report_step << "." << std::endl;
-            exit(-1);
+            std::exit(-1);
         }
     }
     catch (const std::exception& e) {

--- a/opm/utility/ECLPvtOil.cpp
+++ b/opm/utility/ECLPvtOil.cpp
@@ -390,24 +390,6 @@ private:
     using TableInterpolant = ::Opm::ECLPVT::PVTx<SubtableInterpolant>;
 
     TableInterpolant interp_;
-
-    std::vector<Opm::FlowDiagnostics::Graph>
-    repackagePvtCurve(std::vector<Opm::FlowDiagnostics::Graph>&& graphs,
-                      const Opm::ECLPVT::RawCurve                curve) const
-    {
-        if (curve != Opm::ECLPVT::RawCurve::SaturatedState) {
-            // Not saturated state curve.  Nothing to do here.
-            return graphs;
-        }
-
-        // Saturated state curve for live oil.  Columns are (Rs, Po).  Swap
-        // first and second columns to normalised form: (Po, Rs).
-        for (auto& graph : graphs) {
-            graph.first.swap(graph.second);
-        }
-
-        return graphs;
-    }
 };
 
 // #####################################################################

--- a/opm/utility/imported/Parameter.cpp
+++ b/opm/utility/imported/Parameter.cpp
@@ -1,0 +1,176 @@
+//===========================================================================
+//
+// File: Parameter.cpp
+//
+// Created: Tue Jun  2 19:18:25 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <opm/utility/imported/Parameter.hpp>
+
+#include <sstream>
+#include <string>
+
+namespace Opm {
+
+std::string
+correct_parameter_tag(const ParameterMapItem& item)
+{
+    std::string tag = item.getTag();
+    if (tag != ID_xmltag__param) {
+        std::string error = "The XML tag was '" +
+                            tag + "' but should be '" +
+                            ID_xmltag__param + "'.\n";
+        return error;
+    } else {
+        return "";
+    }
+}
+
+std::string
+correct_type(const Parameter& parameter,
+             const std::string& param_type)
+{
+    std::string type = parameter.getType();
+    if (type != param_type && type != ID_param_type__cmdline) {
+        std::string error = "The data was of type '" + type +
+                            "' but should be of type '" +
+                            param_type + "'.\n";
+        return error;
+    } else {
+        return "";
+    }
+}
+
+int ParameterMapItemTrait<int>::
+convert(const ParameterMapItem& item,
+        std::string& conversion_error,
+        const bool)
+{
+    conversion_error = correct_parameter_tag(item);
+    if (!conversion_error.empty()) {
+        return 0;
+    }
+    const Parameter& parameter = dynamic_cast<const Parameter&>(item);
+    conversion_error = correct_type(parameter, ID_param_type__int);
+    if (!conversion_error.empty()) {
+        return 0;
+    }
+    std::stringstream stream;
+    stream << parameter.getValue();
+    int value;
+    stream >> value;
+    if (stream.fail()) {
+        conversion_error = "Conversion to '" +
+                           ID_param_type__int +
+                           "' failed. Data was '" +
+                           parameter.getValue() + "'.\n";
+        return 0;
+    }
+    return value;
+}
+
+double ParameterMapItemTrait<double>::
+convert(const ParameterMapItem& item,
+        std::string& conversion_error,
+        const bool)
+{
+    conversion_error = correct_parameter_tag(item);
+    if (!conversion_error.empty()) {
+        return 0.0;
+    }
+    const Parameter& parameter = dynamic_cast<const Parameter&>(item);
+    conversion_error = correct_type(parameter, ID_param_type__float);
+    if (!conversion_error.empty()) {
+        return 0.0;
+    }
+    std::stringstream stream;
+    stream << parameter.getValue();
+    double value;
+    stream >> value;
+    if (stream.fail()) {
+        conversion_error = "Conversion to '" +
+                           ID_param_type__float +
+                           "' failed. Data was '" +
+                           parameter.getValue() + "'.\n";
+        return 0.0;
+    }
+    return value;
+}
+
+bool ParameterMapItemTrait<bool>::
+convert(const ParameterMapItem& item,
+        std::string& conversion_error,
+        const bool)
+{
+    conversion_error = correct_parameter_tag(item);
+    if (!conversion_error.empty()) {
+        return false;
+    }
+    const Parameter& parameter = dynamic_cast<const Parameter&>(item);
+    conversion_error = correct_type(parameter, ID_param_type__bool);
+    if (!conversion_error.empty()) {
+        return false;
+    }
+    if (parameter.getValue() == ID_true) {
+        return true;
+    } else if (parameter.getValue() == ID_false) {
+        return false;
+    } else {
+        conversion_error = "Conversion failed. Data was '" +
+                           parameter.getValue() +
+                           "', but should be one of '" +
+                           ID_true + "' or '" + ID_false + "'.\n";
+        return false;
+    }
+}
+
+std::string ParameterMapItemTrait<std::string>::
+convert(const ParameterMapItem& item,
+        std::string& conversion_error,
+        const bool)
+{
+    conversion_error = correct_parameter_tag(item);
+    if (!conversion_error.empty()) {
+        return "";
+    }
+    const Parameter& parameter = dynamic_cast<const Parameter&>(item);
+    conversion_error = correct_type(parameter, ID_param_type__string);
+    if (!conversion_error.empty()) {
+        return "";
+    }
+    return parameter.getValue();
+}
+
+} // namespace Opm

--- a/opm/utility/imported/Parameter.hpp
+++ b/opm/utility/imported/Parameter.hpp
@@ -1,0 +1,138 @@
+//===========================================================================
+//
+// File: Parameter.hpp
+//
+// Created: Tue Jun  2 16:00:21 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETER_HEADER
+#define OPM_PARAMETER_HEADER
+
+#include <string>
+
+#include <opm/utility/imported/ParameterMapItem.hpp>
+#include <opm/utility/imported/ParameterStrings.hpp>
+
+namespace Opm {
+	/// @brief
+	/// @todo Doc me!
+	class Parameter : public ParameterMapItem {
+	public:
+	    /// @brief
+	    /// @todo Doc me!
+	    virtual ~Parameter() {}
+	    /// @brief
+	    /// @todo Doc me!
+	    /// @return
+            std::string getTag() const override { return ID_xmltag__param; }
+	    /// @brief
+	    /// @todo Doc me!
+	    /// @param
+	    Parameter(const std::string& value, const std::string& type)
+                : value_(value), type_(type) {}
+	    /// @brief
+	    /// @todo Doc me!
+	    /// @return
+	    std::string getValue() const {return value_;}
+	    /// @brief
+	    /// @todo Doc me!
+	    /// @return
+	    std::string getType() const {return type_;}
+	private:
+	    std::string value_;
+	    std::string type_;
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @param
+	/// @return
+	std::string correct_parameter_tag(const ParameterMapItem& item);
+	std::string correct_type(const Parameter& parameter,
+                                 const std::string& type);
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	template<>
+	struct ParameterMapItemTrait<int> {
+	    static int convert(const ParameterMapItem& item,
+                               std::string& conversion_error,
+                               const bool);
+
+	    static std::string type() {return ID_param_type__int;}
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	template<>
+	struct ParameterMapItemTrait<double> {
+	    static double convert(const ParameterMapItem& item,
+                                  std::string& conversion_error,
+                                  const bool);
+
+	    static std::string type() {return ID_param_type__float;}
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	template<>
+	struct ParameterMapItemTrait<bool> {
+	    static bool convert(const ParameterMapItem& item,
+                                std::string& conversion_error,
+                                const bool);
+
+	    static std::string type() {return ID_param_type__bool;}
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	template<>
+	struct ParameterMapItemTrait<std::string> {
+	    static std::string convert(const ParameterMapItem& item,
+                                       std::string& conversion_error,
+                                       const bool);
+
+	    static std::string type() {return ID_param_type__string;}
+	};
+} // namespace Opm
+#endif  // OPM_PARAMETER_HPP

--- a/opm/utility/imported/ParameterGroup.cpp
+++ b/opm/utility/imported/ParameterGroup.cpp
@@ -1,0 +1,345 @@
+//===========================================================================
+//
+// File: ParameterGroup.cpp
+//
+// Created: Tue Jun  2 19:13:17 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <opm/utility/imported/ParameterGroup.hpp>
+#include <opm/utility/imported/Parameter.hpp>
+#include <opm/utility/imported/ParameterStrings.hpp>
+#include <opm/utility/imported/ParameterTools.hpp>
+
+#include <cassert>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace Opm {
+	ParameterGroup::ParameterGroup()
+		: path_(ID_path_root), parent_(0), output_is_enabled_(true)
+	{
+	}
+
+	ParameterGroup::~ParameterGroup() {
+		if (output_is_enabled_) {
+			//TermColors::Normal();
+		}
+	}
+
+	std::string ParameterGroup::getTag() const {
+		return ID_xmltag__param_grp;
+	}
+
+
+	bool ParameterGroup::has(const std::string& name) const
+	{
+		std::pair<std::string, std::string> name_path = splitParam(name);
+		map_type::const_iterator it = map_.find(name_path.first);
+		if (it == map_.end()) {
+			return false;
+		}
+		else if (name_path.second == "") {
+			return true;
+		}
+		else {
+			ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);
+			return pg.has(name_path.second);
+		}
+	}
+
+	std::string ParameterGroup::path() const {
+		return path_;
+	}
+
+	ParameterGroup::ParameterGroup(const std::string& patharg,
+		const ParameterGroup* parent,
+		const bool enable_output)
+		: path_(patharg), parent_(parent), output_is_enabled_(enable_output)
+	{
+	}
+
+	ParameterGroup
+		ParameterGroup::getGroup(const std::string& name) const
+	{
+		return get<ParameterGroup>(name);
+	}
+
+	namespace {
+		inline std::istream&
+			samcode_readline(std::istream& is, std::string& parameter) {
+			return std::getline(is, parameter);
+		}
+	} // anonymous namespace
+
+	void ParameterGroup::readParam(const std::string& param_filename) {
+		std::ifstream is(param_filename.c_str());
+		if (!is) {
+			std::cerr << "Error: Failed to open parameter file '" << param_filename << "'.\n";
+			throw std::exception();
+		}
+		std::string parameter;
+		int lineno = 0;
+		while (samcode_readline(is, parameter)) {
+			++lineno;
+			int commentpos = parameter.find(ID_comment);
+			if (commentpos != 0) {
+				if (commentpos != int(std::string::npos)) {
+					parameter = parameter.substr(0, commentpos);
+				}
+				int fpos = parameter.find(ID_delimiter_assignment);
+				if (fpos == int(std::string::npos)) {
+					std::cerr << "WARNING: No '" << ID_delimiter_assignment << "' found on line " << lineno << ".\n";
+				}
+				int pos = fpos + ID_delimiter_assignment.size();
+				int spos = parameter.find(ID_delimiter_assignment, pos);
+				if (spos == int(std::string::npos)) {
+					std::string name = parameter.substr(0, fpos);
+					std::string value = parameter.substr(pos, spos);
+					this->insertParameter(name, value);
+				}
+				else {
+					std::cerr << "WARNING: To many '" << ID_delimiter_assignment << "' found on line " << lineno << ".\n";
+				}
+			}
+		}
+	}
+
+	void ParameterGroup::writeParam(const std::string& param_filename) const {
+		std::ofstream os(param_filename.c_str());
+		if (!os) {
+			std::cerr << "Error: Failed to open parameter file '"
+				<< param_filename << "'.\n";
+			throw std::exception();
+		}
+		this->writeParamToStream(os);
+	}
+
+	void ParameterGroup::writeParamToStream(std::ostream& os) const
+	{
+		if (map_.empty()) {
+			os << this->path() << "/" << "dummy"
+				<< ID_delimiter_assignment << "0\n";
+		}
+		for (map_type::const_iterator it = map_.begin(); it != map_.end(); ++it) {
+			if ((*it).second->getTag() == ID_xmltag__param_grp) {
+				ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);
+				pg.writeParamToStream(os);
+			}
+			else if ((*it).second->getTag() == ID_xmltag__param) {
+				os << this->path() << "/" << (*it).first << ID_delimiter_assignment
+					<< dynamic_cast<Parameter&>(*(*it).second).getValue() << "\n";
+			}
+			else {
+				os << this->path() << "/" << (*it).first << ID_delimiter_assignment
+					<< "<" << (*it).second->getTag() << ">" << "\n";
+			}
+		}
+	}
+
+	void ParameterGroup::insert(const std::string& name,
+		const std::shared_ptr<ParameterMapItem>& data)
+	{
+		std::pair<std::string, std::string> name_path = splitParam(name);
+		map_type::const_iterator it = map_.find(name_path.first);
+		assert(name_path.second == "");
+		if (it == map_.end()) {
+			map_[name] = data;
+		}
+		else {
+			if ((map_[name]->getTag() == data->getTag()) &&
+				(data->getTag() == ID_xmltag__param_grp)) {
+				ParameterGroup& alpha = dynamic_cast<ParameterGroup&>(*(*it).second);
+				ParameterGroup& beta = dynamic_cast<ParameterGroup&>(*data);
+				for (map_type::const_iterator
+					item = beta.map_.begin(); item != beta.map_.end(); ++item) {
+					alpha.insert((*item).first, (*item).second);
+				}
+			}
+			else {
+				std::cout << "WARNING : The '"
+					<< map_[name]->getTag()
+					<< "' element '"
+					<< name
+					<< "' already exist in group '"
+					<< this->path()
+					<< "'. The element will be replaced by a '"
+					<< data->getTag()
+					<< "' element.\n";
+				map_[name] = data;
+			}
+		}
+	}
+
+	void ParameterGroup::insertParameter(const std::string& name,
+		const std::string& value)
+	{
+		std::pair<std::string, std::string> name_path = splitParam(name);
+		while (name_path.first == "") {
+			name_path = splitParam(name_path.second);
+		}
+		map_type::const_iterator it = map_.find(name_path.first);
+		if (it == map_.end()) {
+			if (name_path.second == "") {
+				std::shared_ptr<ParameterMapItem> data(new Parameter(value, ID_param_type__cmdline));
+				map_[name_path.first] = data;
+			}
+			else {
+				std::shared_ptr<ParameterMapItem> data(new ParameterGroup(this->path() + ID_delimiter_path + name_path.first,
+					this,
+					output_is_enabled_));
+				ParameterGroup& child = dynamic_cast<ParameterGroup&>(*data);
+				child.insertParameter(name_path.second, value);
+				map_[name_path.first] = data;
+			}
+		}
+		else if (name_path.second == "") {
+			if ((*it).second->getTag() != ID_xmltag__param) {
+				std::cout << "WARNING : The "
+					<< map_[name_path.first]->getTag()
+					<< " element '"
+					<< name
+					<< "' already exist in group '"
+					<< this->path()
+					<< "'. It will be replaced by a "
+					<< ID_xmltag__param
+					<< " element.\n";
+			}
+			std::shared_ptr<ParameterMapItem> data(new Parameter(value, ID_param_type__cmdline));
+			map_[name_path.first] = data;
+		}
+		else {
+			ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);
+			pg.insertParameter(name_path.second, value);
+		}
+	}
+
+#if 0
+	void ParameterGroup::display() const {
+		std::cout << "Begin: " << this->path() << "\n";
+		for (map_type::const_iterator it = map_.begin(); it != map_.end(); ++it) {
+			if ((*it).second->getTag() == ID_xmltag__param_grp) {
+				ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);
+				pg.display();
+			}
+			else if ((*it).second->getTag() == ID_xmltag__param) {
+				std::cout << (*it).first
+					<< " ("
+					<< (*it).second->getTag()
+					<< ") has value "
+					<< dynamic_cast<Parameter&>(*(*it).second).getValue()
+					<< "\n";
+			}
+			else {
+				std::cout << (*it).first
+					<< " ("
+					<< (*it).second->getTag()
+					<< ")\n";
+			}
+		}
+		std::cout << "End: " << this->path() << "\n";
+	}
+#endif
+
+	bool ParameterGroup::anyUnused() const
+	{
+		if (!this->used()) {
+			return true;
+		}
+		for (map_type::const_iterator it = map_.begin(); it != map_.end(); ++it) {
+			if (it->second->getTag() == ID_xmltag__param_grp) {
+				ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(it->second));
+				if (pg.anyUnused()) {
+					return true;
+				}
+			}
+			else if (it->second->getTag() == ID_xmltag__param) {
+				if (!it->second->used()) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	void ParameterGroup::displayUsage(bool used_params) const
+	{
+		if (this->used() == used_params) {
+			std::cout << this->path() << '\n';
+		}
+		for (map_type::const_iterator it = map_.begin(); it != map_.end(); ++it) {
+			if (it->second->getTag() == ID_xmltag__param_grp) {
+				ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(it->second));
+				pg.displayUsage(used_params);
+			}
+			else if (it->second->getTag() == ID_xmltag__param) {
+				if (it->second->used() == used_params) {
+					std::cout << path() << '/' << it->first << '\n';
+				}
+			}
+		}
+		std::cout << std::flush;
+	}
+
+	void ParameterGroup::disableOutput() {
+		this->recursiveSetIsOutputEnabled(false);
+	}
+
+	void ParameterGroup::enableOutput() {
+		this->recursiveSetIsOutputEnabled(true);
+	}
+
+	bool ParameterGroup::isOutputEnabled() const {
+		return output_is_enabled_;
+	}
+
+	void ParameterGroup::recursiveSetIsOutputEnabled(bool output_is_enabled)
+	{
+		output_is_enabled_ = output_is_enabled;
+		for (map_type::const_iterator it = map_.begin(); it != map_.end(); ++it) {
+			if (it->second->getTag() == ID_xmltag__param_grp) {
+				ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(it->second));
+				pg.recursiveSetIsOutputEnabled(output_is_enabled);
+			}
+		}
+	}
+
+	const std::vector<std::string>& ParameterGroup::unhandledArguments() const
+	{
+		return unhandled_arguments_;
+	}
+
+} // namespace Opm

--- a/opm/utility/imported/ParameterGroup.hpp
+++ b/opm/utility/imported/ParameterGroup.hpp
@@ -1,0 +1,274 @@
+//===========================================================================
+//
+// File: ParameterGroup.hpp
+//
+// Created: Tue Jun  2 19:11:11 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETERGROUP_HEADER
+#define OPM_PARAMETERGROUP_HEADER
+
+#include <opm/utility/imported/ParameterMapItem.hpp>
+#include <opm/utility/imported/ParameterRequirement.hpp>
+
+#include <exception>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Opm {
+	/// ParameterGroup is a class that is used to provide run-time parameters.
+	/// The standard use of the class is to call create it with the
+	/// (int argc, char** argv) constructor (where the arguments are those
+	/// given by main). This parses the command line, where each token
+	/// either
+	/// A) specifies a parameter (by a "param=value" token).
+	/// B) specifies a param file to be read (by a "filename.param" token).
+	/// After the tokens are parsed they are stored in a tree structure
+	/// in the ParameterGroup object; it is worth mentioning that parameters
+	/// are inherited in this tree structure. Thus, if ``grid\_prefix'' is
+	/// given a value in the root node, this value will be visible in all
+	/// parts of the tree (unless the parameter is overwritten in a subtree).
+	/// Applications using this ParameterGroup objects will usually write out
+	/// a message for each node in the three that is used by the application;
+	/// this is one way to determine valid parameters.
+	///
+	/// Parameters specified as "param=value" on the command line
+	///
+	/// To specify a parameter on the command line, you must know where in the tree the
+	/// parameter resides. The syntax for specifying parameters on the command line given
+	/// an application called ``simulator'' is
+	///         simulator param1=value grp/param2=value
+	//  for parameter ``param1'' lying at the root and ``param2'' in the group
+	/// ``grp''. If the same parameters are specified multiple times on the command
+	/// line, only the last will be used. Thus an application named ``simulator'' run with
+	/// the following command
+	///         simulator param=value1 param=value2
+	/// will use value2 as the value of ``param''.
+	///
+	/// param files
+	///
+	/// A param file consists of multiple lienes, where each line consists of "param=value".
+	/// This syntax is identical to the one for parameters specified on the command line.
+	class ParameterGroup : public ParameterMapItem {
+	public:
+	    struct NotFoundException          : public std::exception {};
+	    struct WrongTypeException         : public std::exception {};
+	    struct ConversionFailedException  : public std::exception {};
+
+	    template<typename T>
+	    struct RequirementFailedException : public std::exception {};
+
+	    ParameterGroup();
+	    ParameterGroup(const std::string& path, const ParameterGroup* parent,
+                           const bool enable_output);
+
+	    // From ParameterMapItem
+	    virtual ~ParameterGroup();
+            std::string getTag() const override;
+
+	    /// \brief A constructor typically used to initialize a
+	    ///        ParameterGroup from command-line arguments.
+	    ///
+	    /// It is required that argv[0] is the program name, while if
+	    /// 0 < i < argc, then argv[i] is either
+	    /// the name of a parameter file or parametername=value.
+	    ///
+	    /// \param argc is the number of command-line arguments,
+	    ///        including the name of the executable.
+	    /// \param argv is an array of char*, each of which is a
+	    ///        command line argument.
+	    /// \param verify_syntax  If true (default), then it is an error to
+	    ///        pass arguments that cannot be handled by the ParameterGroup,
+	    ///        or an empty argument list. If false, such arguments are stored
+	    ///        and can be retrieved later with unhandledArguments().
+            /// \param enable_output Whether to enable output or not.
+            template <typename StringArray>
+	    ParameterGroup(int argc, StringArray argv, const bool verify_syntax = true,
+                           const bool enabled_output=true);
+
+	    /// \brief This method checks if there is something with name
+	    ///        \p name in the parameter gropup.
+	    ///
+	    /// \param name is the name of the parameter.
+	    /// \return true if \p name is the name of something in the parameter
+	    ///         group, false otherwise.
+	    bool has(const std::string& name) const;
+
+	    /// \brief This method is used to read a parameter from the
+	    ///        parameter group.
+	    ///
+	    /// NOTE:  If the reading of the parameter fails, then this method
+	    ///        throws an appropriate exception.
+	    ///
+	    /// \param name is the name of the parameter in question.
+	    /// \return The value associated with then name in this parameter
+	    ///         group.
+	    template<typename T>
+	    T get(const std::string& name) const;
+
+	    template<typename T, class Requirement>
+	    T get(const std::string& name, const Requirement&) const;
+
+	    /// \brief This method is used to read a parameter from the
+	    ///        parameter group.
+	    ///
+	    /// NOTE:  If the reading of the parameter fails, then either
+	    ///        a) this method returns \p default_value if there
+	    ///           was no parameter with name \p name in
+	    ///           the parameter group
+	    ///        or
+	    ///        b) this method throws an appropriate exception.
+	    ///
+	    /// \param name is the name of the parameter in question.
+	    /// \param default_value the default value of the parameter in
+	    ///        question.
+	    /// \return The value associated with this name in this parameter
+	    ///         group.
+	    template<typename T>
+	    T getDefault(const std::string& name,
+			 const T& default_value) const;
+
+	    template<typename T, class Requirement>
+	    T getDefault(const std::string& name,
+			 const T& default_value,
+			 const Requirement& r) const;
+
+	    /// \brief This method returns the parameter group given by name,
+	    ///        i.e. it is an alias of get<ParameterGroup>().
+	    ///
+	    /// \param name is the name of the parameter group sought.
+	    /// \return the parameter group sought.
+	    ParameterGroup getGroup(const std::string& name) const;
+
+	    /// \brief Disables the output from get, getDefault and getGroup.
+	    ///        By default, such output is enabled.
+	    void disableOutput();
+
+	    /// \brief Enables the output from get, getDefault and getGroup.
+	    ///        By default, such output is enabled.
+	    void enableOutput();
+
+	    /// \brief Returs true if and only if output from get, getDefault
+	    ///        and getGroup is enabled.
+	    ///
+	    /// \return true if and only if output from get, getDefault and
+	    ///         getGroup is enabled.
+	    bool isOutputEnabled() const;
+
+	    /// \brief Reads the contents of the param file specified by
+	    ///        param_filename into this ParameterGroup.
+	    ///
+	    /// NOTE: A param file contains lines on the form 'a/b/c=d'.
+	    //        The '/' separates ParameterGroups and Parameters
+	    ///       (e.g. c is a Parameter in the ParameterGroup b,
+	    ///       and b is a ParameterGroup in the ParameterGroup a)
+	    ///       while '=' separates the name from the value (e.g. the
+	    ///       value of the parameter c above will be d).
+	    /// NOTE: A param file does not store any type information about
+	    ///       its values.
+	    ///
+	    /// \param param_filename is the name of a param file.
+	    void readParam(const std::string& param_filename);
+
+	    /// \brief Writes this ParameterGroup into a param file
+	    ///        specified by param_filename.
+	    ///
+	    /// \param param_filename is the name of a param file.
+	    void writeParam(const std::string& param_filename) const;
+
+	    /// \brief Writes this ParameterGroup to a stream.
+	    ///
+	    /// \param stream is the stream to write to.
+	    void writeParamToStream(std::ostream& stream) const;
+
+
+	    /// vki param interface - deprecated
+	    template<typename T>
+	    void get(const char* name, T& value, const T& default_value) const {
+		value = this->getDefault<T>(name, default_value);
+	    }
+
+	    /// vki param interface - deprecated
+	    template<typename T>
+	    void get(const char* name, T& value) const {
+		value = this->get<T>(name);
+	    }
+
+            /// \brief Return true if any parameters are unused.
+            bool anyUnused() const;
+
+	    /// \brief Shows which parameters which are used or unused.
+	    void displayUsage(bool used_params = false) const;
+
+            /// \brief Returns the path of the parameter group.
+	    std::string path() const;
+
+            /// Insert a new item into the group.
+	    void insert(const std::string& name,
+                        const std::shared_ptr<ParameterMapItem>& data);
+
+            /// Insert a new parameter item into the group.
+	    void insertParameter(const std::string& name, const std::string& value);
+
+            /// Unhandled arguments from command line parsing.
+            const std::vector<std::string>& unhandledArguments() const;
+
+	private:
+	    typedef std::shared_ptr<ParameterMapItem> data_type;
+	    typedef std::pair<std::string, data_type> pair_type;
+	    typedef std::map<std::string, data_type> map_type;
+
+	    std::string path_;
+	    map_type map_;
+	    const ParameterGroup* parent_;
+	    bool output_is_enabled_;
+	    std::vector<std::string> unhandled_arguments_;
+
+	    template<typename T, class Requirement>
+	    T translate(const pair_type& data, const Requirement& chk) const;
+            template <typename StringArray>
+	    void parseCommandLineArguments(int argc, StringArray argv, bool verify_syntax);
+	    void recursiveSetIsOutputEnabled(bool output_is_enabled);
+
+	    // helper routines to do textual I/O
+	    template <typename T>
+	    static std::string to_string(const T& val);
+	    static std::pair<std::string, std::string>
+	    filename_split(const std::string& filename);
+	};
+} // namespace Opm
+
+#include <opm/utility/imported/ParameterGroup_impl.hpp>
+
+#endif // OPM_PARAMETERGROUP_HEADER

--- a/opm/utility/imported/ParameterGroup_impl.hpp
+++ b/opm/utility/imported/ParameterGroup_impl.hpp
@@ -1,0 +1,329 @@
+//===========================================================================
+//
+// File: ParameterGroup_impl.hpp
+//
+// Created: Tue Jun  2 19:06:46 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETERGROUP_IMPL_HEADER
+#define OPM_PARAMETERGROUP_IMPL_HEADER
+
+#include <opm/utility/imported/ParameterGroup.hpp>
+#include <opm/utility/imported/ParameterStrings.hpp>
+#include <opm/utility/imported/ParameterTools.hpp>
+#include <opm/utility/imported/Parameter.hpp>
+
+#if 0
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#endif
+
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace Opm {
+	template<>
+	struct ParameterMapItemTrait<ParameterGroup> {
+		static ParameterGroup
+			convert(const ParameterMapItem& item,
+				std::string& conversion_error,
+				bool enable_output)
+		{
+			std::string tag = item.getTag();
+			if (tag != ID_xmltag__param_grp) {
+				conversion_error = "The XML tag was '" + tag +
+					"' but should be '" +
+					ID_xmltag__param_grp + "'.\n";
+				return ParameterGroup("", 0, enable_output);
+			}
+			conversion_error = "";
+			const ParameterGroup& pg = dynamic_cast<const ParameterGroup&>(item);
+			return pg;
+		}
+		static std::string type() { return "ParameterGroup"; }
+	};
+
+	template <typename T>
+	inline std::string
+		ParameterGroup::to_string(const T& val)
+	{
+		return std::to_string(val);
+	}
+
+	template <>
+	inline std::string
+		ParameterGroup::to_string<std::string>(const std::string& val)
+	{
+		return val;
+	}
+
+	template <>
+	inline std::string
+		ParameterGroup::to_string(const bool& b) {
+		if (b) {
+			return ID_true;
+		}
+		else {
+			return ID_false;
+		}
+	}
+
+	template <>
+	inline std::string
+		ParameterGroup::to_string(const ParameterGroup&)
+	{
+		return std::string("<parameter group>");
+	}
+
+	inline std::pair<std::string, std::string>
+		ParameterGroup::filename_split(const std::string& filename)
+	{
+		int fpos = filename.rfind('.');
+		std::string name = filename.substr(0, fpos);
+		std::string type = filename.substr(fpos + 1);
+		return std::make_pair(name, type);
+	}
+
+	template <typename StringArray>
+	ParameterGroup::ParameterGroup(int argc, StringArray argv, bool verify_syntax,
+		const bool enable_output)
+		: path_(ID_path_root), parent_(0), output_is_enabled_(enable_output)
+	{
+		if (verify_syntax && (argc < 2)) {
+			std::cerr << "Usage: " << argv[0] << " "
+				<< "[paramfilename1.param] "
+				<< "[paramfilename2.param] "
+				<< "[overridden_arg1=value1] "
+				<< "[overridden_arg2=value2] "
+				<< "[...]" << std::endl;
+			std::exit(EXIT_FAILURE);
+		}
+		this->parseCommandLineArguments(argc, argv, verify_syntax);
+	}
+
+	template <typename StringArray>
+	void ParameterGroup::parseCommandLineArguments(int argc, StringArray argv, bool verify_syntax)
+	{
+		std::vector<std::string> files;
+		std::vector<std::pair<std::string, std::string> > assignments;
+		for (int i = 1; i < argc; ++i) {
+			std::string arg(argv[i]);
+			int fpos = arg.find(ID_delimiter_assignment);
+			if (fpos == int(std::string::npos)) {
+				std::string filename = arg.substr(0, fpos);
+				files.push_back(filename);
+				continue;
+			}
+			int pos = fpos + ID_delimiter_assignment.size();
+			int spos = arg.find(ID_delimiter_assignment, pos);
+			if (spos == int(std::string::npos)) {
+				std::string name = arg.substr(0, fpos);
+				std::string value = arg.substr(pos, spos);
+				assignments.push_back(std::make_pair(name, value));
+				continue;
+			}
+			std::cerr << "Too many assignments  (' " <<ID_delimiter_assignment <<
+				 "') detected in argument " << to_string(i);
+		}
+		for (int i = 0; i < int(files.size()); ++i) {
+			std::pair<std::string, std::string> file_type = filename_split(files[i]);
+			if (file_type.second == "param") {
+				this->readParam(files[i]);
+			}
+			else {
+				if (verify_syntax) {
+					std::cerr << "ERROR: Input '" << files[i] << "' is not a valid name for a parameter file.\n";
+					std::cerr << "       Valid filename extensions are 'param'.\n";
+					throw std::runtime_error{ "ParameterGroup cannot handle argument: " + files[i] };
+				}
+				else {
+					unhandled_arguments_.push_back(files[i]);
+				}
+			}
+		}
+		for (int i = 0; i < int(assignments.size()); ++i) {
+			this->insertParameter(assignments[i].first, assignments[i].second);
+		}
+	}
+
+
+	template<typename T>
+	inline T ParameterGroup::get(const std::string& name) const
+	{
+		return this->get<T>(name, ParameterRequirementNone());
+	}
+
+	template<typename T, class Requirement>
+	inline T ParameterGroup::get(const std::string& name,
+		const Requirement& r) const
+	{
+		setUsed();
+		std::pair<std::string, std::string> name_path = splitParam(name);
+		map_type::const_iterator it = map_.find(name_path.first);
+		if (it == map_.end()) {
+			if (parent_ != 0) {
+				// If we have a parent, ask it instead.
+				if (output_is_enabled_) {
+					std::cerr << name << " not found at " << path() << ID_delimiter_path << ", asking parent.";
+				}
+				return parent_->get<T>(name, r);
+			}
+			else {
+				// We are at the top, name has not been found.
+				std::cerr << "ERROR: The group '"
+					<< this->path()
+					<< "' does not contain an element named '"
+					<< name
+					<< "'.\n";
+				throw NotFoundException();
+			}
+		}
+		if (name_path.second == "") {
+			T val = this->translate<T>(*it, r);
+			it->second->setUsed();
+			if (output_is_enabled_) {
+				std::cerr << name << " found at " << path() << ID_delimiter_path << ", value is " << to_string(val);
+			}
+			return val;
+		}
+		else {
+			ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);
+			pg.setUsed();
+			return pg.get<T>(name_path.second, r);
+		}
+	}
+
+	template<typename T>
+	inline T ParameterGroup::getDefault(const std::string& name,
+		const T& default_value) const
+	{
+		return this->getDefault<T>(name, default_value, ParameterRequirementNone());
+	}
+
+	template<typename T, class Requirement>
+	inline T ParameterGroup::getDefault(const std::string& name,
+		const T& default_value,
+		const Requirement& r) const
+	{
+		setUsed();
+		std::pair<std::string, std::string> name_path = splitParam(name);
+		map_type::const_iterator it = map_.find(name_path.first);
+		if (it == map_.end()) {
+			if (parent_ != 0) {
+				// If we have a parent, ask it instead.
+				if (output_is_enabled_) {
+					std::cerr << name << " not found at " << path() << ID_delimiter_path << ", asking parent.";
+				}
+				return parent_->getDefault<T>(name, default_value, r);
+			}
+			else {
+				// We check the requirement for the default value
+				std::string requirement_result = r(default_value);
+				if (requirement_result != "") {
+					std::cerr << "ERROR: The default value for the "
+						<< " element named '"
+						<< name
+						<< "' in the group '"
+						<< this->path()
+						<< "' failed to meet a requirenemt.\n";
+					std::cerr << "The requirement enforcer returned the following message:\n"
+						<< requirement_result
+						<< "\n";
+					throw RequirementFailedException<Requirement>();
+				}
+			}
+			if (output_is_enabled_) {
+				std::cerr << name << " not found. Using default value '" << to_string(default_value) << "'.";
+			}
+			return default_value;
+		}
+		if (name_path.second == "") {
+			T val = this->translate<T>(*it, r);
+			it->second->setUsed();
+			if (output_is_enabled_) {
+				std::cerr << name << " found at " << path() << ID_delimiter_path
+					<< ", value is '"<< to_string(val) << "'.";
+			}
+			return val;
+		}
+		else {
+			ParameterGroup& pg = dynamic_cast<ParameterGroup&>(*(*it).second);
+			pg.setUsed();
+			return pg.getDefault<T>(name_path.second, default_value, r);
+		}
+	}
+
+	template<typename T, class Requirement>
+	inline T ParameterGroup::translate(const pair_type& named_data,
+		const Requirement& chk) const
+	{
+		const std::string& name = named_data.first;
+		const data_type data = named_data.second;
+		std::string conversion_error;
+		T value = ParameterMapItemTrait<T>::convert(*data, conversion_error,
+			output_is_enabled_);
+		if (conversion_error != "") {
+			std::cerr << "ERROR: Failed to convert the element named '"
+				<< name
+				<< "' in the group '"
+				<< this->path()
+				<< "' to the type '"
+				<< ParameterMapItemTrait<T>::type()
+				<< "'.\n";
+			std::cerr << "The conversion routine returned the following message:\n"
+				<< conversion_error
+				<< "\n";
+			throw WrongTypeException();
+		}
+		std::string requirement_result = chk(value);
+		if (requirement_result != "") {
+			std::cerr << "ERROR: The element named '"
+				<< name
+				<< "' in the group '"
+				<< this->path()
+				<< "' of type '"
+				<< ParameterMapItemTrait<T>::type()
+				<< "' failed to meet a requirenemt.\n";
+			std::cerr << "The requirement enforcer returned the following message:\n"
+				<< requirement_result
+				<< "\n";
+			throw RequirementFailedException<Requirement>();
+		}
+		return value;
+	}
+} // namespace Opm
+
+#endif // OPM_PARAMETERGROUP_IMPL_HEADER

--- a/opm/utility/imported/ParameterMapItem.hpp
+++ b/opm/utility/imported/ParameterMapItem.hpp
@@ -1,0 +1,71 @@
+//===========================================================================
+//
+// File: ParameterMapItem.hpp
+//
+// Created: Tue Jun  2 19:05:54 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETERMAPITEM_HEADER
+#define OPM_PARAMETERMAPITEM_HEADER
+
+#include <string>
+
+namespace Opm {
+	/// The parameter handlig system is structured as a tree,
+	/// where each node inhertis from ParameterMapItem.
+	///
+	/// The abstract virtual function getTag() is  used to determine
+	/// which derived class the node actually is.
+	struct ParameterMapItem {
+	    /// Default constructor
+	    ParameterMapItem() : used_(false) {}
+
+	    /// Destructor
+	    virtual ~ParameterMapItem() {}
+
+	    /// \brief This function returns a string describing
+	    ///        the ParameterMapItem.
+	    virtual std::string getTag() const = 0;
+	    void setUsed() const { used_ = true; }
+	    bool used() const { return used_; }
+	private:
+	    mutable bool used_;
+	};
+
+	template<typename T>
+	struct ParameterMapItemTrait {
+	    static T convert(const ParameterMapItem&,
+                             std::string& conversion_error);
+	    static std::string type();
+	};
+} // namespace Opm
+
+#endif // OPM_PARAMETERMAPITEM_HEADER

--- a/opm/utility/imported/ParameterRequirement.cpp
+++ b/opm/utility/imported/ParameterRequirement.cpp
@@ -1,0 +1,90 @@
+//===========================================================================
+//
+// File: ParameterRequirement.cpp
+//
+// Created: Tue Jun  2 19:05:02 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/utility/imported/ParameterRequirement.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <sstream>
+
+namespace Opm {
+
+std::string ParameterRequirementProbability::
+operator()(double x) const
+{
+    if ( (x < 0.0) || (x > 1.0) ) {
+        std::ostringstream stream;
+        stream << "The value '" << x
+               << "' is not in the interval [0, 1].";
+        return stream.str();
+    } else {
+        return "";
+    }
+}
+
+ParameterRequirementMemberOf::
+ParameterRequirementMemberOf(const std::vector<std::string>& elements)
+    : elements_(elements)
+{
+    assert(elements_.size() > 0);
+}
+
+std::string ParameterRequirementMemberOf::
+operator()(const std::string& x) const
+{
+    if (std::find(elements_.begin(), elements_.end(), x) == elements_.end()) {
+        if (elements_.size() == 1) {
+            return "The string '" + x + "' is not '" + elements_[0] + "'.";
+        }
+        std::ostringstream stream;
+        stream << "The string '" << x << "' is not among '";
+        for (int i = 0; i < int(elements_.size()) - 2; ++i) {
+            stream << elements_[i] << "', '";
+        }
+        stream << elements_[elements_.size() - 2]
+               << "' and '"
+               << elements_[elements_.size() - 1]
+               << "'.";
+        return stream.str();
+    } else {
+        return "";
+    }
+}
+
+} // namespace Opm

--- a/opm/utility/imported/ParameterRequirement.hpp
+++ b/opm/utility/imported/ParameterRequirement.hpp
@@ -1,0 +1,205 @@
+//===========================================================================
+//
+// File: ParameterRequirement.hpp
+//
+// Created: Tue Jun  2 19:05:02 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETERREQUIREMENT_HEADER
+#define OPM_PARAMETERREQUIREMENT_HEADER
+
+#include <string>
+#include <vector>
+
+namespace Opm {
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	struct ParameterRequirementNone {
+	    template<typename T>
+	    std::string operator()(const T&) const {
+		return "";
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @param
+	/// @return
+        struct ParameterRequirementProbability {
+            std::string operator()(double x) const;
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	struct ParameterRequirementPositive {
+	    template<typename T>
+	    std::string operator()(const T& x) const {
+		if (x > 0) {
+		    return "";
+		} else {
+                    return "The value '" + std::to_string(x) +
+                           "' is not positive.";
+		}
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	struct ParameterRequirementNegative {
+	    template<typename T>
+	    std::string operator()(const T& x) const {
+		if (x < 0) {
+		    return "";
+		} else {
+                    return "The value '" + std::to_string(x) +
+                           "' is not negative.";
+		}
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	struct ParameterRequirementNonPositive {
+	    template<typename T>
+	    std::string operator()(const T& x) const {
+		if (x > 0) {
+                    return "The value '" + std::to_string(x) +
+                           "' is positive.";
+		} else {
+		    return "";
+		}
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	struct ParameterRequirementNonNegative {
+	    template<typename T>
+	    std::string operator()(const T& x) const {
+		if (x < 0) {
+                    return "The value '" + std::to_string(x) +
+                           "' is negative.";
+		} else {
+		    return "";
+		}
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	struct ParameterRequirementNonZero {
+	    template<typename T>
+	    std::string operator()(const T& x) const {
+		if (x != 0) {
+		    return "";
+		} else {
+		    return "The value was zero.";
+		}
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @param
+	/// @return
+	struct ParameterRequirementNonEmpty {
+	    std::string operator()(const std::string& x) const {
+		if (x != "") {
+		    return "The string was empty.";
+		} else {
+		    return "";
+		}
+	    }
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @tparam
+	/// @param
+	/// @return
+	template<class Requirement1, class Requirement2>
+	struct ParameterRequirementAnd {
+	    ParameterRequirementAnd(const Requirement1& r1, const Requirement2& r2) :
+	    r1_(r1), r2_(r2) { }
+
+	    template<typename T>
+	    std::string operator()(const T& t) const {
+		std::string e1 = r1_(t);
+		std::string e2 = r2_(t);
+		if (e1 == "") {
+		    return e2;
+		} else if (e2 == "") {
+		    return e1;
+		} else {
+		    return e1 + " AND " + e2;
+		}
+	    }
+	private:
+	    const Requirement1 r1_;
+	    const Requirement2 r2_;
+	};
+
+	/// @brief
+	/// @todo Doc me!
+	/// @param
+        struct ParameterRequirementMemberOf {
+            explicit ParameterRequirementMemberOf(const std::vector<std::string>& elements);
+
+            /// @brief
+            /// @todo Doc me!
+            /// @param
+            /// @return
+            std::string operator()(const std::string& x) const;
+
+	private:
+	    const std::vector<std::string> elements_;
+	};
+} // namespace Opm
+
+#endif // OPM_PARAMETERREQUIREMENT_HEADER

--- a/opm/utility/imported/ParameterStrings.hpp
+++ b/opm/utility/imported/ParameterStrings.hpp
@@ -1,0 +1,63 @@
+//===========================================================================
+//
+// File: ParameterStrings.hpp
+//
+// Created: Tue Jun  2 19:04:15 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETERSTRINGS_HEADER
+#define OPM_PARAMETERSTRINGS_HEADER
+
+#include <string>
+
+namespace Opm {
+	const std::string ID_true                   = "true";
+	const std::string ID_false                  = "false";
+
+	const std::string ID_xmltag__param_grp      = "ParameterGroup";
+	const std::string ID_xmltag__param          = "Parameter";
+
+	const std::string ID_param_type__bool       = "bool";
+	const std::string ID_param_type__int        = "int";
+	const std::string ID_param_type__float      = "double";
+	const std::string ID_param_type__string     = "string";
+	const std::string ID_param_type__file       = "file";
+	const std::string ID_param_type__cmdline    = "cmdline";
+
+	//
+
+	const std::string ID_path_root            = "";
+	const std::string ID_delimiter_path       = "/";
+	const std::string ID_comment              = "//";
+	const std::string ID_delimiter_assignment = "=";
+} // namespace Opm
+
+#endif // OPM_PARAMETERSTRINGS_HEADER

--- a/opm/utility/imported/ParameterTools.cpp
+++ b/opm/utility/imported/ParameterTools.cpp
@@ -1,0 +1,57 @@
+//===========================================================================
+//
+// File: ParameterTools.cpp
+//
+// Created: Tue Jun  2 19:03:09 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <opm/utility/imported/ParameterTools.hpp>
+#include <opm/utility/imported/ParameterStrings.hpp>
+
+#include <utility>
+#include <string>
+
+namespace Opm {
+	std::pair<std::string, std::string> splitParam(const std::string& name)
+        {
+	    int pos = name.find(ID_delimiter_path);
+	    if (pos == int(std::string::npos)) {
+		return std::make_pair(name, "");
+	    } else {
+		return std::make_pair(name.substr(0, pos),
+                                      name.substr(pos + ID_delimiter_path.size()));
+	    }
+	}
+} // namespace Opm

--- a/opm/utility/imported/ParameterTools.hpp
+++ b/opm/utility/imported/ParameterTools.hpp
@@ -1,0 +1,46 @@
+//===========================================================================
+//
+// File: ParameterTools.hpp
+//
+// Created: Tue Jun  2 19:02:19 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARAMETERTOOLS_HEADER
+#define OPM_PARAMETERTOOLS_HEADER
+
+#include <string>
+#include <utility>
+
+namespace Opm {
+	std::pair<std::string, std::string> splitParam(const std::string& name);
+} // namespace Opm
+
+#endif // OPM_PARAMETERTOOLS_HEADER

--- a/tests/test_eclendpointscaling.cpp
+++ b/tests/test_eclendpointscaling.cpp
@@ -25,9 +25,7 @@
 
 #define BOOST_TEST_MODULE TEST_ECLENDPOINTSCALING
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/utility/ECLEndPointScaling.hpp>
 

--- a/tests/test_eclproptable.cpp
+++ b/tests/test_eclproptable.cpp
@@ -25,9 +25,7 @@
 
 #define BOOST_TEST_MODULE TEST_ECLPROPTABLE
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/utility/ECLPropTable.hpp>
 

--- a/tests/test_eclpvtcommon.cpp
+++ b/tests/test_eclpvtcommon.cpp
@@ -26,9 +26,7 @@
 
 #define BOOST_TEST_MODULE TEST_ECLPVTCOMMON_UNITCONV
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/utility/ECLPvtCommon.hpp>
 

--- a/tests/test_eclregionmapping.cpp
+++ b/tests/test_eclregionmapping.cpp
@@ -26,9 +26,7 @@
 
 #define BOOST_TEST_MODULE TEST_REGION_MAPPING
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/utility/ECLRegionMapping.hpp>
 

--- a/tests/test_eclunithandling.cpp
+++ b/tests/test_eclunithandling.cpp
@@ -26,9 +26,7 @@
 
 #define BOOST_TEST_MODULE TEST_UNIT_HANDLING
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/utility/ECLUnitHandling.hpp>
 


### PR DESCRIPTION
In particular, switch to using a self-hosted build system which  depends only on CMake and which uses Boost.Test as its unit testing framework.  Import a copy of the Parameter* library from  OPM-Common and bring in LibECL, version 2.7.0, through the CMake  module [FetchContent](https://cmake.org/cmake/help/v3.27/module/FetchContent.html).