### PR TITLE
Decouple Function Curves From Grid Information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,19 +192,19 @@ target_link_libraries(computeTracers
     Boost::filesystem
 )
 
-add_executable(dynamicCellProperty)
-target_sources(dynamicCellProperty
-  PRIVATE
-    examples/dynamicCellProperty.cpp
-    examples/exampleSetup.hpp
-)
-target_link_libraries(dynamicCellProperty
-  PUBLIC
-    OpmFDApplications
-    FDExampleParameterHandling
-    OpmFDEngine::OpmFDEngine
-    Boost::filesystem
-)
+#add_executable(dynamicCellProperty)
+#target_sources(dynamicCellProperty
+#  PRIVATE
+#    examples/dynamicCellProperty.cpp
+#    examples/exampleSetup.hpp
+#)
+#target_link_libraries(dynamicCellProperty
+#  PUBLIC
+#    OpmFDApplications
+#    FDExampleParameterHandling
+#    OpmFDEngine::OpmFDEngine
+#    Boost::filesystem
+#)
 
 add_executable(extractFromRestart)
 target_sources(extractFromRestart
@@ -230,6 +230,11 @@ target_link_libraries(extractPropCurves
     FDExampleParameterHandling
     OpmFDEngine::OpmFDEngine
     Boost::filesystem
+)
+
+install(TARGETS extractPropCurves
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 add_executable(computeFlowStorageCurve)

--- a/examples/computePhaseFluxes.cpp
+++ b/examples/computePhaseFluxes.cpp
@@ -150,6 +150,7 @@ namespace {
     }
 
     void computePhaseFluxes(const Opm::ECLGraph&                    G,
+                            const Opm::ECLInitFileData&             init,
                             const Opm::ECLCaseUtilities::ResultSet& rset,
                             const Opm::ECLFluxCalc&                 fcalc,
                             const int                               step,
@@ -166,9 +167,9 @@ namespace {
             const auto pname = phaseName(phase);
             auto       pflux = std::vector<double>{};
 
-            timeIt(std::cout, [&fcalc, &rstrt, phase, &pname, &pflux]()
+            timeIt(std::cout, [&fcalc, &rstrt, &init, phase, &pname, &pflux]()
             {
-                pflux = fcalc.flux(*rstrt, phase);
+                pflux = fcalc.flux(*rstrt, init, phase);
 
                 std::cout << "    - " << std::right
                           << std::setw(5) << std::setfill(' ')
@@ -208,13 +209,13 @@ try {
     auto rstrt = std::unique_ptr<Opm::ECLRestartData>{};
 
     for (const auto& step : steps) {
-        timeIt(std::cout, [&rset, &graph, &rstrt, &fcalc, ndgt, step]()
+        timeIt(std::cout, [&rset, &graph, &init, &rstrt, &fcalc, ndgt, step]()
         {
             std::cout << "Phase Fluxes for Report Step "
                       << std::setw(ndgt) << std::setfill('0')
                       << step << std::endl;
 
-            computePhaseFluxes(graph, rset, fcalc, step, ndgt, rstrt);
+            computePhaseFluxes(graph, init, rset, fcalc, step, ndgt, rstrt);
 
             std::cout << "  - Step Time: ";
         });

--- a/examples/dynamicCellProperty.cpp
+++ b/examples/dynamicCellProperty.cpp
@@ -53,9 +53,9 @@ struct CellState
 {
     CellState(const Opm::ECLGraph&                    G,
               const Opm::ECLCaseUtilities::ResultSet& rset,
-              const int                               cellID_);
+              const int                               pvtnum_);
 
-    int                 cellID;
+    int                 pvtnum;
     std::vector<double> time;
     std::vector<double> Po;
     std::vector<double> Rs;
@@ -64,8 +64,8 @@ struct CellState
 
 CellState::CellState(const Opm::ECLGraph&                    G,
                      const Opm::ECLCaseUtilities::ResultSet& rset,
-                     const int                               cellID_)
-    : cellID(cellID_)
+                     const int                               pvtnum_)
+    : pvtnum(pvtnum_)
 {
     const auto rsteps = rset.reportStepIDs();
 
@@ -87,7 +87,7 @@ CellState::CellState(const Opm::ECLGraph&                    G,
             const auto& press =
                 G.rawLinearisedCellData<double>(*rstrt, "PRESSURE");
 
-            this->Po.push_back(press[cellID]);
+            this->Po.push_back(press[this->pvtnum]);
         }
 
         {
@@ -244,7 +244,7 @@ try {
     const auto init  = Opm::ECLInitFileData(rset.initFile());
     const auto graph = Opm::ECLGraph::load(rset.gridFile(), init);
 
-    auto pvtCC = Opm::ECLPVT::ECLPvtCurveCollection(graph, init);
+    auto pvtCC = Opm::ECLPVT::ECLPvtCurveCollection(init);
     if (prm.has("unit")) {
         pvtCC.setOutputUnits(makeUnits(prm.get<std::string>("unit"), init));
     }

--- a/examples/exampleSetup.hpp
+++ b/examples/exampleSetup.hpp
@@ -90,10 +90,10 @@ namespace example {
 
             Opm::ECLFluxCalc calc(G, init, grav, useEPS);
 
-            return extractFluxField(G, [&calc, &rstrt]
+            return extractFluxField(G, [&calc, &init, &rstrt]
                 (const Opm::ECLPhaseIndex p)
             {
-                return calc.flux(rstrt, p);
+                return calc.flux(rstrt, init, p);
             });
         }
 

--- a/examples/extractPropCurves.cpp
+++ b/examples/extractPropCurves.cpp
@@ -54,13 +54,13 @@ namespace {
             const auto& x = graph.first;
             const auto& y = graph.second;
 
-            os << name << '{' << k << "} = extendTab([\n";
+            //os << name << '{' << k << "} = extendTab([\n";
 
             for (auto n = x.size(), i = 0*n; i < n; ++i) {
                 os << x[i] << ' ' << y[i] << '\n';
             }
 
-            os << "]);\n\n";
+            //os << "]);\n\n";
             k += 1;
         }
 
@@ -100,6 +100,7 @@ namespace {
     // Relative permeability
 
     void krg(const Opm::ECLSaturationFunc&                 sfunc,
+             const Opm::ECLInitFileData&                   init,
              const int                                     activeCell,
              const Opm::ECLSaturationFunc::SatFuncScaling& scaling)
     {
@@ -115,13 +116,18 @@ namespace {
             Opm::ECLPhaseIndex::Vapour
         });
 
-        const auto graph =
-            sfunc.getSatFuncCurve(func, activeCell, scaling);
+        const auto gridID = std::string{}; // Empty => global grid.
+
+        const auto satnum = init.keywordData<int>("SATNUM", gridID)[activeCell];
+
+        const auto graph = sfunc
+            .getSatFuncCurve(func, init, gridID, activeCell, satnum, scaling);
 
         printGraph(std::cout, "crv.krg", graph);
     }
 
     void krog(const Opm::ECLSaturationFunc&                 sfunc,
+              const Opm::ECLInitFileData&                   init,
               const int                                     activeCell,
               const Opm::ECLSaturationFunc::SatFuncScaling& scaling)
     {
@@ -137,13 +143,18 @@ namespace {
             Opm::ECLPhaseIndex::Liquid
         });
 
-        const auto graph =
-            sfunc.getSatFuncCurve(func, activeCell, scaling);
+        const auto gridID = std::string{}; // Empty => global grid.
+
+        const auto satnum = init.keywordData<int>("SATNUM", gridID)[activeCell];
+
+        const auto graph = sfunc
+            .getSatFuncCurve(func, init, gridID, activeCell, satnum, scaling);
 
         printGraph(std::cout, "crv.krog", graph);
     }
 
     void krow(const Opm::ECLSaturationFunc&                 sfunc,
+              const Opm::ECLInitFileData&                   init,
               const int                                     activeCell,
               const Opm::ECLSaturationFunc::SatFuncScaling& scaling)
     {
@@ -159,13 +170,18 @@ namespace {
             Opm::ECLPhaseIndex::Liquid
         });
 
-        const auto graph =
-            sfunc.getSatFuncCurve(func, activeCell, scaling);
+        const auto gridID = std::string{}; // Empty => global grid.
+
+        const auto satnum = init.keywordData<int>("SATNUM", gridID)[activeCell];
+
+        const auto graph = sfunc
+            .getSatFuncCurve(func, init, gridID, activeCell, satnum, scaling);
 
         printGraph(std::cout, "crv.krow", graph);
     }
 
     void krw(const Opm::ECLSaturationFunc&                 sfunc,
+             const Opm::ECLInitFileData&                   init,
              const int                                     activeCell,
              const Opm::ECLSaturationFunc::SatFuncScaling& scaling)
     {
@@ -181,8 +197,12 @@ namespace {
             Opm::ECLPhaseIndex::Aqua
         });
 
-        const auto graph =
-            sfunc.getSatFuncCurve(func, activeCell, scaling);
+        const auto gridID = std::string{}; // Empty => global grid.
+
+        const auto satnum = init.keywordData<int>("SATNUM", gridID)[activeCell];
+
+        const auto graph = sfunc
+            .getSatFuncCurve(func, init, gridID, activeCell, satnum, scaling);
 
         printGraph(std::cout, "crv.krw", graph);
     }
@@ -191,6 +211,7 @@ namespace {
     // Capillary pressure
 
     void pcgo(const Opm::ECLSaturationFunc&                 sfunc,
+              const Opm::ECLInitFileData&                   init,
               const int                                     activeCell,
               const Opm::ECLSaturationFunc::SatFuncScaling& scaling)
     {
@@ -206,13 +227,18 @@ namespace {
             Opm::ECLPhaseIndex::Vapour
         });
 
-        const auto graph =
-            sfunc.getSatFuncCurve(func, activeCell, scaling);
+        const auto gridID = std::string{}; // Empty => global grid.
+
+        const auto satnum = init.keywordData<int>("SATNUM", gridID)[activeCell];
+
+        const auto graph = sfunc
+            .getSatFuncCurve(func, init, gridID, activeCell, satnum, scaling);
 
         printGraph(std::cout, "crv.pcgo", graph);
     }
 
     void pcow(const Opm::ECLSaturationFunc&                 sfunc,
+              const Opm::ECLInitFileData&                   init,
               const int                                     activeCell,
               const Opm::ECLSaturationFunc::SatFuncScaling& scaling)
     {
@@ -228,8 +254,12 @@ namespace {
             Opm::ECLPhaseIndex::Aqua
         });
 
-        const auto graph =
-            sfunc.getSatFuncCurve(func, activeCell, scaling);
+        const auto gridID = std::string{}; // Empty => global grid.
+
+        const auto satnum = init.keywordData<int>("SATNUM", gridID)[activeCell];
+
+        const auto graph = sfunc
+            .getSatFuncCurve(func, init, gridID, activeCell, satnum, scaling);
 
         printGraph(std::cout, "crv.pcow", graph);
     }
@@ -418,8 +448,8 @@ try {
 
     const auto cellID = getActiveCell(graph, prm);
 
-    auto sfunc = Opm::ECLSaturationFunc(graph, init);
-    auto pvtCC = Opm::ECLPVT::ECLPvtCurveCollection(graph, init);
+    auto sfunc = Opm::ECLSaturationFunc(init);
+    auto pvtCC = Opm::ECLPVT::ECLPvtCurveCollection(init);
 
     if (prm.has("unit")) {
         auto units = makeUnits(prm.get<std::string>("unit"), init);
@@ -433,16 +463,16 @@ try {
     // -----------------------------------------------------------------
     // Relative permeability
 
-    if (prm.getDefault("krg" , false)) { krg (sfunc, cellID, scaling); }
-    if (prm.getDefault("krog", false)) { krog(sfunc, cellID, scaling); }
-    if (prm.getDefault("krow", false)) { krow(sfunc, cellID, scaling); }
-    if (prm.getDefault("krw" , false)) { krw (sfunc, cellID, scaling); }
+    if (prm.getDefault("krg" , false)) { krg (sfunc, init, cellID, scaling); }
+    if (prm.getDefault("krog", false)) { krog(sfunc, init, cellID, scaling); }
+    if (prm.getDefault("krow", false)) { krow(sfunc, init, cellID, scaling); }
+    if (prm.getDefault("krw" , false)) { krw (sfunc, init, cellID, scaling); }
 
     // -----------------------------------------------------------------
     // Capillary pressure
     if (prm.getDefault("pcog", false) || // Alias pcog -> pcgo
-        prm.getDefault("pcgo", false)) { pcgo(sfunc, cellID, scaling); }
-    if (prm.getDefault("pcow", false)) { pcow(sfunc, cellID, scaling); }
+        prm.getDefault("pcgo", false)) { pcgo(sfunc, init, cellID, scaling); }
+    if (prm.getDefault("pcow", false)) { pcow(sfunc, init, cellID, scaling); }
 
     // -----------------------------------------------------------------
     // PVT Curves

--- a/opm/utility/ECLEndPointScaling.hpp
+++ b/opm/utility/ECLEndPointScaling.hpp
@@ -655,6 +655,14 @@ namespace Opm { namespace SatFunc {
                           const EPSOptions&        opt,
                           const RawTableEndPoints& tep);
 
+            static std::unique_ptr<EPSEvalInterface>
+            fromECLOutput(const ECLInitFileData&   init,
+                          const std::string&       gridID,
+                          const std::size_t        activeCell,
+                          const int                satnum,
+                          const EPSOptions&        opt,
+                          const RawTableEndPoints& tep);
+
             /// Extract table end points relevant to a particular horizontal
             /// EPS evaluator from raw tabulated saturation functions.
             ///
@@ -718,6 +726,15 @@ namespace Opm { namespace SatFunc {
                           const RawTableEndPoints& tep,
                           const FuncValVector&     fvals);
 
+            static std::unique_ptr<VerticalScalingInterface>
+            fromECLOutput(const ECLInitFileData&                          init,
+                          const std::string&                              gridID,
+                          const std::size_t                               activeCell,
+                          const int                                       satnum,
+                          const EPSOptions&                               opt,
+                          const RawTableEndPoints&                        tep,
+                          const VerticalScalingInterface::FunctionValues& fvals);
+
             /// Extract table end points relevant to a particular vertical
             /// scaling evaluator from raw tabulated saturation functions.
             ///
@@ -742,6 +759,14 @@ namespace Opm { namespace SatFunc {
                                    const RawTableEndPoints& ep,
                                    const EPSOptions&        opt,
                                    const SatFuncEvaluator&  evalSF);
+
+			static VerticalScalingInterface::FunctionValues
+            unscaledFunctionValues(const ECLInitFileData&   init,
+                                   const std::string&       gridID,
+                                   const int                satnum,
+                                   const RawTableEndPoints& ep,
+                                   const EPSOptions&        opt,
+                                   const SatFuncEvaluator&  evalSF);
         };
     };
 
@@ -750,10 +775,23 @@ namespace Opm { namespace SatFunc {
                      const ECLInitFileData&              init,
                      const CreateEPS::RawTableEndPoints& tep);
 
+    double scaledConnateGas(const ECLInitFileData&              init,
+                            const std::string&                  gridID,
+                            const std::size_t                   activeCell,
+                            const int                           satnum,
+                            const CreateEPS::RawTableEndPoints& tep);
+
     std::vector<double>
     scaledConnateWater(const ECLGraph&                     G,
                        const ECLInitFileData&              init,
                        const CreateEPS::RawTableEndPoints& tep);
+
+    double scaledConnateWater(const ECLInitFileData&              init,
+                              const std::string&                  gridID,
+                              const std::size_t                   activeCell,
+                              const int                           satnum,
+                              const CreateEPS::RawTableEndPoints& tep);
+
 }} // namespace Opm::SatFunc
 
 #endif // OPM_ECLENDPOINTSCALING_HEADER_INCLUDED

--- a/opm/utility/ECLFluxCalc.cpp
+++ b/opm/utility/ECLFluxCalc.cpp
@@ -188,7 +188,7 @@ namespace Opm
                              const double           grav,
                              const bool             /* useEPS */)
         : graph_(graph)
-        , satfunc_(graph, init)
+        , satfunc_(init)
         , rmap_(pvtnumVector(graph, init))
         , neighbours_(graph.neighbours())
         , transmissibility_(graph.transmissibility())
@@ -208,8 +208,9 @@ namespace Opm
 
 
     std::vector<double>
-    ECLFluxCalc::flux(const ECLRestartData& rstrt,
-                      const ECLPhaseIndex   phase) const
+    ECLFluxCalc::flux(const ECLRestartData&  rstrt,
+                      const ECLInitFileData& init,
+                      const ECLPhaseIndex    phase) const
     {
         if (! this->phaseIsActive(phase)) {
             // Inactive phase.  Return empty flux vector.
@@ -217,7 +218,7 @@ namespace Opm
         }
 
         // Obtain dynamic data.
-        const auto dyn_data = this->phaseProperties(rstrt, phase);
+        const auto dyn_data = this->phaseProperties(rstrt, init, phase);
 
         // Compute fluxes per connection.
         const int num_conn = transmissibility_.size();
@@ -230,8 +231,9 @@ namespace Opm
 
 
     std::vector<double>
-    ECLFluxCalc::massflux(const ECLRestartData& rstrt,
-                          const ECLPhaseIndex   phase) const
+    ECLFluxCalc::massflux(const ECLRestartData&  rstrt,
+                          const ECLInitFileData& init,
+                          const ECLPhaseIndex    phase) const
     {
         if (! this->phaseIsActive(phase)) {
             // Inactive phase.  Return empty (mass) flux vector.
@@ -239,7 +241,7 @@ namespace Opm
         }
 
         // Obtain dynamic data.
-        const auto dyn_data = this->phaseProperties(rstrt, phase);
+        const auto dyn_data = this->phaseProperties(rstrt, init, phase);
 
         // Compute fluxes per connection.
         const int num_conn = transmissibility_.size();
@@ -325,8 +327,9 @@ namespace Opm
 
 
     ECLFluxCalc::DynamicData
-    ECLFluxCalc::phaseProperties(const ECLRestartData& rstrt,
-                                 const ECLPhaseIndex   phase) const
+    ECLFluxCalc::phaseProperties(const ECLRestartData&  rstrt,
+                                 const ECLInitFileData& init,
+                                 const ECLPhaseIndex    phase) const
     {
         auto dyn_data = DynamicData{};
 
@@ -339,7 +342,7 @@ namespace Opm
         // Step 1 of Mobility Calculation.
         // Store phase's relative permeability values.
         dyn_data.mobility =
-            this->satfunc_.relperm(this->graph_, rstrt, phase);
+            this->satfunc_.relperm(this->graph_, init, rstrt, phase);
 
         // Step 1 of Mass Density (Reservoir Conditions) Calculation.
         // Allocate space for storing the cell values.

--- a/opm/utility/ECLFluxCalc.hpp
+++ b/opm/utility/ECLFluxCalc.hpp
@@ -71,8 +71,9 @@ namespace Opm
         ///    requisite data is missing.  Numerical values in SI units
         ///    (rm^3/s).
         std::vector<double>
-        flux(const ECLRestartData& rstrt,
-             const ECLPhaseIndex   phase) const;
+        flux(const ECLRestartData&  rstrt,
+             const ECLInitFileData& init,
+             const ECLPhaseIndex    phase) const;
 
         /// Retrive phase mass flux on all connections defined by \code
         /// graph.neighbours() \endcode.
@@ -86,8 +87,9 @@ namespace Opm
         ///    if requisite data is missing.  Numerical values in SI units
         ///    (kg/s).
         std::vector<double>
-        massflux(const ECLRestartData& rstrt,
-                 const ECLPhaseIndex   phase) const;
+        massflux(const ECLRestartData&  rstrt,
+                 const ECLInitFileData& init,
+                 const ECLPhaseIndex    phase) const;
 
         /// Return type for the phaseProperties() method, encapsulates
         /// dynamic properties for a single phase.
@@ -108,8 +110,9 @@ namespace Opm
         ///
         /// \return DynamicData struct containing cell-values for phase
         ///    properties.  Numerical values in SI units (kg/s).
-        DynamicData phaseProperties(const ECLRestartData& rstrt,
-                                    const ECLPhaseIndex   phase) const;
+        DynamicData phaseProperties(const ECLRestartData&  rstrt,
+                                    const ECLInitFileData& init,
+                                    const ECLPhaseIndex    phase) const;
 
         /// Retrive the constant surface density of a phase.
         ///

--- a/opm/utility/ECLPvtCurveCollection.cpp
+++ b/opm/utility/ECLPvtCurveCollection.cpp
@@ -236,8 +236,7 @@ namespace {
 }
 
 Opm::ECLPVT::ECLPvtCurveCollection::
-ECLPvtCurveCollection(const ECLGraph&        G,
-                      const ECLInitFileData& init)
+ECLPvtCurveCollection(const ECLInitFileData& init)
     : gas_          (CreateGasPVTInterpolant::fromECLOutput(init))
     , oil_          (CreateOilPVTInterpolant::fromECLOutput(init))
     , usys_native_  (ECLUnits::serialisedUnitConventions(init))

--- a/opm/utility/ECLPvtCurveCollection.hpp
+++ b/opm/utility/ECLPvtCurveCollection.hpp
@@ -56,8 +56,7 @@ namespace Opm { namespace ECLPVT {
         ///
         /// \param[in] init Container of tabulated PVT functions for all PVT
         ///    regions in the model \p G.
-        ECLPvtCurveCollection(const ECLGraph&        G,
-                              const ECLInitFileData& init);
+        ECLPvtCurveCollection(const ECLInitFileData& init);
 
         /// Define a collection of units of measure for output purposes.
         ///

--- a/opm/utility/ECLSaturationFunc.hpp
+++ b/opm/utility/ECLSaturationFunc.hpp
@@ -131,8 +131,7 @@ namespace Opm {
         /// \param[in] init Container of tabulated saturation functions and
         ///    saturation table end points, if applicable, for all active
         ///    cells in the model \p G.
-        ECLSaturationFunc(const ECLGraph&        G,
-                          const ECLInitFileData& init);
+        ECLSaturationFunc(const ECLInitFileData& init);
 
         /// Destructor.
         ~ECLSaturationFunc();
@@ -205,73 +204,10 @@ namespace Opm {
         ///    p for all active cells in model \p G.  Empty if phase \p p is
         ///    not actually active in the current result set.
         std::vector<double>
-        relperm(const ECLGraph&       G,
-                const ECLRestartData& rstrt,
-                const ECLPhaseIndex   p) const;
-
-        /// Retrieve 2D graph representations of sequence of effective
-        /// saturation functions in a single cell.
-        ///
-        /// \param[in] func Sequence of saturation function descriptions.
-        ///
-        /// \param[in] activeCell Index of active cell from which to derive
-        ///    the effective saturation function.  Use member function \code
-        ///    ECLGraph::activeCell() \endcode to translate a global cell
-        ///    (I,J,K) tuple--relative to a model grid--to a linear active
-        ///    cell ID.
-        ///
-        /// \param[in] useEPS Whether or not to include effects of
-        ///    saturation end-point scaling.  No effect if the INIT result
-        ///    set from which the object was constructed does not actually
-        ///    include saturation end-point scaling data.  Otherwise,
-        ///    enables turning EPS off even if associate data is present in
-        ///    the INIT result set.
-        ///
-        ///    Default value (\c true) means that effects of EPS are
-        ///    included if requisite data is present in the INIT result.
-        ///
-        /// \return Sequence of 2D graphs for all saturation function
-        ///    requests represented by \p func.  In particular, the \c i-th
-        ///    element of the result corresponds to input request \code
-        ///    func[i] \endcode.  Abscissas are stored in \code
-        ///    graph[i].first \endcode and ordinates are stored in \code
-        ///    graph[i].second \endcode.  If a particular request is
-        ///    semantically invalid, such as when requesting the water
-        ///    relative permeability in the oil-gas system, then the
-        ///    corresponding graph in the result is empty.
-        ///
-        /// Example: Retrieve relative permeability curves for oil in active
-        ///    cell 2718 in both the oil-gas and oil-water sub-systems while
-        ///    excluding effects of end-point scaling.  This effectively
-        ///    retrieves the "raw" tabulated saturation functions in the
-        ///    INIT result set.
-        ///
-        ///    \code
-        ///       using RC = ECLSaturationFunc::RawCurve;
-        ///       auto func = std::vector<RC>{};
-        ///       func.reserve(2);
-        ///
-        ///       // Request krog (oil rel-perm in oil-gas system)
-        ///       func.push_back(RC{
-        ///           RC::Function::RelPerm,
-        ///           RC::SubSystem::OilGas,
-        ///           ECLPhaseIndex::Liquid
-        ///       });
-        ///
-        ///       // Request krow (oil rel-perm in oil-water system)
-        ///       func.push_back(RC{
-        ///           RC::Function::RelPerm,
-        ///           RC::SubSystem::OilWater,
-        ///           ECLPhaseIndex::Liquid
-        ///       });
-        ///
-        ///       const auto graph =
-        ///           sfunc.getSatFuncCurve(func, 2718, false);
-        ///    \endcode
-        std::vector<FlowDiagnostics::Graph>
-        getSatFuncCurve(const std::vector<RawCurve>& func,
-                        const int                    activeCell,
-                        const bool                   useEPS = true) const;
+        relperm(const ECLGraph&        G,
+                const ECLInitFileData& init,
+                const ECLRestartData&  rstrt,
+                const ECLPhaseIndex    p) const;
 
         /// Retrieve 2D graph representations of sequence of effective
         /// saturation functions in a single cell.
@@ -333,7 +269,10 @@ namespace Opm {
         ///    \endcode
         std::vector<FlowDiagnostics::Graph>
         getSatFuncCurve(const std::vector<RawCurve>& func,
+                        const ECLInitFileData&       init,
+                        const std::string&           gridID,
                         const int                    activeCell,
+                        const int                    satnum,
                         const SatFuncScaling&        scaling) const;
 
     private:

--- a/tests/test_propcurves_integration.cpp
+++ b/tests/test_propcurves_integration.cpp
@@ -58,7 +58,7 @@ namespace {
     {
         NorneSatfuncFixture()
             : NorneFixture()
-            , satFunc { G, init }
+            , satFunc {init }
         {}
 
         Opm::ECLSaturationFunc satFunc;
@@ -89,8 +89,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Gas)
     auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
     scaling.enable = static_cast<unsigned char>(0);
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -142,8 +147,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Oil_in_Oil_Gas)
     auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
     scaling.enable = static_cast<unsigned char>(0);
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -195,8 +205,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Oil_in_Oil_Water)
     auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
     scaling.enable = static_cast<unsigned char>(0);
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -249,8 +264,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Water)
     auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
     scaling.enable = static_cast<unsigned char>(0);
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -302,8 +322,13 @@ BOOST_AUTO_TEST_CASE(CapPress_Gas_Oil)
     auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
     scaling.enable = static_cast<unsigned char>(0);
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -355,8 +380,13 @@ BOOST_AUTO_TEST_CASE(CapPress_Oil_Water)
     auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
     scaling.enable = static_cast<unsigned char>(0);
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -415,8 +445,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Gas)
     // Default scaling mode is horizontal + vertical.
     const auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -487,8 +522,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Oil_in_Oil_Gas)
     // Default scaling mode is horizontal + vertical.
     const auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -559,8 +599,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Oil_in_Oil_Water)
     // Default scaling mode is horizontal + vertical
     const auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -632,8 +677,13 @@ BOOST_AUTO_TEST_CASE(Relperm_Water)
     // Default scaling mode is horizontal + vertical.
     const auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -703,8 +753,13 @@ BOOST_AUTO_TEST_CASE(CapPress_Gas_Oil)
     // Default scaling mode is horizontal + vertical.
     const auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 
@@ -775,8 +830,13 @@ BOOST_AUTO_TEST_CASE(CapPress_Oil_Water)
     // Default scaling mode is horizontal + vertical.
     const auto scaling = Opm::ECLSaturationFunc::SatFuncScaling{};
 
+    // Grid ID is empty string for the main grid.
+    const auto gridID = std::string{};
+    const auto activeCell = this->G.activeCell(cell_16_31_10());
+    const auto satnum = this->init.keywordData<int>("SATNUM", gridID)[activeCell];
+
     const auto graphs = this->satFunc
-        .getSatFuncCurve(curves, this->G.activeCell(cell_16_31_10()), scaling);
+        .getSatFuncCurve(curves, this->init, gridID, activeCell, satnum, scaling);
 
     BOOST_REQUIRE_EQUAL(graphs.size(), std::size_t{ 1 });
 


### PR DESCRIPTION
We don't really need the full `ECLGraph` structure in order to extract the curves for scaled/unscaled saturation functions or the FVF/viscosity property curves as functions of pressure.

This PR switches to using `ECLInitFileData` exclusively as the source for those curves, albeit at the API cost of the caller having to provide a grid ID&ndash;a string containing the grid name, an empty string for the global grid and LGR name for a local grid&ndash;the active cell ID relative to this grid, and a saturation region (SATNUM) for the saturation functions.
