### PR TITLE
C++ Hygiene: Follow Basic Class Hierarchy Rules

### DIFF
--- a/opm/utility/ECLUnitHandling.hpp
+++ b/opm/utility/ECLUnitHandling.hpp
@@ -28,6 +28,8 @@ namespace Opm {
 
         struct UnitSystem
         {
+            virtual ~UnitSystem() = default;
+
             virtual std::unique_ptr<UnitSystem> clone() const = 0;
 
             virtual double density()             const = 0;


### PR DESCRIPTION
Abstract base classes must have virtual destructors.